### PR TITLE
GG-26740 .NET: Fix ClientServerCompatibilityTest - set Java version in pom.xml

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/pom.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer/pom.xml
@@ -25,6 +25,11 @@
     <artifactId>ignite-maven-server</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.ignite</groupId>


### PR DESCRIPTION
Maven seems to assume 1.5 language level by default, which is not supported in some Maven versions, causing a compiler error. Set version explicitly to fix this.