### PR TITLE
GG-20306 [WC] Can't start web-console with .bat-file from any folder different from .bat-file location

### DIFF
--- a/modules/web-console/bin/web-console.bat
+++ b/modules/web-console/bin/web-console.bat
@@ -62,7 +62,7 @@ if %MAJOR_JAVA_VER% LSS 8 (
 :checkIgniteHome1
 pushd "%~dp0"
 set IGNITE_HOME=%CD%
-popd
+
 goto :checkIgniteHome2
 
 :checkIgniteHome2


### PR DESCRIPTION
 * Fixed Web Console start with .bat file from any folder