### PR TITLE
GG-28579 [IGNITE-7609] .NET: Expose field types in FieldsQueryCursor

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformFieldsQueryCursor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformFieldsQueryCursor.java
@@ -21,6 +21,7 @@ import org.apache.ignite.cache.query.FieldsQueryCursor;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import org.apache.ignite.internal.processors.cache.query.QueryCursorEx;
 import org.apache.ignite.internal.processors.platform.PlatformContext;
+import org.apache.ignite.internal.processors.query.GridQueryFieldMetadata;
 
 import java.util.List;
 
@@ -30,6 +31,9 @@ import java.util.List;
 public class PlatformFieldsQueryCursor extends PlatformAbstractQueryCursor<List<?>> {
     /** Gets field names. */
     private static final int OP_GET_FIELD_NAMES = 7;
+
+    /** Gets field types. */
+    private static final int OP_GET_FIELDS_META = 8;
 
     /**
      * Constructor.
@@ -54,7 +58,7 @@ public class PlatformFieldsQueryCursor extends PlatformAbstractQueryCursor<List<
             writer.writeObjectDetached(val);
 
         int rowEndPos = writer.out().position();
-        
+
         writer.writeInt(rowSizePos, rowEndPos - rowSizePos);
     }
 
@@ -68,6 +72,21 @@ public class PlatformFieldsQueryCursor extends PlatformAbstractQueryCursor<List<
 
             for (int i = 0; i < cnt; i++) {
                 writer.writeString(fq.getFieldName(i));
+            }
+        } else if (type == OP_GET_FIELDS_META) {
+            QueryCursorEx<List<?>> cursor = cursor();
+
+            List<GridQueryFieldMetadata> metas = cursor.fieldsMeta();
+
+            if (metas == null) {
+                writer.writeInt(0);
+            } else {
+                writer.writeInt(metas.size());
+
+                for (GridQueryFieldMetadata meta : metas) {
+                    writer.writeString(meta.fieldName());
+                    writer.writeString(meta.fieldTypeName());
+                }
             }
         } else {
             super.processOutStream(type, writer);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
@@ -845,6 +845,76 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
+        /// Tests the FieldsMetadata property.
+        /// </summary>
+        [Test]
+        public void TestFieldsMetadata()
+        {
+            var cache = Cache();
+            PopulateCache(cache, false, 5, x => true);
+
+            // Get before iteration.
+            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson");
+            var cur = cache.Query(qry);
+            var metas = cur.Fields;
+
+            ValidateFieldsMetadata(
+                metas,
+                new[] {"AGE", "NAME"},
+                new[] {typeof(int), typeof(string)},
+                new[] {"java.lang.Integer", "java.lang.String"}
+            );
+
+            cur.Dispose();
+            Assert.AreSame(metas, cur.Fields);
+
+            Assert.Throws<NotSupportedException>(() => cur.Fields.Add(default(IQueryCursorField)));
+
+            // Custom order, key-val, get after iteration.
+            qry.Sql = "SELECT NAME, _key, AGE, _val FROM QueryPerson";
+            cur = cache.Query(qry);
+            var list = cur.GetAll();
+
+            ValidateFieldsMetadata(
+                cur.Fields,
+                new[] {"NAME", "_KEY", "AGE", "_VAL"},
+                new[] {typeof(string), typeof(object), typeof(int), typeof(object)},
+                new[] {"java.lang.String", "java.lang.Object", "java.lang.Integer", "java.lang.Object"}
+            );
+
+            // Get after disposal.
+            qry.Sql = "SELECT 1, AGE FROM QueryPerson";
+            cur = cache.Query(qry);
+            cur.Dispose();
+
+            ValidateFieldsMetadata(
+                cur.Fields,
+                new[] {"1", "AGE"},
+                new[] {typeof(int), typeof(int)},
+                new[] {"java.lang.Integer", "java.lang.Integer"}
+            );
+        }
+
+        /// <summary>
+        /// Validates fields metadata collection
+        /// </summary>
+        /// <param name="metadata">Metadata</param>
+        /// <param name="expectedNames">Expected field names</param>
+        /// <param name="expectedTypes">Expected field types</param>
+        /// <param name="expectedJavaTypeNames">Expected java type names</param>
+        private static void ValidateFieldsMetadata(
+            IList<IQueryCursorField> metadata,
+            string[] expectedNames,
+            Type[] expectedTypes,
+            string[] expectedJavaTypeNames
+        )
+        {
+            Assert.AreEqual(expectedNames, metadata.Select(m => m.Name));
+            Assert.AreEqual(expectedTypes, metadata.Select(m => m.Type));
+            Assert.AreEqual(expectedJavaTypeNames, metadata.Select(m => m.JavaTypeName));
+        }
+
+        /// <summary>
         /// Validates the query results.
         /// </summary>
         /// <param name="cache">Cache.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Cache\Configuration\DataPageEvictionMode.cs" />
     <Compile Include="Cache\Configuration\PlatformCacheConfiguration.cs" />
     <Compile Include="Cache\IQueryMetrics.cs" />
+    <Compile Include="Cache\Query\IQueryCursorField.cs" />
     <Compile Include="Client\Cache\CacheClientConfiguration.cs" />
     <Compile Include="Client\IClientCluster.cs" />
     <Compile Include="Client\IClientClusterGroup.cs" />
@@ -91,6 +92,7 @@
     <Compile Include="Impl\Cache\Platform\PlatformCacheManager.cs" />
     <Compile Include="Impl\Cache\QueryMetricsImpl.cs" />
     <Compile Include="Impl\Cache\Query\PlatformCacheQueryCursor.cs" />
+    <Compile Include="Impl\Cache\Query\QueryCursorField.cs" />
     <Compile Include="Impl\Client\ClientContextBase.cs" />
     <Compile Include="Impl\Client\ClientOpExtensions.cs" />
     <Compile Include="Impl\Client\ClientRequestContext.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/IQueryCursorField.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/IQueryCursorField.cs
@@ -16,23 +16,27 @@
 
 namespace Apache.Ignite.Core.Cache.Query
 {
-    using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
+    using System;
 
     /// <summary>
-    /// Fields query cursor.
+    /// Query field descriptor. This descriptor is used to provide metadata
+    /// about fields returned in query result.
     /// </summary>
-    [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
-    public interface IFieldsQueryCursor : IQueryCursor<IList<object>>
+    public interface IQueryCursorField
     {
         /// <summary>
-        /// Gets the field names.
+        /// Gets the field name.
         /// </summary>
-        IList<string> FieldNames { get; }
+        string Name { get; }
 
         /// <summary>
-        /// Gets fields metadata.
+        /// Gets the name of Java type for this field.
         /// </summary>
-        IList<IQueryCursorField> Fields { get; }
+        string JavaTypeName { get; }
+
+        /// <summary>
+        /// Gets the field type.
+        /// </summary>
+        Type Type { get; }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryReaderExtensions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryReaderExtensions.cs
@@ -111,7 +111,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// from org.apache.ignite.internal.processors.platform.utils package
         /// Note: return null if collection is empty
         /// </summary>
-        public static ICollection<T> ReadCollectionRaw<T, TReader>(this TReader reader,
+        public static IList<T> ReadCollectionRaw<T, TReader>(this TReader reader,
             Func<TReader, T> factory) where TReader : IBinaryRawReader
         {
             Debug.Assert(reader != null);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/JavaTypes.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/JavaTypes.cs
@@ -44,7 +44,8 @@ namespace Apache.Ignite.Core.Impl.Binary
             {typeof (string), "java.lang.String"},
             {typeof (decimal), "java.math.BigDecimal"},
             {typeof (Guid), "java.util.UUID"},
-            {typeof (DateTime), "java.sql.Timestamp"}
+            {typeof (DateTime), "java.sql.Timestamp"},
+            {typeof (object), "java.lang.Object"}
         };
 
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/FieldsQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/FieldsQueryCursor.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Linq;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Impl.Binary;
@@ -32,7 +33,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
         /// Constructor.
         /// </summary>
         /// <param name="target">Target.</param>
-        /// <param name="keepBinary">Keep poratble flag.</param>
+        /// <param name="keepBinary">Keep binary flag.</param>
         /// <param name="readerFunc">The reader function.</param>
         public FieldsQueryCursor(IPlatformTargetInternal target, bool keepBinary, 
             Func<IBinaryRawReader, int, T> readerFunc)
@@ -60,13 +61,19 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
         private const int OpGetFieldNames = 7;
 
         /** */
+        private const int OpGetFieldsMeta = 8;
+
+        /** */
         private IList<string> _fieldNames;
+
+        /** */
+        private IList<IQueryCursorField> _fieldsMeta;
 
         /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="target">Target.</param>
-        /// <param name="keepBinary">Keep poratble flag.</param>
+        /// <param name="keepBinary">Keep binary flag.</param>
         /// <param name="readerFunc">The reader function.</param>
         public FieldsQueryCursor(IPlatformTargetInternal target, bool keepBinary, 
             Func<IBinaryRawReader, int, IList<object>> readerFunc) : base(target, keepBinary, readerFunc)
@@ -82,6 +89,25 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
                 return _fieldNames ??
                        (_fieldNames = new ReadOnlyCollection<string>(
                            Target.OutStream(OpGetFieldNames, reader => reader.ReadStringCollection())));
+            }
+        }
+
+        /** <inheritdoc /> */
+        public IList<IQueryCursorField> Fields
+        {
+            get
+            {
+                if (_fieldsMeta == null)
+                {
+                    var metadata = Target.OutStream(
+                        OpGetFieldsMeta,
+                        reader => reader.ReadCollectionRaw(stream =>
+                            new QueryCursorField(stream) as IQueryCursorField));
+
+                    _fieldsMeta = new ReadOnlyCollection<IQueryCursorField>(metadata ?? new List<IQueryCursorField>());
+                }
+
+                return _fieldsMeta;
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/QueryCursorField.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/QueryCursorField.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Cache.Query
+{
+    using System;
+    using Apache.Ignite.Core.Binary;
+    using Apache.Ignite.Core.Cache.Query;
+    using Apache.Ignite.Core.Impl.Binary;
+
+    /// <summary>
+    /// Query cursor field implementation.
+    /// </summary>
+    internal class QueryCursorField : IQueryCursorField
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QueryCursorField"/> class.
+        /// </summary>
+        /// <param name="reader">The reader.</param>
+        public QueryCursorField(IBinaryRawReader reader)
+        {
+            Name = reader.ReadString();
+            JavaTypeName = reader.ReadString();
+            Type = JavaTypes.GetDotNetType(JavaTypeName);
+        }
+
+        /** <inheritdoc /> */
+        public string Name { get; private set; }
+
+        /** <inheritdoc /> */
+        public string JavaTypeName { get; private set; }
+
+        /** <inheritdoc /> */
+        public Type Type { get; private set; }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -871,7 +871,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             QueryBase.WriteQueryArgs(writer, qry.Arguments);
 
             // .NET client does not discern between different statements for now.
-            // We cound have ExecuteNonQuery method, which uses StatementType.Update, for example.
+            // We could have ExecuteNonQuery method, which uses StatementType.Update, for example.
             writer.WriteByte((byte)StatementType.Any);
 
             writer.WriteBoolean(qry.EnableDistributedJoins);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientFieldsQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientFieldsQueryCursor.cs
@@ -61,6 +61,15 @@ namespace Apache.Ignite.Core.Impl.Client.Cache.Query
         /** <inheritdoc /> */
         public IList<string> FieldNames { get; private set; }
 
+        /** <inheritdoc /> */
+        public IList<IQueryCursorField> Fields
+        {
+            get
+            {
+                throw IgniteClient.GetClientNotSupportedException();
+            }
+        }
+
         /// <summary>
         /// Reads the columns.
         /// </summary>


### PR DESCRIPTION
Add `IList<IQueryCursorField> IFieldsQueryCursor.Fields` property, which provides field names with types.