### PR TITLE
GG-20866 [IGNITE-11966] Fixed using AdaptiveLoadBalancingSpi without IgniteConfiguration.setIncludeEventTypes(EventType.EVT_TASK_FINISHED, EventType.EVT_TASK_FAILED) leads to memory leak - Fixed #6690.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/eventstorage/GridEventStorageManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/eventstorage/GridEventStorageManager.java
@@ -71,9 +71,12 @@ import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.events.EventType.EVTS_ALL;
 import static org.apache.ignite.events.EventType.EVTS_DISCOVERY_ALL;
+import static org.apache.ignite.events.EventType.EVT_JOB_MAPPED;
 import static org.apache.ignite.events.EventType.EVT_NODE_FAILED;
 import static org.apache.ignite.events.EventType.EVT_NODE_LEFT;
 import static org.apache.ignite.events.EventType.EVT_NODE_METRICS_UPDATED;
+import static org.apache.ignite.events.EventType.EVT_TASK_FAILED;
+import static org.apache.ignite.events.EventType.EVT_TASK_FINISHED;
 import static org.apache.ignite.internal.GridTopic.TOPIC_EVENT;
 import static org.apache.ignite.internal.events.DiscoveryCustomEvent.EVT_DISCOVERY_CUSTOM_EVT;
 import static org.apache.ignite.internal.managers.communication.GridIoPolicy.PUBLIC_POOL;
@@ -504,7 +507,16 @@ public class GridEventStorageManager extends GridManagerAdapter<EventStorageSpi>
      * @return {@code true} if this is an internal event.
      */
     private boolean isInternalEvent(int type) {
-        return type == EVT_DISCOVERY_CUSTOM_EVT || F.contains(EVTS_DISCOVERY_ALL, type);
+        switch (type) {
+            case EVT_DISCOVERY_CUSTOM_EVT:
+            case EVT_TASK_FINISHED:
+            case EVT_TASK_FAILED:
+            case EVT_JOB_MAPPED:
+                return true;
+
+            default:
+                return F.contains(EVTS_DISCOVERY_ALL, type);
+        }
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridEventStorageRuntimeConfigurationSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridEventStorageRuntimeConfigurationSelfTest.java
@@ -137,7 +137,7 @@ public class GridEventStorageRuntimeConfigurationSelfTest extends GridCommonAbst
         try {
             Ignite g = startGrid();
 
-            g.events().enableLocal(EVT_TASK_STARTED, EVT_TASK_FINISHED, EVT_JOB_STARTED);
+            g.events().enableLocal(EVT_TASK_STARTED, EVT_JOB_STARTED);
 
             final AtomicInteger cnt = new AtomicInteger();
 
@@ -147,17 +147,17 @@ public class GridEventStorageRuntimeConfigurationSelfTest extends GridCommonAbst
 
                     return true;
                 }
-            }, EVT_TASK_STARTED, EVT_TASK_FINISHED, EVT_JOB_STARTED);
+            }, EVT_TASK_STARTED, EVT_JOB_STARTED);
+
+            g.compute().run(F.noop());
+
+            assertEquals(2, cnt.get());
+
+            g.events().disableLocal(EVT_TASK_STARTED, EVT_JOB_FAILED);
 
             g.compute().run(F.noop());
 
             assertEquals(3, cnt.get());
-
-            g.events().disableLocal(EVT_TASK_STARTED, EVT_TASK_FINISHED, EVT_JOB_FAILED);
-
-            g.compute().run(F.noop());
-
-            assertEquals(4, cnt.get());
         }
         finally {
             stopAllGrids();


### PR DESCRIPTION
…