### PR TITLE
GG-25549 .NET: Add NuGet verification script

### DIFF
--- a/modules/platforms/dotnet/release/Program.cs
+++ b/modules/platforms/dotnet/release/Program.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Apache.Ignite.Core;
+using Apache.Ignite.Core.Cache.Configuration;
+using Apache.Ignite.Core.Client;
+using Apache.Ignite.Core.Discovery.Tcp;
+using Apache.Ignite.Core.Discovery.Tcp.Static;
+using Apache.Ignite.Linq;
+using Apache.Ignite.NLog;
+
+namespace test_proj
+{
+    public static class Program
+    {
+        public static async Task Main()
+        {
+            var cfg = new IgniteConfiguration
+            {
+                DiscoverySpi = new TcpDiscoverySpi
+                {
+                    IpFinder = new TcpDiscoveryStaticIpFinder
+                    {
+                        Endpoints = new[] {"127.0.0.1:47500"}
+                    },
+                    SocketTimeout = TimeSpan.FromSeconds(0.3)
+                },
+                Logger = new IgniteNLogLogger()
+            };
+
+            using (var ignite = Ignition.Start(cfg))
+            {
+                var cacheCfg = new CacheConfiguration(
+                    "cache1",
+                    new QueryEntity(typeof(int), typeof(Person)));
+                
+                var cache = ignite.CreateCache<int, Person>(cacheCfg);
+                
+                cache.Put(1, new Person(1));
+                Debug.Assert(1 == cache[1].Age);
+
+                var resPerson = cache.AsCacheQueryable()
+                    .Where(e => e.Key > 0 && e.Value.Name.StartsWith("Person"))
+                    .Select(e => e.Value)
+                    .Single();
+                Debug.Assert(1 == resPerson.Age);
+
+                using (var igniteThin = Ignition.StartClient(new IgniteClientConfiguration("127.0.0.1")))
+                {
+                    var cacheThin = igniteThin.GetCache<int, Person>(cacheCfg.Name);
+                    var personThin = await cacheThin.GetAsync(1);
+                    Debug.Assert("Person-1" == personThin.Name);
+
+                    var personNames = cacheThin.AsCacheQueryable()
+                        .Where(e => e.Key != 2 && e.Value.Age < 10)
+                        .Select(e => e.Value.Name)
+                        .ToArray();
+                    Debug.Assert(personNames.SequenceEqual(new[] {"Person-1"}));
+                }
+            }
+        }
+    }
+
+    public class Person
+    {
+        public Person(int age)
+        {
+            Age = age;
+            Name = $"Person-{age}";
+        }
+
+        public string Name { get; }
+        
+        public int Age { get; }
+    }
+}

--- a/modules/platforms/dotnet/release/Program.cs
+++ b/modules/platforms/dotnet/release/Program.cs
@@ -29,7 +29,13 @@ namespace test_proj
 {
     public static class Program
     {
-        public static async Task Main()
+        public static void Main()
+        {
+            // Don't use async Main - compatibility with C# 7.0
+            MainAsync().GetAwaiter().GetResult();
+        }
+
+        private static async Task MainAsync()
         {
             var cfg = new IgniteConfiguration
             {

--- a/modules/platforms/dotnet/release/Program.cs
+++ b/modules/platforms/dotnet/release/Program.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;

--- a/modules/platforms/dotnet/release/Program.cs
+++ b/modules/platforms/dotnet/release/Program.cs
@@ -8,7 +8,6 @@ using Apache.Ignite.Core.Client;
 using Apache.Ignite.Core.Discovery.Tcp;
 using Apache.Ignite.Core.Discovery.Tcp.Static;
 using Apache.Ignite.Linq;
-using Apache.Ignite.NLog;
 
 namespace test_proj
 {
@@ -25,8 +24,7 @@ namespace test_proj
                         Endpoints = new[] {"127.0.0.1:47500"}
                     },
                     SocketTimeout = TimeSpan.FromSeconds(0.3)
-                },
-                Logger = new IgniteNLogLogger()
+                }
             };
 
             using (var ignite = Ignition.Start(cfg))
@@ -70,8 +68,10 @@ namespace test_proj
             Name = $"Person-{age}";
         }
 
+        [QuerySqlField]
         public string Name { get; }
         
+        [QuerySqlField]
         public int Age { get; }
     }
 }

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -29,13 +29,14 @@ Requirements:
 .PARAMETER packageDir
 Directory with nupkg files to verify, defaults to ..\nupkg.
 
-
 #>
 
 param (
     [string]$packageDir="..\nupkg"
 )
 
