### PR TITLE
GG-29576 JAVADOC build fails after adding spi.tracing package fixed.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/tracing/package-info.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/tracing/package-info.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * <!-- Package description. -->
+ * Contains common classes and interfaces for tracing SPI implementations.
+ */
+package org.apache.ignite.spi.tracing;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -566,6 +566,10 @@
                                 <title>System view SPI</title>
                                 <packages>org.apache.ignite.spi.systemview*</packages>
                             </group>
+                            <group>
+                                <title>Tracing SPI</title>
+                                <packages>org.apache.ignite.spi.tracing*</packages>
+                            </group>
                         </groups>
                         <bottom>
                             <![CDATA[


### PR DESCRIPTION
Signed-off-by: alapin <lapin1702@gmail.com>