### PR TITLE
.NET: Fix Resharper inspection warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ git-patch-prop-local.sh
 *.classname*
 *.exe
 .mvn/
+mvnw
+mvnw.cmd
 
 #Ignore all Intellij IDEA files (except default inspections config)
 .idea/

--- a/modules/platforms/dotnet/Apache.Ignite.AspNet.Tests/IgniteSessionStateStoreDataTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.AspNet.Tests/IgniteSessionStateStoreDataTest.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.AspNet.Tests
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Reflection;
     using System.Web;
@@ -38,8 +39,9 @@ namespace Apache.Ignite.AspNet.Tests
         {
             // Modification method is internal.
             var statics = new HttpStaticObjectsCollection();
-            statics.GetType().GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic)
-                .Invoke(statics, new object[] { "int", typeof(int), false });
+            var methodInfo = statics.GetType().GetMethod("Add", BindingFlags.Instance | BindingFlags.NonPublic);
+            Debug.Assert(methodInfo != null);
+            methodInfo.Invoke(statics, new object[] { "int", typeof(int), false });
 
             var data = new IgniteSessionStateStoreData(statics, 44);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/Serializable/ObjectReferenceTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/Serializable/ObjectReferenceTests.cs
@@ -95,6 +95,7 @@ namespace Apache.Ignite.Core.Tests.Binary.Serializable
 
             public void GetObjectData(SerializationInfo info, StreamingContext context)
             {
+                // ReSharper disable once AssignNullToNotNullAttribute
                 info.FullTypeName = typeof(ObjectInfoHolder).FullName;
                 info.AssemblyName = typeof(ObjectInfoHolder).Assembly.FullName;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
@@ -267,6 +267,7 @@ namespace Apache.Ignite.Core.Tests.Binary
                 Assert.AreEqual(type.FullName, res.GetNameWithNamespace() + res.GetArray());
             }
 
+            Assert.IsNotNull(type.FullName);
             Assert.AreEqual(type.FullName.Length + 2, res.AssemblyStart);
             Assert.AreEqual(type.FullName, res.GetFullName());
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/AddArgCacheEntryProcessor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/AddArgCacheEntryProcessor.cs
@@ -81,7 +81,9 @@ namespace Apache.Ignite.Core.Tests.Cache
             return entry.Value;
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Invalid override.
+        /// </summary>
         public int Process(IMutableCacheEntry<int, int> entry, int arg)
         {
             throw new Exception("Invalid method");

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityFunctionSpringTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityFunctionSpringTest.cs
@@ -93,6 +93,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             Assert.AreEqual(3, aff.GetPartition(4L));
         }
 
