### PR TITLE
GG-22693 .NET: Fix NuGet references in LINQPad samples

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/BinaryModeExample.linq
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/BinaryModeExample.linq
@@ -1,5 +1,5 @@
 <Query Kind="Statements">
-  <NuGetReference>Apache.Ignite</NuGetReference>
+  <NuGetReference>GridGain.Ignite</NuGetReference>
   <Namespace>Apache.Ignite.Core</Namespace>
   <Namespace>Apache.Ignite.Core.Binary</Namespace>
   <Namespace>Apache.Ignite.Core.Cache.Configuration</Namespace>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/ComputeExample.linq
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/ComputeExample.linq
@@ -1,5 +1,5 @@
 <Query Kind="Program">
-  <NuGetReference>Apache.Ignite</NuGetReference>
+  <NuGetReference>GridGain.Ignite</NuGetReference>
   <Namespace>Apache.Ignite.Core</Namespace>
   <Namespace>Apache.Ignite.Core.Binary</Namespace>
   <Namespace>Apache.Ignite.Core.Cache.Configuration</Namespace>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/PutGetExample.linq
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/PutGetExample.linq
@@ -1,5 +1,5 @@
 <Query Kind="Program">
-    <NuGetReference>Apache.Ignite</NuGetReference>
+    <NuGetReference>GridGain.Ignite</NuGetReference>
     <Namespace>Apache.Ignite.Core</Namespace>
     <Namespace>Apache.Ignite.Core.Binary</Namespace>
 </Query>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/QueryExample.linq
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/QueryExample.linq
@@ -1,5 +1,5 @@
 <Query Kind="Program">
-  <NuGetReference>Apache.Ignite</NuGetReference>
+  <NuGetReference>GridGain.Ignite</NuGetReference>
   <Namespace>Apache.Ignite.Core</Namespace>
   <Namespace>Apache.Ignite.Core.Binary</Namespace>
   <Namespace>Apache.Ignite.Core.Cache.Configuration</Namespace>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/ThinClient.linq
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/NuGet/LINQPad/ThinClient.linq
@@ -1,5 +1,5 @@
 <Query Kind="Statements">
-  <NuGetReference>Apache.Ignite</NuGetReference>
+  <NuGetReference>GridGain.Ignite</NuGetReference>
   <Namespace>Apache.Ignite.Core</Namespace>
   <Namespace>Apache.Ignite.Core.Client</Namespace>
   <Namespace>Apache.Ignite.Core.Binary</Namespace>

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/NuGet/LINQPad/QueryExample.linq
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/NuGet/LINQPad/QueryExample.linq
@@ -1,5 +1,5 @@
 <Query Kind="Program">
-  <NuGetReference>Apache.Ignite.Linq</NuGetReference>
+  <NuGetReference>GridGain.Ignite.Linq</NuGetReference>
   <Namespace>Apache.Ignite.Core</Namespace>
   <Namespace>Apache.Ignite.Core.Binary</Namespace>
   <Namespace>Apache.Ignite.Core.Cache.Configuration</Namespace>


### PR DESCRIPTION
Reference GridGain.Ignite.* packages instead of Apache.Ignite.*