### PR TITLE
GG-28952 [IGNITE-12940] .NET: Use fixed NuGet version in build script

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.NuGet/install-package.ps1
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.NuGet/install-package.ps1
@@ -14,11 +14,11 @@ rmdir packages -Force -Recurse
 # Detect NuGet
 $ng = "nuget"
 if ((Get-Command $ng -ErrorAction SilentlyContinue) -eq $null) { 
-    $ng = ".\nuget.exe"
+    $ng = "$PSScriptRoot\..\nuget.exe"
 
     if (-not (Test-Path $ng)) {
         echo "Downloading NuGet..."
-        (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v3.3.0/nuget.exe", "nuget.exe");    
+        (New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe", $ng)    
     }
 }
 

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -175,7 +175,7 @@ if ((Get-Command $ng -ErrorAction SilentlyContinue) -eq $null) {
 
 	if (-not (Test-Path $ng)) {
 		echo "Downloading NuGet..."
-		(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/latest/nuget.exe", "$PSScriptRoot/nuget.exe")    
+		(New-Object System.Net.WebClient).DownloadFile("https://dist.nuget.org/win-x86-commandline/v5.3.1/nuget.exe", "$PSScriptRoot/nuget.exe")    
 	}
 }
 


### PR DESCRIPTION
New NuGet release has a bug causing failing builds: https://github.com/NuGet/Home/issues/9458
To fix this and prevent future issues, use a fixed NuGet version instead of the latest.