+
+# Find NuGet packages (*.nupkg)
 $dir = Join-Path $PSScriptRoot $packageDir
 if (!(Test-Path $dir)) {
     throw "Path does not exist: '$packageDir' (resolved to '$dir')"
@@ -44,4 +45,19 @@ if (!(Test-Path $dir)) {
 $packages = ls $dir *.nupkg
 if ($packages.Length -eq 0) {
     throw "nupkg files not found in '$dir'"
+}
+
+
+# Create test dir
+$testDir = Join-Path $PSScriptRoot "test-proj"
+mkdir -Force $testDir
+del -Force $testDir\*.*
+cd $testDir
+
+
+# Create project and install all packages
+dotnet new console
+$packages | % { 
+    $packageId = $_.Name -replace "(.*?)\.\d\.\d\.\d\.nupkg", "$1"
+    dotnet add package $packageId -s $packageDir 
 }

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -55,9 +55,13 @@ del -Force $testDir\*.*
 cd $testDir
 
 
-# Create project and install all packages
+# Create project, install packages, copy test code, run
 dotnet new console
+
 $packages | % { 
     $packageId = $_.Name -replace "(.*?)\.\d\.\d\.\d\.nupkg", "$1"
     dotnet add package $packageId -s $packageDir 
 }
+
+# TODO: Copy code from parent dir
+dotnet run

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -77,7 +77,11 @@ $packages | % {
     }
 }
 
-# TODO: Copy code from parent dir
+
+$programFile = Join-Path $PSScriptRoot "Program.cs"
+Copy-Item $programFile $testDir -force
+
+
 dotnet run
 if ($LastExitCode -ne 0) {
     throw "Failed to run the test program"

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -56,9 +56,6 @@ $testDir = Join-Path $PSScriptRoot "test-proj"
 mkdir -Force $testDir
 del -Force $testDir\*.*
 cd $testDir
-if ($LastExitCode -ne 0) {
-    throw "Failed to create test dir"
-}
 
 
 # Create project, install packages, copy test code, run

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -60,11 +60,22 @@ cd $testDir
 
 # Create project, install packages, copy test code, run
 dotnet new console
+if ($LastExitCode -ne 0) {
+    throw "Failed to create .NET Core project"
+}
+
 
 $packages | % { 
     $packageId = $_.Name -replace '(.*?)\.\d\.\d\.\d\.nupkg', '$1'
-    dotnet add package $packageId -s $dir 
+    dotnet add package $packageId -s $dir
+
+    if ($LastExitCode -ne 0) {
+        throw "Failed to install package $packageId"
+    }
 }
 
 # TODO: Copy code from parent dir
 dotnet run
+if ($LastExitCode -ne 0) {
+    throw "Failed to run the test program"
+}

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -48,7 +48,7 @@ if ($packages.Length -eq 0) {
 }
 
 
-echo "Verifying $(packages.Length) packages from '$dir'..."  
+echo "Verifying $($packages.Length) packages from '$dir'..."  
 
 
 # Create test dir
@@ -62,8 +62,8 @@ cd $testDir
 dotnet new console
 
 $packages | % { 
-    $packageId = $_.Name -replace "(.*?)\.\d\.\d\.\d\.nupkg", "$1"
-    dotnet add package $packageId -s $packageDir 
+    $packageId = $_.Name -replace '(.*?)\.\d\.\d\.\d\.nupkg', '$1'
+    dotnet add package $packageId -s $dir 
 }
 
 # TODO: Copy code from parent dir

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -1,0 +1,35 @@
+<#
+Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+Licensed under the GridGain Community Edition License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#>
+
+ <#
+
+.SYNOPSIS
+Verifies release NuGet packages.
+
+.DESCRIPTION
+Creates a project with .NET Core CLI, installs all packages, runs simple code to start Ignite node, verifies exit code.
+
+Requirements:
+* .NET Core 2.0+
+* JDK 8+
+
+.PARAMETER packageDir
+Directory with nupkg files to verify, defaults to ..\nupkg.
+
+
+#>
+
+$

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -48,6 +48,9 @@ if ($packages.Length -eq 0) {
 }
 
 
+echo "Verifying $(packages.Length) packages from '$dir'..."  
+
+
 # Create test dir
 $testDir = Join-Path $PSScriptRoot "test-proj"
 mkdir -Force $testDir

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -37,7 +37,7 @@ param (
 
 
 # Find NuGet packages (*.nupkg)
-$dir = Join-Path $PSScriptRoot $packageDir
+$dir = If ([System.IO.Path]::IsPathRooted($packageDir)) { $packageDir } Else { Join-Path $PSScriptRoot $packageDir }
 if (!(Test-Path $dir)) {
     throw "Path does not exist: '$packageDir' (resolved to '$dir')"
 }

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -32,4 +32,16 @@ Directory with nupkg files to verify, defaults to ..\nupkg.
 
 #>
 
-$
+param (
+    [string]$packageDir="..\nupkg"
+)
+
+$dir = Join-Path $PSScriptRoot $packageDir
+if (!(Test-Path $dir)) {
+    throw "Path does not exist: '$packageDir' (resolved to '$dir')"
+}
+
+$packages = ls $dir *.nupkg
+if ($packages.Length -eq 0) {
+    throw "nupkg files not found in '$dir'"
+}

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -56,6 +56,9 @@ $testDir = Join-Path $PSScriptRoot "test-proj"
 mkdir -Force $testDir
 del -Force $testDir\*.*
 cd $testDir
+if ($LastExitCode -ne 0) {
+    throw "Failed to create test dir"
+}
 
 
 # Create project, install packages, copy test code, run


### PR DESCRIPTION
Add a script to verify NuGet packages:
* Creates a test project with `dotnet new console`
* Installs all packages from specified folder with `dotnet add package`
* Runs a test program that uses basic Cache, SQL and LINQ APIs
* Checks exit codes to make sure there were no exceptions/errors