### PR TITLE
GG-19602 Backport [IGNITE-10824] 

### DIFF
--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheInsertSqlQuerySelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheInsertSqlQuerySelfTest.java
@@ -200,22 +200,30 @@ public class IgniteCacheInsertSqlQuerySelfTest extends IgniteCacheAbstractInsert
     }
 
     /**
-     *
+     * Test that nested fields could be updated using sql UPDATE just by nested field name.
      */
     @Test
-    public void testNestedFieldsHandling() {
+    public void testNestedFieldsHandling1() {
         IgniteCache<Integer, AllTypes> p = ignite(0).cache("I2AT");
 
-        p.query(new SqlFieldsQuery(
-            "insert into AllTypes(_key, innerTypeCol, arrListCol, _val, innerStrCol) values (1, ?, ?, ?, 'sss')").
-            setArgs(
-                new AllTypes.InnerType(50L),
-                new ArrayList<>(Arrays.asList(3L, 2L, 1L)),
-                new AllTypes(1L)
-            )
-        );
+        final int ROOT_KEY = 1;
 
-        AllTypes res = p.get(1);
+        // Create 1st level value
+        AllTypes rootVal = new AllTypes(1L);
+
+        // With random inner field
+        rootVal.innerTypeCol = new AllTypes.InnerType(42L);
+
+
+        p.query(new SqlFieldsQuery(
+            "INSERT INTO AllTypes(_key,_val) VALUES (?, ?)").setArgs(ROOT_KEY, rootVal)
+        ).getAll();
+
+        // Update inner fields just by their names
+        p.query(new SqlFieldsQuery("UPDATE AllTypes SET innerLongCol = ?, innerStrCol = ?, arrListCol = ?;")
+            .setArgs(50L, "sss", new ArrayList<>(Arrays.asList(3L, 2L, 1L)))).getAll();
+
+        AllTypes res = p.get(ROOT_KEY);
 
         AllTypes.InnerType resInner = new AllTypes.InnerType(50L);
 
@@ -231,12 +239,14 @@ public class IgniteCacheInsertSqlQuerySelfTest extends IgniteCacheAbstractInsert
     @Test
     public void testCacheRestartHandling() {
         for (int i = 0; i < 4; i++) {
-            IgniteCache<Integer, IgniteCacheUpdateSqlQuerySelfTest.AllTypes> p =
+            IgniteCache<Integer, AllTypes> p =
                 ignite(0).getOrCreateCache(cacheConfig("I2AT", true, false, Integer.class,
-                    IgniteCacheUpdateSqlQuerySelfTest.AllTypes.class));
+                    AllTypes.class));
 
-            p.query(new SqlFieldsQuery("insert into AllTypes(_key, _val, dateCol) values (1, ?, null)")
-                .setArgs(new IgniteCacheUpdateSqlQuerySelfTest.AllTypes(1L)));
+            p.query(new SqlFieldsQuery("INSERT INTO AllTypes(_key, _val) VALUES (1, ?)")
+                .setArgs(new AllTypes(1L))).getAll();
+
+            p.query(new SqlFieldsQuery("UPDATE AllTypes SET dateCol = null;")).getAll();
 
             p.destroy();
         }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheMergeSqlQuerySelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheMergeSqlQuerySelfTest.java
@@ -16,13 +16,9 @@
 
 package org.apache.ignite.internal.processors.cache;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.junit.Test;
-
-import static org.apache.ignite.internal.processors.cache.IgniteCacheUpdateSqlQuerySelfTest.AllTypes;
 
 /**
  *
@@ -124,26 +120,5 @@ public class IgniteCacheMergeSqlQuerySelfTest extends IgniteCacheAbstractInsertS
         assertEquals(2, (int)p.get(1));
 
         assertEquals(4, (int)p.get(3));
-    }
-
-    /**
-     *
-     */
-    @Test
-    public void testNestedFieldsHandling() {
-        IgniteCache<Integer, AllTypes> p = ignite(0).cache("I2AT");
-
-        p.query(new SqlFieldsQuery("merge into AllTypes(_key, innerTypeCol, arrListCol, _val, innerStrCol) " +
-            "values (1, ?, ?, ?, 'sss')") .setArgs(new AllTypes.InnerType(50L),
-            new ArrayList<>(Arrays.asList(3L, 2L, 1L)), new AllTypes(1L)));
-
-        AllTypes res = p.get(1);
-
-        AllTypes.InnerType resInner = new AllTypes.InnerType(50L);
-
-        resInner.innerStrCol = "sss";
-        resInner.arrListCol = new ArrayList<>(Arrays.asList(3L, 2L, 1L));
-
-        assertEquals(resInner, res.innerTypeCol);
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheSqlDmlErrorSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheSqlDmlErrorSelfTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.internal.processors.query.IgniteSQLException;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Negative java API tests for dml queries (insert, merge, update).
+ */
+@RunWith(JUnit4.class)
+public class IgniteCacheSqlDmlErrorSelfTest extends GridCommonAbstractTest {
+    /** Dummy cache, just cache api entry point. */
+    private static IgniteCache<?, ?> cache;
+
+    /** {@inheritDoc} */
+    @Override public void beforeTestsStarted() throws Exception {
+        startGrids(1);
+
+        cache = grid(0).createCache(DEFAULT_CACHE_NAME);
+    }
+
+    /**
+     * Create test tables.
+     */
+    @Before
+    public void dropAdnCreateTables() {
+        execute("DROP TABLE IF EXISTS COMPOSITE;");
+        execute("DROP TABLE IF EXISTS SIMPLE");
+        execute("DROP TABLE IF EXISTS SIMPLE_WRAPPED");
+
+        execute("CREATE TABLE COMPOSITE (id1 INT, id2 INT, name1 VARCHAR, name2 VARCHAR, PRIMARY KEY(id1, id2)) " +
+            "WITH \"key_type=" + CompositeKey.class.getName() + ", value_type=" + CompositeValue.class.getName() + "\"");
+        execute("CREATE TABLE SIMPLE (id INT PRIMARY KEY, name VARCHAR) WITH \"wrap_value=false, wrap_key=false\"");
+        execute("CREATE TABLE SIMPLE_WRAPPED (id INT PRIMARY KEY, name VARCHAR) WITH \"wrap_value=true, wrap_key=true\"");
+
+        execute("INSERT INTO COMPOSITE (_key, _val) VALUES (?, ?)", new CompositeKey(), new CompositeValue());
+        execute("INSERT INTO SIMPLE VALUES (146, 'default name')");
+        execute("INSERT INTO SIMPLE_WRAPPED VALUES (147, 'default name')");
+    }
+
+    /**
+     * Check it's forbidden to specify any two of _key, _key alias or key field (column that belongs to key) together in
+     * the insert/merge dml statement. Same constraints are right for (_val, _val alias, val fields).
+     */
+    @Test
+    public void testInsertMixingPlaceholderAndFields() {
+        assertThrows(() ->
+                execute("INSERT INTO COMPOSITE (_key, id2, name1, name2) VALUES (?, ?, ?, ?)",
+                    new CompositeKey(), 42, "name#1", "name#2"),
+            "Column _KEY refers to entire key cache object.");
+
+        assertThrows(() ->
+                execute("INSERT INTO COMPOSITE (id1, id2, _val, name2) VALUES (?, ?, ?, ?)",
+                    1, 2, new CompositeValue(), "name#2"),
+            "Column _VAL refers to entire value cache object.");
+
+        assertThrows(() ->
+                execute("INSERT INTO SIMPLE (_key, id, name) VALUES (?, ?, ?)", 42, 43, "some name"),
+            "Columns _KEY and ID both refer to entire cache key object.");
+
+        assertThrows(() ->
+                execute("INSERT INTO SIMPLE (_key, _val, name) VALUES (?, ?, ?)", 42, "name#1", "name#2"),
+            "Columns _VAL and NAME both refer to entire cache value object.");
+
+        // And the same asserts for the MERGE:
+        assertThrows(() ->
+                execute("MERGE INTO COMPOSITE (_key, id2, name1, name2) VALUES (?, ?, ?, ?)",
+                    new CompositeKey(), 42, "name#1", "name#2"),
+            "Column _KEY refers to entire key cache object.");
+
+        assertThrows(() ->
+                execute("MERGE INTO COMPOSITE (id1, id2, _val, name2) VALUES (?, ?, ?, ?)",
+                    1, 2, new CompositeValue(), "name#2"),
+            "Column _VAL refers to entire value cache object.");
+
+        assertThrows(() ->
+                execute("MERGE INTO SIMPLE (_key, id, name) VALUES (?, ?, ?)", 42, 43, "some name"),
+            "Columns _KEY and ID both refer to entire cache key object.");
+
+        assertThrows(() ->
+                execute("MERGE INTO SIMPLE (_key, _val, name) VALUES (?, ?, ?)", 42, "name#1", "name#2"),
+            "Columns _VAL and NAME both refer to entire cache value object.");
+    }
+
+    /**
+     * Check it's forbidden to specify any two of _key, _key alias or key field (column that belongs to key) together in
+     * the COPY (aka bulk load) sql statement. Same constraints are right for (_val, _val alias, val fields).
+     */
+    @Test
+    public void testCopyMixingPlaceholderAndFields() {
+        assertThrows(() ->
+                execute("COPY FROM \'stub/file/path\' " +
+                    "INTO SIMPLE (_key, id, name) FORMAT CSV"),
+            "Columns _KEY and ID both refer to entire cache key object.");
+
+        assertThrows(() ->
+                execute("COPY FROM \'stub/file/path\' " +
+                    "INTO SIMPLE_WRAPPED (_key, id, name) FORMAT CSV"),
+            "Column _KEY refers to entire key cache object.");
+
+        assertThrows(() ->
+                execute("COPY FROM \'stub/file/path\' " +
+                    "INTO SIMPLE (id, _val, name) FORMAT CSV"),
+            "Columns _VAL and NAME both refer to entire cache value object.");
+
+        assertThrows(() ->
+                execute("COPY FROM \'stub/file/path\' " +
+                    "INTO SIMPLE_WRAPPED (id, _val, name) FORMAT CSV"),
+            "Column _VAL refers to entire value cache object.");
+
+    }
+
+    /**
+     * Check update statements that modify any two of _val, _val alias or val field (column that belongs to cache value
+     * object) are forbidden.
+     */
+    @Test
+    public void testUpdateMixingValueAndValueFields() {
+        assertThrows(() ->
+                execute("UPDATE COMPOSITE SET _val = ?, name2 = ?",
+                    new CompositeValue(), "name#2"),
+            "Column _VAL refers to entire value cache object.");
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET _val = ?, name = ?",
+                    "name#1", "name#2"),
+            "Columns _VAL and NAME both refer to entire cache value object.");
+    }
+
+    /**
+     * Check that null values for entire key or value are disallowed.
+     */
+    @Test
+    public void testInsertNullKeyValue() {
+        assertThrows(() ->
+                execute("INSERT INTO COMPOSITE (_key, _val) VALUES (?, ?)", null, new CompositeKey()),
+            "Key for INSERT, COPY, or MERGE must not be null");
+
+        assertThrows(() ->
+                execute("INSERT INTO COMPOSITE (_key, _val) VALUES (?, ?)", new CompositeKey(), null),
+            "Value for INSERT, COPY, MERGE, or UPDATE must not be null");
+
+        assertThrows(() ->
+                execute("INSERT INTO SIMPLE (_key, _val) VALUES(?, ?)", null, "name#1"),
+            "Null value is not allowed for column 'ID'");
+
+        assertThrows(() ->
+                execute("INSERT INTO SIMPLE (id, _val) VALUES(?, ?)", null, "name#1"),
+            "Null value is not allowed for column 'ID'");
+
+        assertThrows(() ->
+                execute("INSERT INTO SIMPLE (_key, _val) VALUES(?, ?)", 42, null),
+            "Null value is not allowed for column 'NAME'");
+
+        assertThrows(() ->
+                execute("INSERT INTO SIMPLE (_key, name) VALUES(?, ?)", 42, null),
+            "Null value is not allowed for column 'NAME'");
+
+        // And the same checks for the MERGE:
+        assertThrows(() ->
+                execute("MERGE INTO COMPOSITE (_key, _val) VALUES (?, ?)", null, new CompositeKey()),
+            "Key for INSERT, COPY, or MERGE must not be null");
+
+        assertThrows(() ->
+                execute("MERGE INTO COMPOSITE (_key, _val) VALUES (?, ?)", new CompositeKey(), null),
+            "Value for INSERT, COPY, MERGE, or UPDATE must not be null");
+
+        assertThrows(() ->
+                execute("MERGE INTO SIMPLE (_key, _val) VALUES(?, ?)", null, "name#1"),
+            "Null value is not allowed for column 'ID'");
+
+        assertThrows(() ->
+                execute("MERGE INTO SIMPLE (id, _val) VALUES(?, ?)", null, "name#1"),
+            "Null value is not allowed for column 'ID'");
+
+        assertThrows(() ->
+                execute("MERGE INTO SIMPLE (_key, _val) VALUES(?, ?)", 42, null),
+            "Null value is not allowed for column 'NAME'");
+
+        assertThrows(() ->
+                execute("MERGE INTO SIMPLE (_key, name) VALUES(?, ?)", 42, null),
+            "Null value is not allowed for column 'NAME'");
+    }
+
+    /**
+     * Check that updates of key or key fields are disallowed.
+     */
+    @Test
+    public void testUpdateKey() {
+        assertThrows(() ->
+                execute("UPDATE COMPOSITE SET _key = ?, _val = ?", new CompositeKey(), new CompositeValue()),
+            "SQL UPDATE can't modify key or its fields directly");
+        assertThrows(() ->
+                execute("UPDATE COMPOSITE SET id1 = ?, _val = ?", 42, new CompositeValue()),
+            "SQL UPDATE can't modify key or its fields directly");
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET _key = ?, _val = ?", 42, "simple name"),
+            "SQL UPDATE can't modify key or its fields directly");
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET id = ?, _val = ?", 42, "simple name"),
+            "SQL UPDATE can't modify key or its fields directly");
+    }
+
+    /**
+     * Check that setting entire cache key to {@code null} via sql is forbidden.
+     */
+    @Test
+    public void testUpdateKeyToNull() {
+        // It's ok to assert just fact of failure if we update key to null.
+        // Both reasons (the fact of updating key and setting _key to null) are correct.
+        // Empty string is contained by any exception message.
+        final String ANY_MESSAGE = "";
+
+        assertThrows(() ->
+                execute("UPDATE COMPOSITE SET _key = ?, _val = ?", null, new CompositeValue()),
+            ANY_MESSAGE);
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET id = ?, _val = ?", null, "simple name"),
+            ANY_MESSAGE);
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET id = ?, _val = ?", null, "simple name"),
+            ANY_MESSAGE);
+    }
+
+    /**
+     * Check that setting entire cache value to {@code null} via sql is forbidden.
+     */
+    @Test
+    public void testUpdateValToNull() {
+        assertThrows(() ->
+                execute("UPDATE COMPOSITE SET _val = ?", (Object)null),
+            "New value for UPDATE must not be null");
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET _val = ?", (Object)null),
+            "New value for UPDATE must not be null");
+
+        assertThrows(() ->
+                execute("UPDATE SIMPLE SET name = ?", (Object)null),
+            "New value for UPDATE must not be null");
+    }
+
+    /**
+     * Execute sql query with PUBLIC schema and specified positional arguments of sql query.
+     *
+     * @param sql query.
+     * @param args positional arguments if sql query got ones.
+     * @return fetched result set.
+     */
+    private static List<List<?>> execute(String sql, Object... args) {
+        SqlFieldsQuery qry = new SqlFieldsQuery(sql).setSchema("PUBLIC");
+
+        if (!F.isEmpty(args))
+            qry.setArgs(args);
+
+        return cache.query(qry).getAll();
+    }
+
+    /**
+     * Check that query execution using cache api results to {@code IgniteSqlException} with message, containing
+     * provided expected message.
+     *
+     * @param qryClos closure that performs the query.
+     * @param expErrMsg expected message.
+     */
+    private void assertThrows(Callable<?> qryClos, String expErrMsg) {
+        GridTestUtils.assertThrows(
+            log(),
+            qryClos,
+            IgniteSQLException.class,
+            expErrMsg);
+    }
+
+    /**
+     * Class which instance can be (de)serialized to(from) key object.
+     */
+    private static class CompositeKey {
+        /** First key field. */
+        int id1;
+
+        /** Second key field. */
+        int id2;
+
+        /** Constructs key with random fields. */
+        public CompositeKey() {
+            ThreadLocalRandom rnd = ThreadLocalRandom.current();
+
+            id1 = rnd.nextInt();
+            id2 = rnd.nextInt();
+        }
+    }
+
+    /**
+     * Class which instance can be (de)serialized to(from) value object.
+     */
+    private static class CompositeValue {
+        /** First value field. */
+        String name1;
+
+        /** Second value field. */
+        String name2;
+
+        /** Creates value with random fields. */
+        public CompositeValue() {
+            name1 = UUID.randomUUID().toString();
+            name2 = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheUpdateSqlQuerySelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheUpdateSqlQuerySelfTest.java
@@ -124,35 +124,39 @@ public class IgniteCacheUpdateSqlQuerySelfTest extends IgniteCacheAbstractSqlDml
     }
 
     /**
-     *
+     * Test that nested fields could be updated using sql UPDATE just by nested field name.
      */
     @Test
-    public void testUpdateValueAndFields() {
-        IgniteCache p = cache();
+    public void testNestedFieldsUpdate() {
+        IgniteCache<Long, AllTypes> p = ignite(0).cache("L2AT");
 
-        QueryCursor<List<?>> c = p.query(new SqlFieldsQuery("update Person p set id = ?, _val = ? where _key = ?")
-            .setArgs(44, createPerson(2, "Jo", "Woo"), "FirstKey"));
+        final long ROOT_KEY = 1;
 
-        c.iterator();
+        // Create 1st level value
+        AllTypes rootVal = new AllTypes(1L);
 
-        c = p.query(new SqlFieldsQuery("select _key, _val, * from Person order by _key, id"));
+        // With random inner field
+        rootVal.innerTypeCol = new AllTypes.InnerType(42L);
 
-        List<List<?>> leftovers = c.getAll();
+        p.query(new SqlFieldsQuery(
+            "INSERT INTO \"AllTypes\"(_key,_val) VALUES (?, ?)").setArgs(ROOT_KEY, rootVal)
+        ).getAll();
 
-        assertEquals(4, leftovers.size());
+        // Update inner fields just by their names
+        p.query(new SqlFieldsQuery("UPDATE \"AllTypes\" " +
+            "SET \"innerLongCol\" = ?, \"innerStrCol\" = ?, \"arrListCol\" = ?;"
+        ).setArgs(50L, "sss", new ArrayList<>(Arrays.asList(3L, 2L, 1L)))).getAll();
 
-        assertEqualsCollections(Arrays.asList("FirstKey", createPerson(44, "Jo", "Woo"), 44, "Jo", "Woo"),
-            leftovers.get(0));
+        AllTypes res = p.get(ROOT_KEY);
 
-        assertEqualsCollections(Arrays.asList("SecondKey", createPerson(2, "Joe", "Black"), 2, "Joe", "Black"),
-            leftovers.get(1));
+        AllTypes.InnerType resInner = new AllTypes.InnerType(50L);
 
-        assertEqualsCollections(Arrays.asList("f0u4thk3y", createPerson(4, "Jane", "Silver"), 4, "Jane", "Silver"),
-            leftovers.get(2));
+        resInner.innerStrCol = "sss";
+        resInner.arrListCol = new ArrayList<>(Arrays.asList(3L, 2L, 1L));
 
-        assertEqualsCollections(Arrays.asList("k3", createPerson(3, "Sylvia", "Green"), 3, "Sylvia", "Green"),
-            leftovers.get(3));
+        assertEquals(resInner, res.innerTypeCol);
     }
+
 
     /**
      *
@@ -161,8 +165,9 @@ public class IgniteCacheUpdateSqlQuerySelfTest extends IgniteCacheAbstractSqlDml
     public void testDefault() {
         IgniteCache p = cache();
 
-        QueryCursor<List<?>> c = p.query(new SqlFieldsQuery("update Person p set id = DEFAULT, _val = ? where _key = ?")
-            .setArgs(createPerson(2, "Jo", "Woo"), "FirstKey"));
+        QueryCursor<List<?>> c = p.query(new SqlFieldsQuery(
+            "UPDATE Person p SET id = DEFAULT, firstName = ?, secondName = ? WHERE _key = ?"
+        ).setArgs( "Jo", "Woo", "FirstKey"));
 
         c.iterator();
 
@@ -190,17 +195,35 @@ public class IgniteCacheUpdateSqlQuerySelfTest extends IgniteCacheAbstractSqlDml
     public void testTypeConversions() throws ParseException {
         IgniteCache cache = ignite(0).cache("L2AT");
 
-        cache.query(new SqlFieldsQuery("insert into \"AllTypes\"(_key, _val, \"dateCol\", \"booleanCol\"," +
-            "\"tsCol\") values(2, ?, '2016-11-30 12:00:00', false, DATE '2016-12-01')").setArgs(new AllTypes(2L)));
+        cache.query(new SqlFieldsQuery("INSERT INTO \"AllTypes\" (_key, _val) VALUES(2, ?)")
+            .setArgs(new AllTypes(2L))).getAll();
+
+        cache.query (new SqlFieldsQuery(
+            "UPDATE \"AllTypes\" " +
+                "SET " +
+                "\"dateCol\" = '2016-11-30 12:00:00', " +
+                "\"booleanCol\" = false, " +
+                "\"tsCol\" = DATE '2016-12-01' " +
+                "WHERE _key = 2")
+        );
 
         // Look ma, no hands: first we set value of inner object column (innerTypeCol), then update only one of its
         // fields (innerLongCol), while leaving another inner property (innerStrCol) as specified by innerTypeCol.
-        cache.query(new SqlFieldsQuery("update \"AllTypes\" set \"innerLongCol\" = ?, \"doubleCol\" = CAST('50' as INT)," +
-            " \"booleanCol\" = 80, \"innerTypeCol\" = ?, \"strCol\" = PI(), \"shortCol\" = " +
-            "CAST(WEEK(PARSEDATETIME('2016-11-30', 'yyyy-MM-dd')) as VARCHAR), " +
-            "\"sqlDateCol\"=TIMESTAMP '2016-12-02 13:47:00', \"tsCol\"=TIMESTAMPADD('MI', 2, " +
-            "DATEADD('DAY', 2, \"tsCol\")), \"primitiveIntsCol\" = ?, \"bytesCol\" = ?")
-            .setArgs(5, new AllTypes.InnerType(80L), new int[] {2, 3}, new Byte[] {4, 5, 6}));
+        cache.query(new SqlFieldsQuery(
+                "UPDATE \"AllTypes\" " +
+                    "SET " +
+                    "\"innerLongCol\" = ?, " +  // (1)
+                    "\"doubleCol\" = CAST('50' as INT), " +
+                    "\"booleanCol\" = 80, " +
+                    "\"innerTypeCol\" = ?, " + // (2)
+                    "\"strCol\" = PI(), " +
+                    "\"shortCol\" = CAST(WEEK(PARSEDATETIME('2016-11-30', 'yyyy-MM-dd')) as VARCHAR), " +
+                    "\"sqlDateCol\"=TIMESTAMP '2016-12-02 13:47:00', " +
+                    "\"tsCol\"=TIMESTAMPADD('MI', 2, DATEADD('DAY', 2, \"tsCol\")), " +
+                    "\"primitiveIntsCol\" = ?, " +  //(3)
+                    "\"bytesCol\" = ?" // (4)
+            ).setArgs(5, new AllTypes.InnerType(80L), new int[] {2, 3}, new Byte[] {4, 5, 6})
+        ).getAll();
 
         AllTypes res = (AllTypes) cache.get(2L);
 
@@ -235,8 +258,16 @@ public class IgniteCacheUpdateSqlQuerySelfTest extends IgniteCacheAbstractSqlDml
     public void testSingleInnerFieldUpdate() throws ParseException {
         IgniteCache cache = ignite(0).cache("L2AT");
 
-        cache.query(new SqlFieldsQuery("insert into \"AllTypes\"(_key, _val, \"dateCol\", \"booleanCol\") values(2, ?," +
-            "'2016-11-30 12:00:00', false)").setArgs(new AllTypes(2L)));
+        cache.query(new SqlFieldsQuery("insert into \"AllTypes\" (_key, _val) values(2, ?)")
+            .setArgs(new AllTypes(2L))).getAll();
+
+        cache.query(new SqlFieldsQuery(
+            "UPDATE \"AllTypes\" " +
+                "SET " +
+                "\"dateCol\" = '2016-11-30 12:00:00', " +
+                "\"booleanCol\" = false " +
+                "WHERE _key = 2")
+        ).getAll();
 
         assertFalse(cache.query(new SqlFieldsQuery("select * from \"AllTypes\"")).getAll().isEmpty());
 

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteBinaryCacheQueryTestSuite.java
@@ -24,7 +24,6 @@ import org.apache.ignite.internal.processors.cache.BinarySerializationQueryWithR
 import org.apache.ignite.internal.processors.cache.CacheIteratorScanQueryTest;
 import org.apache.ignite.internal.processors.cache.CacheLocalQueryDetailMetricsSelfTest;
 import org.apache.ignite.internal.processors.cache.CacheLocalQueryMetricsSelfTest;
-import org.apache.ignite.internal.processors.cache.CacheOffheapBatchIndexingBaseTest;
 import org.apache.ignite.internal.processors.cache.CacheOffheapBatchIndexingMultiTypeTest;
 import org.apache.ignite.internal.processors.cache.CacheOffheapBatchIndexingSingleTypeTest;
 import org.apache.ignite.internal.processors.cache.CachePartitionedQueryDetailMetricsDistributedSelfTest;
@@ -80,6 +79,7 @@ import org.apache.ignite.internal.processors.cache.IgniteCachePrimitiveFieldsQue
 import org.apache.ignite.internal.processors.cache.IgniteCacheQueryH2IndexingLeakTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheQueryIndexSelfTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheQueryLoadSelfTest;
+import org.apache.ignite.internal.processors.cache.IgniteCacheSqlDmlErrorSelfTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheSqlInsertValidationSelfTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheSqlQueryErrorSelfTest;
 import org.apache.ignite.internal.processors.cache.IgniteCacheUnionDuplicatesTest;
@@ -280,6 +280,7 @@ import org.junit.runners.Suite;
     // Parsing
     GridQueryParsingTest.class,
     IgniteCacheSqlQueryErrorSelfTest.class,
+    IgniteCacheSqlDmlErrorSelfTest.class,
 
     // Config.
     IgniteCacheDuplicateEntityConfigurationSelfTest.class,


### PR DESCRIPTION
SQL: Restricted mixed use of _KEY and key fields or _VAL and value fields in the same DML statement.