### PR TITLE
GG-21332 Do not rely on the value returned from user profile update endpoint

### DIFF
--- a/modules/web-console/frontend/app/modules/user/User.service.ts
+++ b/modules/web-console/frontend/app/modules/user/User.service.ts
@@ -83,8 +83,8 @@ export default function UserFactory(
 
         async save(user: Partial<User>): Promise<User> {
             try {
-                const {data: updatedUser} = await $http.post<User>('/api/v1/profile/save', user);
-                await this.load();
+                await $http.post<User>('/api/v1/profile/save', user);
+                const updatedUser = await this.load();
                 IgniteMessages.showInfo('Profile saved.');
                 current$.next(updatedUser);
                 return updatedUser;

--- a/modules/web-console/frontend/app/modules/user/User.service.ts
+++ b/modules/web-console/frontend/app/modules/user/User.service.ts
@@ -83,10 +83,11 @@ export default function UserFactory(
 
         async save(user: Partial<User>): Promise<User> {
             try {
-                await $http.post<User>('/api/v1/profile/save', user);
-                const updatedUser = await this.load();
-                IgniteMessages.showInfo('Profile saved.');
+                const {data: updatedUser} = await $http.post<User>('/api/v1/profile/save', user);
                 current$.next(updatedUser);
+
+                IgniteMessages.showInfo('Profile saved.');
+
                 return updatedUser;
             }
             catch (e) {

--- a/modules/web-console/web-console-server/src/main/java/org/apache/ignite/console/common/Utils.java
+++ b/modules/web-console/web-console-server/src/main/java/org/apache/ignite/console/common/Utils.java
@@ -25,9 +25,11 @@ import org.apache.ignite.console.json.JsonArray;
 import org.apache.ignite.console.json.JsonObject;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.T2;
+import org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestWrapper;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import static org.apache.ignite.console.utils.Utils.fromJson;
+import static org.springframework.security.web.authentication.switchuser.SwitchUserFilter.ROLE_PREVIOUS_ADMINISTRATOR;
 
 /**
  * Utilities.
@@ -124,5 +126,14 @@ public class Utils {
             .replacePath(null)
             .build()
             .toString();
+    }
+
+    /**
+     * Is switch user used.
+     * @param req Request wrapper.
+     * @return Switch user used flag.
+     */
+    public static boolean isBecomeUsed(SecurityContextHolderAwareRequestWrapper req) {
+        return req.isUserInRole(ROLE_PREVIOUS_ADMINISTRATOR);
     }
 }

--- a/modules/web-console/web-console-server/src/main/java/org/apache/ignite/console/web/controller/AccountController.java
+++ b/modules/web-console/web-console-server/src/main/java/org/apache/ignite/console/web/controller/AccountController.java
@@ -92,12 +92,14 @@ public class AccountController {
     }
 
     /**
+     * @param req Request wrapper.
      * @param acc Current user.
      * @param changes Changes to apply to user.
      */
     @ApiOperation(value = "Save user.")
     @PostMapping(path = "/api/v1/profile/save", consumes = APPLICATION_JSON_VALUE)
-    public ResponseEntity<Void> save(
+    public ResponseEntity<UserResponse> save(
+        SecurityContextHolderAwareRequestWrapper req,
         @AuthenticationPrincipal Account acc,
         @Valid @RequestBody ChangeUserRequest changes
     ) {
@@ -107,7 +109,7 @@ public class AccountController {
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new UserResponse(acc, req.isUserInRole(ROLE_PREVIOUS_ADMINISTRATOR)));
     }
 
     /**

--- a/modules/web-console/web-console-server/src/main/java/org/apache/ignite/console/web/controller/AccountController.java
+++ b/modules/web-console/web-console-server/src/main/java/org/apache/ignite/console/web/controller/AccountController.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.console.web.controller;
 
+import java.util.UUID;
 import io.swagger.annotations.ApiOperation;
 import javax.validation.Valid;
 import org.apache.ignite.console.dto.Account;
@@ -38,6 +39,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import static org.apache.ignite.console.common.Utils.isBecomeUsed;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.security.web.authentication.switchuser.SwitchUserFilter.ROLE_PREVIOUS_ADMINISTRATOR;
 
@@ -50,15 +52,15 @@ public class AccountController {
     private final AuthenticationManager authMgr;
 
     /** Accounts service. */
-    private final AccountsService accountsSrv;
+    private final AccountsService accountsSrvc;
 
     /**
      * @param authMgr Authentication manager.
-     * @param accountsSrv Accounts service.
+     * @param accountsSrvc Accounts service.
      */
-    public AccountController(AuthenticationManager authMgr, AccountsService accountsSrv) {
+    public AccountController(AuthenticationManager authMgr, AccountsService accountsSrvc) {
         this.authMgr = authMgr;
-        this.accountsSrv = accountsSrv;
+        this.accountsSrvc = accountsSrvc;
     }
 
     /**
@@ -67,7 +69,7 @@ public class AccountController {
     @ApiOperation(value = "Get current user.")
     @GetMapping(path = "/api/v1/user")
     public ResponseEntity<UserResponse> user(SecurityContextHolderAwareRequestWrapper req) {
-        Account acc = accountsSrv.loadUserByUsername(req.getUserPrincipal().getName());
+        Account acc = accountsSrvc.loadUserByUsername(req.getUserPrincipal().getName());
 
         return ResponseEntity.ok(new UserResponse(acc, req.isUserInRole(ROLE_PREVIOUS_ADMINISTRATOR)));
     }
@@ -78,7 +80,7 @@ public class AccountController {
     @ApiOperation(value = "Register user.")
     @PostMapping(path = "/api/v1/signup")
     public ResponseEntity<Void> signup(@Valid @RequestBody SignUpRequest params) {
-        accountsSrv.register(params);
+        accountsSrvc.register(params);
 
         Authentication authentication = authMgr.authenticate(
             new UsernamePasswordAuthenticationToken(
@@ -89,6 +91,26 @@ public class AccountController {
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         return ResponseEntity.ok().build();
+    }
+
+    /**
+     * Save and auth user.
+     *
+     * @param accId Account id.
+     * @param changes Changes to apply to user.
+     */
+    public Account saveAndAuth(UUID accId, ChangeUserRequest changes) {
+        Account acc = accountsSrvc.save(accId, changes);
+
+        Authentication authentication = new PreAuthenticatedAuthenticationToken(
+            acc,
+            acc.getPassword(),
+            acc.getAuthorities()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return acc;
     }
 
     /**
@@ -103,13 +125,9 @@ public class AccountController {
         @AuthenticationPrincipal Account acc,
         @Valid @RequestBody ChangeUserRequest changes
     ) {
-        Account userObj = accountsSrv.save(acc.getId(), changes);
+        Account newAcc = saveAndAuth(acc.getId(), changes);
 
-        Authentication authentication = new PreAuthenticatedAuthenticationToken(userObj, userObj.getPassword(), userObj.getAuthorities());
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        return ResponseEntity.ok(new UserResponse(acc, req.isUserInRole(ROLE_PREVIOUS_ADMINISTRATOR)));
+        return ResponseEntity.ok(new UserResponse(newAcc, isBecomeUsed(req)));
     }
 
     /**
@@ -118,7 +136,7 @@ public class AccountController {
     @ApiOperation(value = "Send password reset token.")
     @PostMapping(path = "/api/v1/password/forgot", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity forgotPassword(@Valid @RequestBody EmailRequest req) {
-        accountsSrv.forgotPassword(req.getEmail());
+        accountsSrvc.forgotPassword(req.getEmail());
 
         return ResponseEntity.ok().build();
     }
@@ -129,7 +147,7 @@ public class AccountController {
     @ApiOperation(value = "Reset user password.")
     @PostMapping(path = "/api/v1/password/reset")
     public ResponseEntity resetPassword(@Valid @RequestBody ResetPasswordRequest req) {
-        accountsSrv.resetPasswordByToken(req.getEmail(), req.getToken(), req.getPassword());
+        accountsSrvc.resetPasswordByToken(req.getEmail(), req.getToken(), req.getPassword());
 
         return ResponseEntity.ok().build();
     }
@@ -140,7 +158,7 @@ public class AccountController {
     @ApiOperation(value = "Resend activation token.")
     @PostMapping(path = "/api/v1/activation/resend", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity activationResend(@Valid @RequestBody EmailRequest req) {
-        accountsSrv.resetActivationToken(req.getEmail());
+        accountsSrvc.resetActivationToken(req.getEmail());
 
         return ResponseEntity.ok().build();
     }


### PR DESCRIPTION
Previously, the '/api/v1/profile/save' endpoint used to return an updated user object. The new Java backend sends an empty response, so the user value assumes the empty string value, which in turn causes conditions that control UI element visibility to return false. I chose to fix the issue on the frontend side.