+        // ReSharper disable once UnusedType.Local (used from config)
         private class TestFunc : IAffinityFunction   // [Serializable] is not necessary
         {
             [InstanceResource]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityFunctionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityFunctionTest.cs
@@ -299,6 +299,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         private class SimpleAffinityFunction : IAffinityFunction
         {
             #pragma warning disable 649  // field is never assigned
+            // ReSharper disable once UnassignedReadonlyField
             [InstanceResource] private readonly IIgnite _ignite;
 
             public int Partitions

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Base.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Base.cs
@@ -497,7 +497,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                 if (Equals(x, y))
                     return 0;
 
-                if (x is double)
+                if (x is double && y is double)
                 {
                     var dx = (double) x;
                     var dy = (double) y;
@@ -511,6 +511,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                     return Math.Abs((double) x - (double) y) < relEpsilon ? 0 : 1;
                 }
 
+                // ReSharper disable once PossibleNullReferenceException
                 return ((IComparable) x).CompareTo(y);
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -1014,6 +1014,7 @@ namespace Apache.Ignite.Core.Tests.Compute
     {
         [InstanceResource]
 #pragma warning disable 649
+        // ReSharper disable once UnassignedField.Local
         private IIgnite _grid;
 
         public static ConcurrentBag<Guid> Invokes = new ConcurrentBag<Guid>();
@@ -1082,6 +1083,7 @@ namespace Apache.Ignite.Core.Tests.Compute
     class ComputeFunc : INestedComputeFunc, IUserInterface<int>
     {
         [InstanceResource]
+        // ReSharper disable once UnassignedField.Local
         private IIgnite _grid;
 
         public static int InvokeCount;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/IgniteExceptionTaskSelfTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/IgniteExceptionTaskSelfTest.cs
@@ -568,8 +568,6 @@ namespace Apache.Ignite.Core.Tests.Compute
         /// </summary>
         private class BadJob : IComputeJob<object>, IBinarizable
         {
-            [InstanceResource]
-
             /** <inheritDoc /> */
             public object Execute()
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/DataStructures/AtomicReferenceTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/DataStructures/AtomicReferenceTest.cs
@@ -196,7 +196,9 @@ namespace Apache.Ignite.Core.Tests.DataStructures
             /** */
             public int Foo { get; set; }
 
-            /** <inheritdoc /> */
+            /// <summary>
+            /// Determines whether the specified object is equal to the current object.
+            /// </summary>
             private bool Equals(SerializableObj other)
             {
                 return Foo == other.Foo;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/DeploymentTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/DeploymentTest.cs
@@ -229,6 +229,7 @@ namespace Apache.Ignite.Core.Tests
         private class ProcessPathFunc : IComputeFunc<string>
         {
             [InstanceResource]
+            // ReSharper disable once UnassignedField.Local
             private IIgnite _ignite;
 
             /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/EventsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/EventsTest.cs
@@ -943,7 +943,9 @@ namespace Apache.Ignite.Core.Tests
             return _invoke(evt);
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Invalid Invoke method for tests.
+        /// </summary>
         // ReSharper disable once UnusedMember.Global
         public bool Invoke(T evt)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -687,6 +687,7 @@ namespace Apache.Ignite.Core.Tests
         #pragma warning disable 649
         /** Grid. */
         [InstanceResource]
+        // ReSharper disable once UnassignedField.Local
         private IIgnite _grid;
         #pragma warning restore 649
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1137,6 +1137,7 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             /** */
             [InstanceResource]
+            // ReSharper disable once UnassignedField.Local
             private IIgnite _grid;
 
             /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -291,6 +291,7 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(prx.ToString(), svc.ToString());
             Assert.AreEqual(17, prx.TestProperty);
             Assert.IsTrue(prx.Initialized);
+            // ReSharper disable once AccessToModifiedClosure
             Assert.IsTrue(TestUtils.WaitForCondition(() => prx.Executed, 5000));
             Assert.IsFalse(prx.Cancelled);
             Assert.AreEqual(SvcName, prx.LastCallContextName);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryArrayEqualityComparer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryArrayEqualityComparer.cs
@@ -95,7 +95,9 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Computes the hash code of specified stream content.
+        /// </summary>
         public static int GetHashCode(IBinaryStream stream, int startPos, int length)
         {
             Debug.Assert(stream != null);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryEnum.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryEnum.cs
@@ -50,7 +50,9 @@ namespace Apache.Ignite.Core.Impl.Binary
             _marsh = marsh;
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Gets the type id.
+        /// </summary>
         public int TypeId
         {
             get { return _typeId; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
@@ -76,7 +76,9 @@ namespace Apache.Ignite.Core.Impl.Binary
             _header = header;
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Gets the type id.
+        /// </summary>
         public int TypeId
         {
             get { return _header.TypeId; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectHeader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectHeader.cs
@@ -345,13 +345,17 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
         public static bool operator ==(BinaryObjectHeader left, BinaryObjectHeader right)
         {
             return left.Equals(right);
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Inequality operator.
+        /// </summary>
         public static bool operator !=(BinaryObjectHeader left, BinaryObjectHeader right)
         {
             return !left.Equals(right);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/MutableCacheEntry.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/MutableCacheEntry.cs
@@ -32,6 +32,7 @@ namespace Apache.Ignite.Core.Impl.Cache
         /// Initializes a new instance of the <see cref="MutableCacheEntry{K, V}"/> class.
         /// </summary>
         /// <param name="key">The key.</param>
+        // ReSharper disable once UnusedMember.Global (used from Reflection)
         public MutableCacheEntry(TK key)
         {
             Key = key;
@@ -42,6 +43,7 @@ namespace Apache.Ignite.Core.Impl.Cache
         /// </summary>
         /// <param name="key">The key.</param>
         /// <param name="value">The value.</param>
+        // ReSharper disable once UnusedMember.Global (used from Reflection)
         public MutableCacheEntry(TK key, TV value)
         {
             Key = key;
@@ -58,7 +60,9 @@ namespace Apache.Ignite.Core.Impl.Cache
             get { return Key; }
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
         public TV Value
         {
             get { return _value; }
@@ -76,7 +80,9 @@ namespace Apache.Ignite.Core.Impl.Cache
             get { return Value; }
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Gets a value indicating whether cache entry exists in cache.
+        /// </summary>
         public bool Exists { get; private set; }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientProtocolVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientProtocolVersion.cs
@@ -105,37 +105,49 @@ namespace Apache.Ignite.Core.Impl.Client
             return obj is ClientProtocolVersion && Equals((ClientProtocolVersion) obj);
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Equality operator.
+        /// </summary>
         public static bool operator ==(ClientProtocolVersion left, ClientProtocolVersion right)
         {
             return left.Equals(right);
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Inequality operator.
+        /// </summary>
         public static bool operator !=(ClientProtocolVersion left, ClientProtocolVersion right)
         {
             return !left.Equals(right);
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Less-than operator.
+        /// </summary>
         public static bool operator <(ClientProtocolVersion left, ClientProtocolVersion right)
         {
             return left.CompareTo(right) < 0;
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Less-or-equal-than operator.
+        /// </summary>
         public static bool operator <=(ClientProtocolVersion left, ClientProtocolVersion right)
         {
             return left.CompareTo(right) <= 0;
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Greater-than operator.
+        /// </summary>
         public static bool operator >(ClientProtocolVersion left, ClientProtocolVersion right)
         {
             return left.CompareTo(right) > 0;
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Greater-or-equal-than operator.
+        /// </summary>
         public static bool operator >=(ClientProtocolVersion left, ClientProtocolVersion right)
         {
             return left.CompareTo(right) >= 0;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -234,7 +234,7 @@ namespace Apache.Ignite.Core.Impl
             return _prj.ForNodes(GetLocalNode());
         }
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public ICompute GetCompute()
         {
             return _prj.ForServers().GetCompute();
@@ -598,7 +598,7 @@ namespace Apache.Ignite.Core.Impl
             return this;
         }
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public IBinary GetBinary()
         {
             return _binary;
@@ -620,19 +620,19 @@ namespace Apache.Ignite.Core.Impl
             return new TransactionsImpl(this, DoOutOpObject((int) Op.GetTransactions), GetLocalNode().Id);
         }
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public IMessaging GetMessaging()
         {
             return _prj.GetMessaging();
         }
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public IEvents GetEvents()
         {
             return _prj.GetEvents();
         }
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public IServices GetServices()
         {
             return _prj.ForServers().GetServices();
@@ -779,13 +779,13 @@ namespace Apache.Ignite.Core.Impl
         }
 #pragma warning restore 618
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public void SetActive(bool isActive)
         {
             _prj.SetActive(isActive);
         }
 
-        /** <inheritdoc /> */
+        /** <inheritdoc cref="IIgnite" /> */
         public bool IsActive()
         {
             return _prj.IsActive();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceDescriptor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceDescriptor.cs
@@ -86,7 +86,9 @@ namespace Apache.Ignite.Core.Impl.Services
             }
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Gets or sets the platform of this service.
+        /// </summary>
         public Platform Platform { get; private set; }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Env.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Env.cs
@@ -68,6 +68,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private readonly EnvDelegates.CallVoidMethod _callVoidMethod;
 
         /** */
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly EnvDelegates.GetStringChars _getStringChars;
 
         /** */
@@ -80,6 +81,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private readonly EnvDelegates.ReleaseStringUtfChars _releaseStringUtfChars;
 
         /** */
+        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
         private readonly EnvDelegates.ReleaseStringChars _releaseStringChars;
 
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -213,7 +213,9 @@ namespace Apache.Ignite.Linq.Impl
             };
         }
 
-        /** <inheritdoc /> */
+        /// <summary>
+        /// Generates <see cref="QueryData"/> from specified <see cref="QueryModel"/>.
+        /// </summary>
         public static QueryData GetQueryData(QueryModel queryModel)
         {
             Debug.Assert(queryModel != null);

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/MethodVisitor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/MethodVisitor.cs
@@ -31,6 +31,7 @@ namespace Apache.Ignite.Linq.Impl
         /// <summary> Property visitors. </summary>
         private static readonly Dictionary<MemberInfo, string> Properties = new Dictionary<MemberInfo, string>
         {
+            // ReSharper disable AssignNullToNotNullAttribute
             {typeof(string).GetProperty("Length"), "length"},
             {typeof(DateTime).GetProperty("Year"), "year"},
             {typeof(DateTime).GetProperty("Month"), "month"},
@@ -40,6 +41,7 @@ namespace Apache.Ignite.Linq.Impl
             {typeof(DateTime).GetProperty("Hour"), "hour"},
             {typeof(DateTime).GetProperty("Minute"), "minute"},
             {typeof(DateTime).GetProperty("Second"), "second"}
+            // ReSharper restore AssignNullToNotNullAttribute
         };
 
         /// <summary> Method visit delegate. </summary>

--- a/modules/platforms/dotnet/examples/Apache.Ignite.ExamplesDll/DataStructures/AtomicLongIncrementAction.cs
+++ b/modules/platforms/dotnet/examples/Apache.Ignite.ExamplesDll/DataStructures/AtomicLongIncrementAction.cs
@@ -32,6 +32,7 @@ namespace Apache.Ignite.ExamplesDll.DataStructures
         public const string AtomicLongName = "dotnet_atomic_long";
 
         /** */
+        // ReSharper disable once UnassignedReadonlyField
         [InstanceResource] private readonly IIgnite _ignite;
 
         /// <summary>

--- a/modules/platforms/dotnet/examples/Apache.Ignite.ExamplesDll/DataStructures/AtomicReferenceModifyAction.cs
+++ b/modules/platforms/dotnet/examples/Apache.Ignite.ExamplesDll/DataStructures/AtomicReferenceModifyAction.cs
@@ -32,6 +32,7 @@ namespace Apache.Ignite.ExamplesDll.DataStructures
         public const string AtomicReferenceName = "dotnet_atomic_reference";
 
         /** */
+        // ReSharper disable once UnassignedReadonlyField
         [InstanceResource] private readonly IIgnite _ignite;
 
         /// <summary>

--- a/modules/platforms/dotnet/examples/Apache.Ignite.ExamplesDll/DataStructures/AtomicSequenceIncrementAction.cs
+++ b/modules/platforms/dotnet/examples/Apache.Ignite.ExamplesDll/DataStructures/AtomicSequenceIncrementAction.cs
@@ -32,6 +32,7 @@ namespace Apache.Ignite.ExamplesDll.DataStructures
         public const string AtomicSequenceName = "dotnet_atomic_sequence";
 
         /** */
+        // ReSharper disable once UnassignedReadonlyField
         [InstanceResource] private readonly IIgnite _ignite;
 
         /// <summary>


### PR DESCRIPTION
Fix or suppress everything from solution-wide analysis of the latest Resharper and Rider to make it easier to spot new issues during development