### PR TITLE
GG-17432 Excessive use of memory in continuous queries (#359)

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryAcknowledgeBackupBuffer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryAcknowledgeBackupBuffer.java
@@ -19,16 +19,20 @@ package org.apache.ignite.internal.processors.cache.query.continuous;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
+import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.processors.continuous.GridContinuousBatch;
 import org.apache.ignite.internal.processors.continuous.GridContinuousQueryBatch;
 import org.apache.ignite.internal.util.tostring.GridToStringInclude;
 import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteBiTuple;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Buffer for collecting CQ acknowledges before CQ buffer cleanup.
+ * Buffer for collecting CQ acknowledges before sending CQ buffer cleanup message to backup nodes.
  */
-class CacheContinuousQueryAcknowledgeBuffer {
+class CacheContinuousQueryAcknowledgeBackupBuffer {
     /** */
     private int size;
 
@@ -36,12 +40,16 @@ class CacheContinuousQueryAcknowledgeBuffer {
     @GridToStringInclude
     private Map<Integer, Long> updateCntrs = new HashMap<>();
 
+    /** */
+    @GridToStringInclude
+    private Set<AffinityTopologyVersion> topVers = U.newHashSet(1);
+
     /**
      * @param batch Batch.
-     * @return Update counters per partition map if acknowledge should be sent.
+     * @return Tuple if acknowledge should be sent to backups.
      */
     @SuppressWarnings("unchecked")
-    @Nullable synchronized Map<Integer, Long> onAcknowledged(
+    @Nullable synchronized IgniteBiTuple<Map<Integer, Long>, Set<AffinityTopologyVersion>>onAcknowledged(
         GridContinuousBatch batch) {
         assert batch instanceof GridContinuousQueryBatch;
 
@@ -52,13 +60,28 @@ class CacheContinuousQueryAcknowledgeBuffer {
         for (CacheContinuousQueryEntry e : entries)
             addEntry(e);
 
-        return size >= CacheContinuousQueryHandler.ACK_THRESHOLD ? acknowledgeData() : null;
+        return size >= CacheContinuousQueryHandler.BACKUP_ACK_THRESHOLD ? acknowledgeData() : null;
+    }
+
+    /**
+     * @param e Entry.
+     * @return Tuple if acknowledge should be sent to backups.
+     */
+    @Nullable synchronized IgniteBiTuple<Map<Integer, Long>, Set<AffinityTopologyVersion>>
+    onAcknowledged(CacheContinuousQueryEntry e) {
+        size++;
+
+        addEntry(e);
+
+        return size >= CacheContinuousQueryHandler.BACKUP_ACK_THRESHOLD ? acknowledgeData() : null;
     }
 
     /**
      * @param e Entry.
      */
     private void addEntry(CacheContinuousQueryEntry e) {
+        topVers.add(e.topologyVersion());
+
         Long cntr0 = updateCntrs.get(e.partition());
 
         if (cntr0 == null || e.updateCounter() > cntr0)
@@ -66,22 +89,35 @@ class CacheContinuousQueryAcknowledgeBuffer {
     }
 
     /**
-     * @return Update counters per partition information.
+     * @return Tuple if acknowledge should be sent to backups.
      */
-    private Map<Integer, Long> acknowledgeData() {
+    @Nullable synchronized IgniteBiTuple<Map<Integer, Long>, Set<AffinityTopologyVersion>>
+        acknowledgeOnTimeout() {
+        return size > 0 ? acknowledgeData() : null;
+    }
+
+    /**
+     * @return Tuple with acknowledge information.
+     */
+    private IgniteBiTuple<Map<Integer, Long>, Set<AffinityTopologyVersion>> acknowledgeData() {
         assert size > 0;
 
         Map<Integer, Long> cntrs = new HashMap<>(updateCntrs);
+
+        IgniteBiTuple<Map<Integer, Long>, Set<AffinityTopologyVersion>> res =
+            new IgniteBiTuple<>(cntrs, topVers);
+
+        topVers = U.newHashSet(1);
 
         updateCntrs.clear();
 
         size = 0;
 
-        return cntrs;
+        return res;
     }
 
     /** {@inheritDoc} */
     @Override public String toString() {
-        return S.toString(CacheContinuousQueryAcknowledgeBuffer.class, this);
+        return S.toString(CacheContinuousQueryAcknowledgeBackupBuffer.class, this);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryHandler.java
@@ -92,6 +92,10 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
     private static final long serialVersionUID = 0L;
 
     /** */
+    static final int ACK_THRESHOLD =
+        IgniteSystemProperties.getInteger("IGNITE_CONTINUOUS_QUERY_ACK_THRESHOLD", 100);
+
+    /** */
     static final int BACKUP_ACK_THRESHOLD =
         IgniteSystemProperties.getInteger("IGNITE_CONTINUOUS_QUERY_BACKUP_ACK_THRESHOLD", 100);
 
@@ -168,6 +172,9 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
 
     /** */
     private transient CacheContinuousQueryAcknowledgeBuffer ackBuf;
+
+    /** */
+    private transient CacheContinuousQueryAcknowledgeBackupBuffer ackBufBackup;
 
     /** */
     private transient int cacheId;
@@ -357,6 +364,8 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
 
         ackBuf = new CacheContinuousQueryAcknowledgeBuffer();
 
+        ackBufBackup = new CacheContinuousQueryAcknowledgeBackupBuffer();
+
         rcvs = new ConcurrentHashMap<>();
 
         this.nodeId = nodeId;
@@ -463,8 +472,11 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
                 for (Map.Entry<Integer, Long> e : updateCntrs.entrySet()) {
                     CacheContinuousQueryEventBuffer buf = entryBufs.get(e.getKey());
 
-                    if (buf != null)
+                    if (buf != null) {
                         buf.cleanupBackupQueue(e.getValue());
+
+                        buf.cleanupEntries(e.getValue());
+                    }
                 }
             }
 
@@ -500,7 +512,7 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
             }
 
             @Override public void acknowledgeBackupOnTimeout(GridKernalContext ctx) {
-                sendBackupAcknowledge(ackBuf.acknowledgeOnTimeout(), routineId, ctx);
+                sendBackupAcknowledge(ackBufBackup.acknowledgeOnTimeout(), routineId, ctx);
             }
 
             @Override public void skipUpdateEvent(CacheContinuousQueryEvent<K, V> evt,
@@ -1015,7 +1027,7 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
                     notifyLocalListener(evts, trans);
 
                     if (!internal && !skipPrimaryCheck)
-                        sendBackupAcknowledge(ackBuf.onAcknowledged(entry), routineId, ctx);
+                        sendBackupAcknowledge(ackBufBackup.onAcknowledged(entry), routineId, ctx);
                 }
                 else {
                     if (!entry.isFiltered())
@@ -1314,7 +1326,9 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
     @Override public void onBatchAcknowledged(final UUID routineId,
         GridContinuousBatch batch,
         final GridKernalContext ctx) {
-        sendBackupAcknowledge(ackBuf.onAcknowledged(batch), routineId, ctx);
+        sendBackupAcknowledge(ackBufBackup.onAcknowledged(batch), routineId, ctx);
+
+        cleanupBuffers(ackBuf.onAcknowledged(batch));
     }
 
     /**
@@ -1358,6 +1372,20 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
                     }
                 }
             });
+        }
+    }
+
+    /**
+     * @param updateCntrs Acknowledge information.
+     */
+    private void cleanupBuffers(Map<Integer, Long> updateCntrs) {
+        if (updateCntrs != null) {
+            for (Map.Entry<Integer, Long> e : updateCntrs.entrySet()) {
+                CacheContinuousQueryEventBuffer buf = entryBufs.get(e.getKey());
+
+                if (buf != null)
+                    buf.cleanupEntries(e.getValue());
+            }
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/ContinuousQueryBufferCleanupAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/ContinuousQueryBufferCleanupAbstractTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.query.continuous;
+
+import java.util.UUID;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
+import org.apache.ignite.cache.query.AbstractContinuousQuery;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.processors.continuous.GridContinuousProcessor;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi.DFLT_ACK_SND_THRESHOLD;
+
+/**
+ * Test for continuous query buffer cleanup.
+ */
+public abstract class ContinuousQueryBufferCleanupAbstractTest extends GridCommonAbstractTest {
+    /** */
+    private static final int RECORDS_CNT = 10000;
+
+    /** */
+    private static final int ACK_THRESHOLD = 100;
+
+    /** */
+    private static final String REMOTE_ROUTINE_INFO_CLASS_NAME = "org.apache.ignite.internal.processors.continuous.GridContinuousProcessor$RemoteRoutineInfo";
+
+    /** */
+    private static final String LOCAL_ROUTINE_INFO_CLASS_NAME = "org.apache.ignite.internal.processors.continuous.GridContinuousProcessor$LocalRoutineInfo";
+
+    /** */
+    private static final String BATCH_CLASS_NAME = "org.apache.ignite.internal.processors.cache.query.continuous.CacheContinuousQueryEventBuffer$Batch";
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+    }
+
+    /**
+     * @throws Exception If fail.
+     */
+    @Test
+    public void checkCacheWithSingleNode() throws Exception {
+        checkBuffer(1, 0, true);
+    }
+
+    /**
+     * @throws Exception If fail.
+     */
+    @Test
+    public void checkCacheWithMultipleNodes() throws Exception {
+        checkBuffer(2, 0, true);
+    }
+
+    /**
+     * @throws Exception If fail.
+     */
+    @Test
+    public void checkCacheWithMultipleNodesWithBackups() throws Exception {
+        checkBuffer(2, 1, true);
+    }
+
+    /**
+     * @throws Exception If fail.
+     */
+    @Test
+    public void checkCacheWithMultipleNodesWithBackupsWithoutClient() throws Exception {
+        checkBuffer(2, 1, false);
+    }
+
+    /** Provides continuous query for the test. */
+    protected abstract AbstractContinuousQuery<Integer, String> getContinuousQuery();
+
+    /** */
+    private void checkBuffer(int srvCnt, int backupsCnt, boolean useClient) throws Exception {
+        System.setProperty("IGNITE_CONTINUOUS_QUERY_ACK_THRESHOLD", Integer.toString(ACK_THRESHOLD));
+
+        IgniteEx[] srvs = new IgniteEx[srvCnt];
+
+        for (int i = 0; i < srvCnt; i++)
+            srvs[i] = startGrid("srv" + i);
+
+        Ignite queryNode = useClient
+            ? startGrid(optimize(getConfiguration("client").setClientMode(true)))
+            : srvs[0];
+
+        CacheConfiguration<Integer, String> cacheCfg = new CacheConfiguration<Integer, String>("testCache")
+            .setBackups(backupsCnt)
+            .setAffinity(new RendezvousAffinityFunction(32, null));
+
+        IgniteCache<Integer, String> cache = queryNode.getOrCreateCache(cacheCfg);
+
+        AbstractContinuousQuery<Integer, String> qry = getContinuousQuery();
+
+        cache.query(qry);
+
+        for (int i = 0; i < RECORDS_CNT; i++)
+            cache.put(i, Integer.toString(i));
+
+        Thread.sleep(2000);
+
+        for (int i = 0; i < srvCnt; i++)
+            validateBuffer(srvs[i], backupsCnt);
+    }
+
+    /** */
+    private void validateBuffer(IgniteEx srv, int backupsCnt) throws ClassNotFoundException {
+        GridContinuousProcessor contProc = srv.context().continuous();
+
+        ConcurrentMap<UUID, Object> rmtInfos = GridTestUtils.getFieldValue(contProc, GridContinuousProcessor.class, "rmtInfos");
+
+        CacheContinuousQueryHandler hnd;
+
+        if (rmtInfos.values().isEmpty()) {
+            ConcurrentMap<UUID, Object> locInfos = GridTestUtils.getFieldValue(contProc, GridContinuousProcessor.class, "locInfos");
+
+            Object localRoutineInfo = locInfos.values().toArray()[0];
+
+            hnd = GridTestUtils.getFieldValue(localRoutineInfo, Class.forName(LOCAL_ROUTINE_INFO_CLASS_NAME), "hnd");
+        } else {
+            Object rmtRoutineInfo = rmtInfos.values().toArray()[0];
+
+            hnd = GridTestUtils.getFieldValue(rmtRoutineInfo, Class.forName(REMOTE_ROUTINE_INFO_CLASS_NAME), "hnd");
+        }
+
+        ConcurrentMap<Integer, CacheContinuousQueryEventBuffer> entryBufs = GridTestUtils.getFieldValue(hnd, CacheContinuousQueryHandler.class, "entryBufs");
+
+        int notNullCnt = 0;
+
+        for (CacheContinuousQueryEventBuffer evtBuf : entryBufs.values()) {
+            AtomicReference<Object> curBatch = GridTestUtils.getFieldValue(evtBuf, CacheContinuousQueryEventBuffer.class, "curBatch");
+
+            if (curBatch.get() != null) {
+                CacheContinuousQueryEntry[] entries = GridTestUtils.getFieldValue(curBatch.get(), Class.forName(BATCH_CLASS_NAME), "entries");
+
+                for (CacheContinuousQueryEntry entry : entries) {
+                    if (entry != null)
+                        notNullCnt++;
+                }
+            }
+        }
+
+        assertTrue(notNullCnt < ACK_THRESHOLD + (1 + backupsCnt) * DFLT_ACK_SND_THRESHOLD);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/ContinuousQueryBufferCleanupTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/ContinuousQueryBufferCleanupTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.query.continuous;
+
+import org.apache.ignite.cache.query.AbstractContinuousQuery;
+import org.apache.ignite.cache.query.ContinuousQuery;
+
+/**
+ * Test for continuous query buffer cleanup.
+ */
+public class ContinuousQueryBufferCleanupTest extends ContinuousQueryBufferCleanupAbstractTest {
+    /** {@inheritDoc} */
+    @Override
+    protected AbstractContinuousQuery<Integer, String> getContinuousQuery() {
+        ContinuousQuery<Integer, String> qry = new ContinuousQuery<>();
+
+        qry.setLocalListener((evts) -> evts.forEach(e -> System.out.println("key=" + e.getKey() + ", val=" + e.getValue())));
+
+        return qry;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/ContinuousQueryWithTransformerBufferCleanupTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/ContinuousQueryWithTransformerBufferCleanupTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.query.continuous;
+
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.FactoryBuilder;
+import javax.cache.event.CacheEntryEvent;
+import org.apache.ignite.cache.query.AbstractContinuousQuery;
+import org.apache.ignite.cache.query.ContinuousQueryWithTransformer;
+import org.apache.ignite.lang.IgniteClosure;
+
+/**
+ * Test for continuous query with transformer buffer cleanup.
+ */
+public class ContinuousQueryWithTransformerBufferCleanupTest extends ContinuousQueryBufferCleanupAbstractTest {
+    /** {@inheritDoc} */
+    @Override
+    protected AbstractContinuousQuery<Integer, String> getContinuousQuery() {
+        ContinuousQueryWithTransformer<Integer, String, String> qry = new ContinuousQueryWithTransformer<>();
+
+        Factory factory = FactoryBuilder.factoryOf(
+            (IgniteClosure<CacheEntryEvent, String>)event -> ((String)event.getValue())
+        );
+
+        qry.setRemoteTransformerFactory(factory);
+
+        qry.setLocalListener((evts) -> evts.forEach(e -> System.out.println("val=" + e)));
+
+        return qry;
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheQuerySelfTestSuite6.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheQuerySelfTestSuite6.java
@@ -28,7 +28,9 @@ import org.apache.ignite.internal.processors.cache.query.continuous.CacheContinu
 import org.apache.ignite.internal.processors.cache.query.continuous.CacheKeepBinaryIterationNearEnabledTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.CacheKeepBinaryIterationStoreEnabledTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.CacheKeepBinaryIterationTest;
+import org.apache.ignite.internal.processors.cache.query.continuous.ContinuousQueryBufferCleanupTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.ContinuousQueryMarshallerTest;
+import org.apache.ignite.internal.processors.cache.query.continuous.ContinuousQueryWithTransformerBufferCleanupTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.GridCacheContinuousQueryLocalAtomicSelfTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.GridCacheContinuousQueryMultiNodesFilteringTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.GridCacheContinuousQueryPartitionAtomicOneNodeTest;
@@ -68,6 +70,8 @@ import org.junit.runners.Suite;
     StaticCacheDdlKeepStaticConfigurationTest.class,
     MemLeakOnSqlWithClientReconnectTest.class,
     HashJoinQueryTest.class,
+    ContinuousQueryBufferCleanupTest.class,
+    ContinuousQueryWithTransformerBufferCleanupTest.class,
 })
 public class IgniteCacheQuerySelfTestSuite6 {
 }


### PR DESCRIPTION
* GG-17432 clearing entries after processing in continuous queries implemented

* GG-17432 CQ buffers cleanup after getting acknowledge from client implemented

* GG-17432 processed buffer check implemented

* GG-17432 test for CQ buffer clean up implemented

* GG-17432 cleanup entries for backup partitions implemented

* GG-17432 unit test added for case with multiple nodes and backups

* GG-17432 code review fixes

* GG-17432 code review fixes. "cleanupEntries" method was optimized. "testMultipleNodesWithBackupsWithoutClient" test added.

* GG-17432 code style fixed

* GG-17432 tests for the CQ with transformer added

* GG-17432 continuous query buffer cleanup tests renamed

(cherry picked from commit bdf60aeeabfae6cb2b7bcc10a6dead4654615803)