### PR TITLE
GG-29574 [IGNITE-13095] .NET: Fix Thin Client compute task cancellation

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformComputeActiveTaskFuturesTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformComputeActiveTaskFuturesTask.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformComputeActiveTaskFuturesTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformComputeActiveTaskFuturesTask.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobAdapter;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeTaskAdapter;
+import org.apache.ignite.lang.IgniteUuid;
+import org.apache.ignite.resources.IgniteInstanceResource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Task to get active task futures.
+ */
+@SuppressWarnings({"OptionalGetWithoutIsPresent", "unused"})
+public class PlatformComputeActiveTaskFuturesTask extends ComputeTaskAdapter<Object, IgniteUuid[]> {
+    /** {@inheritDoc} */
+    @NotNull @Override public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid,
+                                                                         @Nullable Object arg) {
+        ClusterNode localNode = subgrid.stream().filter(ClusterNode::isLocal).findFirst().get();
+
+        return Collections.singletonMap(new ActiveTaskFuturesJob(), localNode);
+    }
+
+    /** {@inheritDoc} */
+    @Nullable @Override public IgniteUuid[] reduce(List<ComputeJobResult> results) {
+        return results.get(0).getData();
+    }
+
+    /**
+     * Job.
+     */
+    @SuppressWarnings({"ZeroLengthArrayAllocation", "unused"})
+    private static class ActiveTaskFuturesJob extends ComputeJobAdapter {
+        /** Ignite. */
+        @IgniteInstanceResource
+        private Ignite ignite;
+
+        /** {@inheritDoc} */
+        @Nullable @Override public IgniteUuid[] execute() {
+            Set<IgniteUuid> ids = ignite.compute().activeTaskFutures().keySet();
+
+            return ids.toArray(new IgniteUuid[0]);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheTest.cs
@@ -72,7 +72,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             {
                 EnabledLevels = new[] {LogLevel.Error}
             };
-            
+
             var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
                 CacheConfiguration = new[]
@@ -96,7 +96,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             };
 
             _grid = Ignition.Start(cfg);
-            
+
             var cfg2 = new IgniteConfiguration(cfg)
             {
                 IgniteInstanceName = "server2"
@@ -112,7 +112,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             };
 
             _client = Ignition.Start(clientCfg);
-            
+
             WaitForRebalance();
         }
 
@@ -148,14 +148,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var key = TestUtils.GetKey(_grid, cache.Name, primaryKey: primaryKey);
 
             var obj = new Foo(key);
-            
+
             cache[key] = obj;
             var res1 = cache[key];
             var res2 = cache[key];
 
             // Returned object is Equal to the initial.
             Assert.AreEqual(obj, res1);
-            
+
             // But not the same - new instance is stored in platform cache,
             // except primary on servers - thread-local optimization avoids extra deserialization there.
             if (primaryKey && mode == CacheTestMode.ServerLocal || !primaryKey && mode == CacheTestMode.ServerRemote)
@@ -195,14 +195,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 // Put through remote node: platform cache is updated only on Get.
                 var remoteCache = GetCache<int, Foo>(
                     mode == CacheTestMode.Client ? CacheTestMode.ServerRemote : CacheTestMode.Client);
-                
+
                 remoteCache[key] = obj;
             }
 
             Assert.AreEqual(3, cache[key].Bar);
             Assert.AreSame(cache[key], cache[key]);
         }
-        
+
         /// <summary>
         /// Tests that platform cache returns the same object on every get.
         /// </summary>
@@ -221,13 +221,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             {
                 Foo val;
 
-                return localCache.TryGet(key, out val) && 
+                return localCache.TryGet(key, out val) &&
                        ReferenceEquals(val, localCache.Get(key));
-            }, 300);
-            
+            });
+
             // Invalidate after get.
             remoteCache[key] = new Foo(1);
-            
+
             TestUtils.WaitForTrueCondition(() =>
             {
                 Foo val;
@@ -235,9 +235,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 return localCache.TryGet(key, out val) &&
                        val.Bar == 1 &&
                        ReferenceEquals(val, localCache.Get(key));
-            }, 300);
+            });
         }
-        
+
         /// <summary>
         /// Tests that platform cache is updated from remote node after being populated with local Put call.
         /// </summary>
@@ -277,7 +277,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         public void TestPlatformCacheRemoveFromRemoteNodeAfterLocalPut()
         {
             var localCache = _client.GetOrCreateNearCache<int, int>(CacheName, new NearCacheConfiguration());
-            
+
             var remoteCache = _grid.GetCache<int, int>(CacheName);
 
             localCache[1] = 1;
@@ -300,7 +300,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             clientCache[key] = 2;
             Assert.AreEqual(2, serverCache.LocalPeek(key, CachePeekMode.Platform));
-            
+
             clientCache[key] = 3;
             Assert.AreEqual(3, serverCache.LocalPeek(key, CachePeekMode.Platform));
 
@@ -319,7 +319,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 NearConfiguration = new NearCacheConfiguration(),
                 PlatformCacheConfiguration = new PlatformCacheConfiguration()
             };
-            
+
             var cache1 = _grid.CreateCache<int, int>(cfg);
             var cache2 = _grid.GetCache<string, string>(cfg.Name);
             var cache3 = _grid.GetCache<int, Foo>(cfg.Name);
@@ -345,16 +345,16 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 NearConfiguration = new NearCacheConfiguration(),
                 PlatformCacheConfiguration = new PlatformCacheConfiguration()
             };
-            
+
             var cache1 = _grid.CreateCache<int, Foo>(cfg);
             cache1[1] = new Foo(42);
             cache1[2] = new Foo(43);
-            
+
             // Use different type parameters.
             var cache2 = _grid.GetCache<int, string>(cfg.Name);
             cache2[1] = "x";
 
-            // Check that platform cache still works for old entries. 
+            // Check that platform cache still works for old entries.
             Assert.Throws<InvalidCastException>(() => cache1.Get(1));
             Assert.AreEqual(43, cache1[2].Bar);
             Assert.AreSame(cache1[2], cache1[2]);
@@ -399,13 +399,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 WriteThrough = true
             };
 
-            var cache = GetIgnite(mode).CreateCache<int, Foo>(cfg, new NearCacheConfiguration(), 
+            var cache = GetIgnite(mode).CreateCache<int, Foo>(cfg, new NearCacheConfiguration(),
                 new PlatformCacheConfiguration());
-            
+
             // First write succeeds.
             cache.Put(1, new Foo(1));
             Assert.AreEqual(1, cache.LocalPeek(1, CachePeekMode.Platform).Bar);
-            
+
             // Special value causes write failure. Platform cache value is still correct.
             Assert.Throws<CacheStoreException>(() => cache.Put(1, new Foo(FailingCacheStore.FailingValue)));
             Assert.AreEqual(1, cache.LocalPeek(1, CachePeekMode.Platform).Bar);
@@ -421,7 +421,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             var value = new Foo(5);
             cache[1] = value;
-            
+
             cache.Query(new SqlFieldsQuery("update Foo set Bar = 7 where Bar = 5"));
 
             var res = cache[1];
@@ -429,19 +429,19 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         }
 
         /// <summary>
-        /// Tests that eviction policy removes platform cache data for the key. 
+        /// Tests that eviction policy removes platform cache data for the key.
         /// </summary>
         [Test]
         public void TestFifoEvictionPolicyRemovesPlatformCacheValue(
             [Values(CacheTestMode.ServerLocal, CacheTestMode.ServerRemote, CacheTestMode.Client)] CacheTestMode mode)
         {
             var cache = GetCache<int, Foo>(mode);
-            
+
             TestEvictionPolicyRemovesPlatformCacheValue(mode, cache);
         }
 
         /// <summary>
-        /// Tests that eviction policy removes platform cache data for the key. 
+        /// Tests that eviction policy removes platform cache data for the key.
         /// </summary>
         [Test]
         public void TestLruEvictionPolicyRemovesPlatformCacheValue(
@@ -463,7 +463,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             var ignite = GetIgnite(mode);
             var cache = ignite.CreateCache<int, Foo>(cfg, cfg.NearConfiguration);
-            
+
             TestEvictionPolicyRemovesPlatformCacheValue(mode, cache);
         }
 
@@ -472,20 +472,20 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         /// </summary>
         [Test]
         public void TestEvictionPolicyKeepsLastEntriesInPlatformCache(
-            [Values(true, false)] bool lruOrFifo, 
+            [Values(true, false)] bool lruOrFifo,
             [Values(true, false)] bool getOrCreate)
         {
             const int maxSize = 30;
-            
+
             var serverCache = _grid.CreateCache<int, Foo>(TestUtils.TestName);
 
             var nearCfg = new NearCacheConfiguration
             {
-                EvictionPolicy = lruOrFifo 
+                EvictionPolicy = lruOrFifo
                     ? (IEvictionPolicy) new LruEvictionPolicy
                     {
                         MaxSize = maxSize
-                    } 
+                    }
                     : new FifoEvictionPolicy
                     {
                         MaxSize = maxSize
@@ -494,13 +494,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             var platformCfg = new PlatformCacheConfiguration();
 
-            var clientCache = getOrCreate 
+            var clientCache = getOrCreate
                 ? _client.GetOrCreateNearCache<int, Foo>(serverCache.Name, nearCfg, platformCfg)
                 : _client.CreateNearCache<int, Foo>(serverCache.Name, nearCfg, platformCfg);
 
             var keys = Enumerable.Range(1, maxSize * 5).ToList();
             var nearKeys = keys.AsEnumerable().Reverse().Take(maxSize).ToArray();
-            
+
             keys.ForEach(k => serverCache.Put(k, new Foo(k)));
 
             // Get from client to populate platform cache.
@@ -512,7 +512,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             {
                 Assert.AreSame(clientCache.LocalPeek(key, CachePeekMode.Platform), clientCache.Get(key));
             }
-            
+
             // Check that GetAll returns instances from platform cache.
             var all = clientCache.GetAll(nearKeys);
             foreach (var entry in all)
@@ -544,11 +544,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             var serverCache = _grid.CreateCache<int, int>(cfg);
             var clientCache = _client.GetOrCreateNearCache<int, int>(cfg.Name, cfg.NearConfiguration);
-            
+
             clientCache[1] = 1;
             clientCache[2] = 2;
             serverCache[1] = 11;
-            
+
             Assert.AreEqual(11, clientCache[1]);
         }
 
@@ -560,7 +560,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             [Values(CacheTestMode.ServerLocal, CacheTestMode.ServerRemote, CacheTestMode.Client)] CacheTestMode mode)
         {
             var cache = GetCache<int, Foo>(mode);
-            
+
             const int count = 100;
             cache.PutAll(Enumerable.Range(1, count).Select(x => new KeyValuePair<int, Foo>(x, new Foo(x))));
 
@@ -569,9 +569,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             {
                 CacheName = cache.Name
             };
-            
+
             var res = cache.Query(new ScanQuery<int, Foo>(filter));
-            
+
             Assert.AreEqual(count, res.Count());
         }
 
@@ -583,10 +583,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             [Values(CacheTestMode.ServerLocal, CacheTestMode.ServerRemote, CacheTestMode.Client)] CacheTestMode mode)
         {
             var cache = GetCache<int, Foo>(mode);
-            
+
             const int count = 100;
             var data = Enumerable.Range(1, count).ToDictionary(x=> x, x => new Foo(x));
-            
+
             cache.PutAll(data);
 
             // Filter will check that value does not come from native platform cache.
@@ -594,7 +594,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             {
                 CacheName = cache.Name
             };
-            
+
             // Clear platform cache using internal API.
             foreach (var ignite in Ignition.GetAll())
             {
@@ -605,14 +605,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     platformCache.Clear();
                 }
             }
-            
+
             var res = cache.Query(new ScanQuery<int, Foo>(filter));
-            
+
             Assert.AreEqual(count, res.Count());
         }
 
         /// <summary>
-        /// Tests that local scan query uses platform cache directly, avoiding Java roundtrip. 
+        /// Tests that local scan query uses platform cache directly, avoiding Java roundtrip.
         /// </summary>
         [Test]
         public void TestLocalScanQueryUsesKeysAndValuesFromPlatformCache([Values(true, false)] bool withFilter,
@@ -624,23 +624,23 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var qry = new ScanQuery<int, Foo>
             {
                 Local = true,
-                Filter = withFilter 
+                Filter = withFilter
                     ? new ScanQueryPlatformCacheFilter
                     {
                         CacheName = cache.Name
                     }
                     : null,
-                Partition = withPartition 
-                    ? _grid.GetAffinity(cache.Name).GetPartition(TestUtils.GetPrimaryKey(_grid, cache.Name)) 
+                Partition = withPartition
+                    ? _grid.GetAffinity(cache.Name).GetPartition(TestUtils.GetPrimaryKey(_grid, cache.Name))
                     : (int?) null
             };
-            
+
             var res = cache.Query(qry);
 
             foreach (var entry in res)
             {
                 var localValue = cache.LocalPeek(entry.Key, CachePeekMode.Platform);
-                
+
                 if (withPartition)
                 {
                     // Local scan with partition works directly through platform cache.
@@ -660,18 +660,18 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         }
 
         /// <summary>
-        /// Tests that local scan query reserves the partition when <see cref="ScanQuery{TK,TV}.Partition"/> is set. 
+        /// Tests that local scan query reserves the partition when <see cref="ScanQuery{TK,TV}.Partition"/> is set.
         /// </summary>
         [Test]
         public void TestLocalScanQueryWithPartitionReservesPartitionAndReleasesItOnDispose()
         {
             var cache = GetCache<int, Foo>(CacheTestMode.ServerLocal);
-            
+
             var key = TestUtils.GetPrimaryKey(_grid, cache.Name);
             var part = _grid.GetAffinity(cache.Name).GetPartition(key);
 
             cache.PutAll(Enumerable.Range(1, 100).ToDictionary(x => x, x => new Foo(x)));
-            
+
             var qry = new ScanQuery<int, Foo>
             {
                 Local = true,
@@ -679,7 +679,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             };
 
             Func<bool> isReserved = () => TestUtils.IsPartitionReserved(_grid, cache.Name, part);
-            
+
             Assert.IsFalse(isReserved());
 
             // Full iteration.
@@ -690,20 +690,20 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 using (var enumerator = cursor.GetEnumerator())
                 {
                     Assert.IsTrue(isReserved());
-                    
+
                     while (enumerator.MoveNext())
                     {
                         Assert.IsTrue(isReserved());
                     }
-                    
+
                     Assert.IsFalse(isReserved());
                 }
-                
+
                 Assert.IsFalse(isReserved());
             }
-            
+
             Assert.IsFalse(isReserved());
-            
+
             // Partial iteration with LINQ.
             using (var cursor = cache.Query(qry))
             {
@@ -712,10 +712,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 var item = cursor.FirstOrDefault();
                 Assert.IsNotNull(item);
 
-                // Released because LINQ disposes the iterator. 
+                // Released because LINQ disposes the iterator.
                 Assert.IsFalse(isReserved());
             }
-            
+
             // Partial iteration.
             using (var cursor = cache.Query(qry))
             {
@@ -726,9 +726,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
                 Assert.IsTrue(isReserved());
             }
-            
+
             Assert.IsFalse(isReserved());
-            
+
             // GetAll without using block.
             using (var cursor = cache.Query(qry))
             {
@@ -739,10 +739,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
                 Assert.IsFalse(isReserved());
             }
-            
+
             // Exception in filter.
             qry.Filter = new ScanQueryPlatformCacheFilter {FailKey = key};
-            
+
             using (var cursor = cache.Query(qry))
             {
                 Assert.IsTrue(isReserved());
@@ -761,9 +761,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         {
             var cache = GetCache<int, Foo>(CacheTestMode.ServerLocal);
             var qry = new ScanQuery<int, Foo> {Local = true, Partition = 1024};
-            
+
             var ex = Assert.Throws<IgniteException>(() => cache.Query(qry));
-            
+
             Assert.AreEqual("Invalid partition number: 1024", ex.Message);
         }
 
@@ -775,11 +775,11 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         public void TestLocalScanQueryWithPartitionThrowsOnRemoteKeys()
         {
             var cache = GetCache<int, Foo>(CacheTestMode.ServerLocal);
-            
+
             var partition = _grid2.GetAffinity(cache.Name)
                 .GetPrimaryPartitions(_grid2.GetCluster().GetLocalNode())
                 .First();
-            
+
             var qry = new ScanQuery<int, Foo>
             {
                 Local = true,
@@ -787,12 +787,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             };
 
             var ex = Assert.Throws<InvalidOperationException>(() => cache.Query(qry).GetAll());
-            
+
             Assert.AreEqual(
-                string.Format("Failed to reserve partition {0}, it does not belong to the local node.", partition), 
+                string.Format("Failed to reserve partition {0}, it does not belong to the local node.", partition),
                 ex.Message);
         }
-        
+
         /// <summary>
         /// Tests local scan query on client node.
         /// </summary>
@@ -804,10 +804,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             var clientCache = _client.CreateNearCache<int, Foo>(cache.Name, new NearCacheConfiguration(),
                 new PlatformCacheConfiguration());
-            
+
             // Promote key to near cache.
             clientCache.Get(2);
-            
+
             var res = clientCache.Query(new ScanQuery<int, Foo> {Local = true}).GetAll();
 
             // Local scan on client node returns empty collection.
@@ -825,9 +825,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         {
             var cache = GetCache<int, Foo>(mode)
                 .WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromSeconds(0.2), null, null));
-            
+
             cache[1] = new Foo(1);
-            
+
             Assert.AreEqual(1, cache[1].Bar);
             Assert.AreEqual(1, cache.LocalPeek(1, CachePeekMode.Platform).Bar);
             Assert.AreEqual(1, cache.Count());
@@ -852,14 +852,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     KeepBinary = true
                 }
             };
-            
+
             var clientCache = _client.CreateCache<int, Foo>(cfg);
             var serverCache = _grid2.GetCache<int, object>(cfg.Name);
             Assert.IsTrue(serverCache.GetConfiguration().PlatformCacheConfiguration.KeepBinary);
-            
+
             // Put non-binary from client. There is no platform cache on client.
             clientCache[1] = new Foo(2);
-            
+
             // Read from platform on server.
             var res = (IBinaryObject) serverCache.LocalPeek(1, CachePeekMode.Platform);
             Assert.AreEqual(2, res.GetField<int>("Bar"));
@@ -894,7 +894,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     remoteCache.Put(key, new Foo(id));
                 }
             });
-            
+
             var localReader = Task.Factory.StartNew(() =>
             {
                 // ReSharper disable once AccessToModifiedClosure
@@ -912,7 +912,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             // Get actual value with SQL to bypass caches.
             // Actual value may not be equal to the latest id because two threads compete in Put calls.
             var actualValue = (int) localCache.Query(new SqlFieldsQuery("select Bar from Foo")).GetAll()[0][0];
-            
+
             Assert.AreEqual(actualValue, localCache[key].Bar, "Local value");
             Assert.AreEqual(actualValue, remoteCache[key].Bar, "Remote value");
         }
@@ -931,8 +931,8 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             clientCache[1] = new Foo(1);
             serverCache[2] = new Foo(2);
 
-            var res = async 
-                ? clientCache.GetAllAsync(Enumerable.Range(1, 2)).Result 
+            var res = async
+                ? clientCache.GetAllAsync(Enumerable.Range(1, 2)).Result
                 : clientCache.GetAll(Enumerable.Range(1, 2));
 
             Assert.AreEqual(new[] {1, 2}, res.Select(x => x.Key));
@@ -958,20 +958,20 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             serverCache[2] = new Foo(2);
 
             Foo foo;
-            
+
             Assert.IsTrue(clientCache.TryLocalPeek(1, out foo, CachePeekMode.Platform));
             Assert.AreEqual(1, foo.Bar);
-            
+
             Assert.IsTrue(clientCache.TryLocalPeek(1, out foo, CachePeekMode.Platform | CachePeekMode.Near));
             Assert.AreEqual(1, foo.Bar);
-            
+
             Assert.IsFalse(clientCache.TryLocalPeek(2, out foo, CachePeekMode.Platform));
             Assert.IsFalse(clientCache.TryLocalPeek(2, out foo, CachePeekMode.Near));
             Assert.IsFalse(clientCache.TryLocalPeek(2, out foo, CachePeekMode.All));
-            
+
             Assert.AreEqual(2, serverCache.LocalPeek(2, CachePeekMode.Platform).Bar);
             Assert.AreEqual(2, serverCache.LocalPeek(2, CachePeekMode.Near).Bar);
-            
+
             Assert.AreSame(serverCache[2], serverCache.LocalPeek(2, CachePeekMode.Platform));
             Assert.AreNotSame(serverCache[2], serverCache.LocalPeek(2, CachePeekMode.Near));
         }
@@ -983,12 +983,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         {
             var cache = GetCache<int, int>(mode);
             var cache2 = GetCache<int, int>(CacheTestMode.ServerLocal);
-            
+
             var data = Enumerable.Range(1, 100).ToDictionary(x => x, x => x);
             cache2.PutAll(data);
 
             var act = async
-                ? (Func<int, bool>) (k => cache.ContainsKeyAsync(k).Result) 
+                ? (Func<int, bool>) (k => cache.ContainsKeyAsync(k).Result)
                 : k => cache.ContainsKey(k);
 
             foreach (var key in data.Keys)
@@ -1005,12 +1005,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         {
             var cache = GetCache<int, int>(mode);
             var cache2 = GetCache<int, int>(CacheTestMode.ServerLocal);
-            
+
             var data = Enumerable.Range(1, 100).ToDictionary(x => x, x => x);
             cache2.PutAll(data);
-            
+
             var act = async
-                ? (Func<IEnumerable<int>, bool>) (k => cache.ContainsKeysAsync(k).Result) 
+                ? (Func<IEnumerable<int>, bool>) (k => cache.ContainsKeysAsync(k).Result)
                 : k => cache.ContainsKeys(k);
 
             foreach (var key in data.Keys)
@@ -1018,13 +1018,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 Assert.IsTrue(act(new[] {key}));
                 Assert.IsFalse(act(new[] {-key}));
             }
-            
+
             Assert.IsTrue(act(data.Keys));
             Assert.IsTrue(act(data.Keys.Take(10)));
             Assert.IsTrue(act(data.Keys.Skip(10)));
             Assert.IsFalse(act(data.Keys.Concat(new[] {-1})));
         }
-        
+
         /// <summary>
         /// Tests local size on server node.
         /// </summary>
@@ -1056,7 +1056,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var cache = GetCache<int, int>(CacheTestMode.Client, TestUtils.TestName);
             Assert.AreEqual(0, cache.GetLocalSize(CachePeekMode.Platform));
             Assert.AreEqual(0, cache.GetLocalSize(CachePeekMode.All));
-            
+
             cache.PutAll(Enumerable.Range(1, 100).ToDictionary(x => x, x => x));
 
             Assert.AreEqual(0, cache.GetLocalSize());
@@ -1074,14 +1074,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         /// Tests that <see cref="CachePeekMode.Platform"/> works with distributed GetSize overloads.
         /// </summary>
         [Test]
-        public void TestGetSizeWithPlatform([Values(true, false)] bool longMode, 
+        public void TestGetSizeWithPlatform([Values(true, false)] bool longMode,
             [Values(true, false)] bool async)
         {
             var cache = GetCache<int, int>(CacheTestMode.Client, TestUtils.TestName);
             var primaryAndPlatform = new[] {CachePeekMode.Primary, CachePeekMode.Platform};
             var platform = new[] {CachePeekMode.Platform};
             var all = new[] {CachePeekMode.All};
-            
+
             var func =
                 longMode
                     ? async
@@ -1089,7 +1089,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                         : m => cache.GetSizeLong(m)
                     : async
                         ? (Func<CachePeekMode[], long>) (m => cache.GetSizeAsync(m).Result)
-                        : m => cache.GetSize(m); 
+                        : m => cache.GetSize(m);
 
             Assert.AreEqual(0, func(all));
             Assert.AreEqual(0, func(platform));
@@ -1131,7 +1131,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             Assert.AreEqual(1, func(part, platform));
             Assert.AreEqual(2, func(part, primaryAndPlatform));
             Assert.AreEqual(2, func(part, all));
-            
+
             Assert.AreEqual(0, func(part + 1, platform));
             Assert.AreEqual(0, func(part + 1, primaryAndPlatform));
             Assert.AreEqual(0, func(part + 1, all));
@@ -1153,14 +1153,14 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             cache.PutAll(keys.ToDictionary(x => x, x => new Foo(x)));
 
             var localEntries = cache.GetLocalEntries(CachePeekMode.Platform).ToArray();
-            
+
             // Same set of keys.
             CollectionAssert.AreEquivalent(keys, localEntries.Select(e => e.Key));
-            
+
             // Returns same instances every time.
             CollectionAssert.AreEqual(localEntries.Select(e => e.Value),
                 cache.GetLocalEntries(CachePeekMode.Platform).Select(e => e.Value));
-            
+
             // Every instance is from platform cache.
             foreach (var entry in localEntries)
             {
@@ -1186,7 +1186,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var platform = getKeys(CachePeekMode.Platform);
             var all = getKeys(CachePeekMode.All);
             var all2 = getKeys(CachePeekMode.Primary | CachePeekMode.Near | CachePeekMode.Platform);
-            
+
             CollectionAssert.AreEqual(all, all2);
             CollectionAssert.AreEquivalent(all, platform.Concat(primary).Concat(near));
             CollectionAssert.AreEquivalent(platform, primary.Concat(near));
@@ -1211,10 +1211,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             const int count = 100;
             cache1.PutAll(Enumerable.Range(1, count).ToDictionary(x => x, x => x));
-            
+
             Assert.AreEqual(count, cache1.GetLocalSize(CachePeekMode.Platform));
             Assert.AreEqual(count, cache2.GetLocalSize(CachePeekMode.Platform));
-            
+
             Assert.AreEqual(42, cache1.LocalPeek(42, CachePeekMode.Platform));
             Assert.AreEqual(42, cache2.LocalPeek(42, CachePeekMode.Platform));
 
@@ -1241,10 +1241,10 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             const int count = 100;
             cache1.PutAll(Enumerable.Range(1, count).ToDictionary(x => x, x => x));
-            
+
             Assert.AreEqual(count, cache1.GetLocalSize(CachePeekMode.Platform));
             Assert.AreEqual(count, cache2.GetLocalSize(CachePeekMode.Platform));
-            
+
             Assert.AreEqual(42, cache1.LocalPeek(42, CachePeekMode.Platform));
             Assert.AreEqual(42, cache2.LocalPeek(42, CachePeekMode.Platform));
 
@@ -1270,7 +1270,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             cache[1] = new Foo(2);
             var foo = cache[1];
-            
+
             Assert.AreEqual(2, foo.Bar);
             Assert.AreSame(foo, cache[1]);
 
@@ -1278,7 +1278,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             {
                 Assert.AreNotSame(foo, cache[1]);
             }
-            
+
             Assert.AreSame(foo, cache[1]);
 
             using (new TransactionScope())
@@ -1286,9 +1286,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 cache[2] = new Foo(3);
                 Assert.AreNotSame(foo, cache[1]);
             }
-            
+
             Assert.AreSame(foo, cache[1]);
-        } 
+        }
 
         /// <summary>
         /// Tests platform cache misconfiguration / type mismatch.
@@ -1304,7 +1304,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     ValueTypeName = typeof(Guid).FullName
                 }
             };
-            
+
             var nearCfg = new NearCacheConfiguration();
 
             var clientCache = _client.CreateCache<int, Foo>(cfg, nearCfg);
@@ -1312,7 +1312,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
             // Put Foo, but platform cache expects Guid.
             clientCache.GetAndPut(1, new Foo(2));
-            
+
             // Entry is not in platform cache.
             Assert.AreEqual(0, clientCache.GetLocalSize(CachePeekMode.Platform));
 
@@ -1321,7 +1321,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             Assert.AreEqual(2, clientCache[1].Bar);
 
             // Error is logged.
-            Func<ListLogger.Entry> getEntry = () => 
+            Func<ListLogger.Entry> getEntry = () =>
                 _logger.Entries.FirstOrDefault(e => e.Message.StartsWith("Failure in Java callback"));
 
             var message = string.Join(" | ", _logger.Entries.Select(e => e.Message));
@@ -1330,7 +1330,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
 
         /// <summary>
         /// <see cref="ICache{TK,TV}.LoadCache"/> uses same filter mechanism as <see cref="ScanQuery{TK,TV}"/>.
-        /// Platform cache should never be used for cache store load filters.  
+        /// Platform cache should never be used for cache store load filters.
         /// </summary>
         [Test]
         public void TestCacheStoreLoadFilterDoesNotUseNearCache()
@@ -1348,9 +1348,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             // Put a value to be overwritten from store.
             var foo = FailingCacheStore.Foo;
             var key = foo.Bar;
-            
+
             cache[key] = new Foo(1);
-            
+
             // Filter asserts that values do not come from platform cache.
             var filter = new StoreNoPlatformCacheFilter
             {
@@ -1368,7 +1368,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         {
             const int serverMaxSize = 4;
             const int clientMaxSize = serverMaxSize * 3;
-            
+
             var serverCfg = new CacheConfiguration
             {
                 Name = TestUtils.TestName,
@@ -1380,7 +1380,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     }
                 }
             };
-            
+
             var clientCfg = new NearCacheConfiguration
             {
                 EvictionPolicy = new FifoEvictionPolicy
@@ -1388,23 +1388,23 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     MaxSize = clientMaxSize
                 }
             };
-            
+
             var platformCfg = new PlatformCacheConfiguration();
 
             var serverCache = _grid.CreateCache<int, int>(serverCfg);
             var clientCache = _client.CreateNearCache<int, int>(serverCache.Name, clientCfg, platformCfg);
 
             var keys = Enumerable.Range(1, 100).ToList();
-            
+
             keys.ForEach(k => clientCache.Put(k, k));
-            
+
             Assert.AreEqual(clientMaxSize, clientCache.GetLocalSize(CachePeekMode.Near));
             Assert.AreEqual(clientMaxSize, clientCache.GetLocalSize(CachePeekMode.Platform));
 
             var expectedKeys = keys.AsEnumerable().Reverse().Take(clientMaxSize).ToArray();
-            var nearKeys = 
+            var nearKeys =
                 clientCache.GetLocalEntries(CachePeekMode.Platform).Select(e => e.Key).ToArray();
-            
+
             CollectionAssert.AreEquivalent(expectedKeys, nearKeys);
         }
 
@@ -1415,7 +1415,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         public void TestDataStreamerUpdatesPlatformCache()
         {
             const int entryCount = 10000;
-            
+
             var serverCfg = new CacheConfiguration
             {
                 Name = TestUtils.TestName,
@@ -1428,7 +1428,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 },
                 PlatformCacheConfiguration = new PlatformCacheConfiguration()
             };
-            
+
             var clientCfg = new NearCacheConfiguration
             {
                 EvictionPolicy = new LruEvictionPolicy
@@ -1436,9 +1436,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                     MaxSize = entryCount
                 }
             };
-            
+
             var platformCfg = new PlatformCacheConfiguration();
-            
+
             var serverCache = _grid.CreateCache<int, int>(serverCfg);
             var clientCache = _client.CreateNearCache<int, int>(serverCache.Name, clientCfg, platformCfg);
 
@@ -1448,7 +1448,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             // Get data on client.
             var res = clientCache.GetAll(data.Keys);
             Assert.AreEqual(entryCount, res.Count);
-            
+
             // Check that all entries are in platform cache on client.
             Assert.AreEqual(entryCount, clientCache.GetLocalSize(CachePeekMode.Near));
             Assert.AreEqual(entryCount, clientCache.GetLocalSize(CachePeekMode.Platform));
@@ -1457,23 +1457,23 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             using (var streamer = _grid2.GetDataStreamer<int, int>(serverCache.Name))
             {
                 streamer.AllowOverwrite = true;
-                
+
                 foreach (var entry in data)
                 {
                     streamer.AddData(entry.Key, entry.Value + 1);
                 }
             }
-            
+
             // Verify that platform cache contains updated entries.
             foreach (var entry in data)
             {
                 var key = entry.Key;
                 var val = entry.Value + 1;
 
-                TestUtils.WaitForTrueCondition(() => val == clientCache.LocalPeek(key, CachePeekMode.Platform), 
+                TestUtils.WaitForTrueCondition(() => val == clientCache.LocalPeek(key, CachePeekMode.Platform),
                     message: string.Format("{0} = {1}", key, val));
-                
-                TestUtils.WaitForTrueCondition(() => val == serverCache.LocalPeek(key, CachePeekMode.Platform), 
+
+                TestUtils.WaitForTrueCondition(() => val == serverCache.LocalPeek(key, CachePeekMode.Platform),
                     message: string.Format("{0} = {1}", key, val));
             }
         }
@@ -1486,7 +1486,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
             var nearConfiguration = _grid.GetCache<TK, TV>(CacheName).GetConfiguration().NearConfiguration;
             var cacheConfiguration = new CacheConfiguration
             {
-                NearConfiguration = nearConfiguration, 
+                NearConfiguration = nearConfiguration,
                 Name = name,
                 PlatformCacheConfiguration = new PlatformCacheConfiguration()
             };
@@ -1503,7 +1503,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
         }
 
         /// <summary>
-        /// Tests that eviction policy removes platform cache data for the key. 
+        /// Tests that eviction policy removes platform cache data for the key.
         /// </summary>
         private void TestEvictionPolicyRemovesPlatformCacheValue(CacheTestMode mode, ICache<int, Foo> cache)
         {
@@ -1521,7 +1521,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Platform
                 cache[item.Bar] = item;
                 cachedItems.Add(cache[item.Bar]);
             }
-            
+
             // Recent items are in platform cache:
             Assert.AreEqual(NearCacheMaxSize, cache.GetLocalSize(CachePeekMode.Platform));
             foreach (var item in cachedItems.Skip(items.Length - NearCacheMaxSize))

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -17,10 +17,12 @@
 namespace Apache.Ignite.Core.Tests.Client
 {
     using System;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Sockets;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Configuration;
@@ -30,6 +32,7 @@ namespace Apache.Ignite.Core.Tests.Client
     using Apache.Ignite.Core.Configuration;
     using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
     using NUnit.Framework;
 
     /// <summary>
@@ -238,7 +241,7 @@ namespace Apache.Ignite.Core.Tests.Client
                 {
                     Assert.AreEqual("foo", client.GetCacheNames().Single());
                 }
-                
+
                 // Port range.
                 cfg = new IgniteClientConfiguration("127.0.0.1:10798..10800");
 
@@ -258,9 +261,9 @@ namespace Apache.Ignite.Core.Tests.Client
             var cfg = new IgniteClientConfiguration("127.0.0.1:10800..10700");
 
             var ex = Assert.Throws<IgniteClientException>(() => Ignition.StartClient(cfg));
-            
+
             Assert.AreEqual(
-                "Invalid format of IgniteClientConfiguration.Endpoint, port range is empty: 127.0.0.1:10800..10700", 
+                "Invalid format of IgniteClientConfiguration.Endpoint, port range is empty: 127.0.0.1:10800..10700",
                 ex.Message);
         }
 
@@ -589,6 +592,45 @@ namespace Apache.Ignite.Core.Tests.Client
                 Assert.IsNotNull(GetSocketException(Assert.Catch(() => client.GetCacheNames())));
                 Assert.IsNotNull(GetSocketException(Assert.Catch(() => client.GetCacheNames())));
             }
+        }
+
+        /// <summary>
+        /// Tests that client stops it's receiver thread upon disposal.
+        /// </summary>
+        [Test]
+        public void TestClientDisposalStopsReceiverThread([Values(true, false)] bool async)
+        {
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            var logger = new ListLogger {EnabledLevels = new[] {LogLevel.Trace}};
+
+            var cfg = new IgniteClientConfiguration(GetClientConfiguration())
+            {
+                Logger = logger
+            };
+
+            using (var client = Ignition.StartClient(cfg))
+            {
+                var cache = client.GetOrCreateCache<int, int>("c");
+
+                if (async)
+                {
+                    cache.PutAsync(1, 1);
+                }
+                else
+                {
+                    cache.Put(1, 1);
+                }
+            }
+
+            var threadId = logger.Entries
+                .Select(e => Regex.Match(e.Message, "Receiver thread #([0-9]+) started."))
+                .Where(m => m.Success)
+                .Select(m => int.Parse(m.Groups[1].Value))
+                .First();
+
+            TestUtils.WaitForTrueCondition(() => logger.Entries.Any(
+                e => e.Message == string.Format("Receiver thread #{0} stopped.", threadId)));
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/ListDataReader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Process/ListDataReader.cs
@@ -31,6 +31,11 @@ namespace Apache.Ignite.Core.Tests.Process
         /** <inheritdoc /> */
         public void OnOutput(Process proc, string data, bool err)
         {
+            if (string.IsNullOrEmpty(data))
+            {
+                return;
+            }
+
             lock (_list)
             {
                 _list.Add(data);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/ClientStatusCode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/ClientStatusCode.cs
@@ -49,14 +49,24 @@ namespace Apache.Ignite.Core.Client
         CacheExists = 1001,
 
         /// <summary>
-        /// The too many cursors (see <see cref="ClientConnectorConfiguration.MaxOpenCursorsPerConnection"/>).
+        /// Too many cursors (see <see cref="ClientConnectorConfiguration.MaxOpenCursorsPerConnection"/>).
         /// </summary>
         TooManyCursors = 1010,
+
+        /// <summary>
+        /// Resource does not exist.
+        /// </summary>
+        ResourceDoesNotExist = 1011,
 
         /// <summary>
         /// Authorization failure.
         /// </summary>
         SecurityViolation = 1012,
+
+        /// <summary>
+        /// Too many compute tasks (see <see cref="ThinClientConfiguration.MaxActiveComputeTasksPerConnection"/>).
+        /// </summary>
+        TooManyComputeTasks = 1030,
 
         /// <summary>
         /// Authentication failed.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -171,7 +171,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         {
             IgniteArgumentCheck.NotNull(keys, "keys");
 
-            return DoOutInOp(ClientOp.CacheGetAll, ctx => ctx.Writer.WriteEnumerable(keys), 
+            return DoOutInOp(ClientOp.CacheGetAll, ctx => ctx.Writer.WriteEnumerable(keys),
                 s => ReadCacheEntries(s.Stream));
         }
 
@@ -180,7 +180,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         {
             IgniteArgumentCheck.NotNull(keys, "keys");
 
-            return DoOutInOpAsync(ClientOp.CacheGetAll, ctx => ctx.Writer.WriteEnumerable(keys), 
+            return DoOutInOpAsync(ClientOp.CacheGetAll, ctx => ctx.Writer.WriteEnumerable(keys),
                 s => ReadCacheEntries(s.Stream));
         }
 
@@ -226,7 +226,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         {
             IgniteArgumentCheck.NotNull(keys, "keys");
 
-            return DoOutInOp(ClientOp.CacheContainsKeys, ctx => ctx.Writer.WriteEnumerable(keys), 
+            return DoOutInOp(ClientOp.CacheContainsKeys, ctx => ctx.Writer.WriteEnumerable(keys),
                 ctx => ctx.Stream.ReadBool());
         }
 
@@ -235,7 +235,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         {
             IgniteArgumentCheck.NotNull(keys, "keys");
 
-            return DoOutInOpAsync(ClientOp.CacheContainsKeys, ctx => ctx.Writer.WriteEnumerable(keys), 
+            return DoOutInOpAsync(ClientOp.CacheContainsKeys, ctx => ctx.Writer.WriteEnumerable(keys),
                 ctx => ctx.Stream.ReadBool());
         }
 
@@ -248,7 +248,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             // For .NET it is a CacheEntryFilterHolder with a predefined id (BinaryTypeId.CacheEntryPredicateHolder).
             return DoOutInOp(ClientOp.QueryScan, w => WriteScanQuery(w.Writer, scanQuery),
                 ctx => new ClientQueryCursor<TK, TV>(
-                    _ignite, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QueryScanCursorGetPage));
+                    ctx.Socket, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QueryScanCursorGetPage));
         }
 
         /** <inheritDoc /> */
@@ -261,7 +261,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
 
             return DoOutInOp(ClientOp.QuerySql, w => WriteSqlQuery(w.Writer, sqlQuery),
                 ctx => new ClientQueryCursor<TK, TV>(
-                    _ignite, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QuerySqlCursorGetPage));
+                    ctx.Socket, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QuerySqlCursorGetPage));
         }
 
         /** <inheritDoc /> */
@@ -280,7 +280,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         {
             return DoOutInOp(ClientOp.QuerySqlFields,
                 ctx => WriteSqlFieldsQuery(ctx.Writer, sqlFieldsQuery, false),
-                ctx => GetFieldsCursorNoColumnNames(ctx.Stream, readerFunc));
+                ctx => GetFieldsCursorNoColumnNames(ctx, readerFunc));
         }
 
         /** <inheritDoc /> */
@@ -544,14 +544,14 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         /** <inheritDoc /> */
         public long GetSize(params CachePeekMode[] modes)
         {
-            return DoOutInOp(ClientOp.CacheGetSize, w => WritePeekModes(modes, w.Stream), 
+            return DoOutInOp(ClientOp.CacheGetSize, w => WritePeekModes(modes, w.Stream),
                 ctx => ctx.Stream.ReadLong());
         }
 
         /** <inheritDoc /> */
         public Task<long> GetSizeAsync(params CachePeekMode[] modes)
         {
-            return DoOutInOpAsync(ClientOp.CacheGetSize, w => WritePeekModes(modes, w.Stream), 
+            return DoOutInOpAsync(ClientOp.CacheGetSize, w => WritePeekModes(modes, w.Stream),
                 ctx => ctx.Stream.ReadLong());
         }
 
@@ -891,20 +891,20 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             var cursorId = ctx.Stream.ReadLong();
             var columnNames = ClientFieldsQueryCursor.ReadColumns(ctx.Reader);
 
-            return new ClientFieldsQueryCursor(_ignite, cursorId, _keepBinary, ctx.Stream,
+            return new ClientFieldsQueryCursor(ctx.Socket, cursorId, _keepBinary, ctx.Stream,
                 ClientOp.QuerySqlFieldsCursorGetPage, columnNames);
         }
 
         /// <summary>
         /// Gets the fields cursor.
         /// </summary>
-        private ClientQueryCursorBase<T> GetFieldsCursorNoColumnNames<T>(IBinaryStream stream,
+        private ClientQueryCursorBase<T> GetFieldsCursorNoColumnNames<T>(ClientResponseContext ctx,
             Func<IBinaryRawReader, int, T> readerFunc)
         {
-            var cursorId = stream.ReadLong();
-            var columnCount = stream.ReadInt();
+            var cursorId = ctx.Stream.ReadLong();
+            var columnCount = ctx.Stream.ReadInt();
 
-            return new ClientQueryCursorBase<T>(_ignite, cursorId, _keepBinary, stream,
+            return new ClientQueryCursorBase<T>(ctx.Socket, cursorId, _keepBinary, ctx.Stream,
                 ClientOp.QuerySqlFieldsCursorGetPage, r => readerFunc(r, columnCount));
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientFieldsQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientFieldsQueryCursor.cs
@@ -32,15 +32,15 @@ namespace Apache.Ignite.Core.Impl.Client.Cache.Query
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientQueryCursor{TK, TV}" /> class.
         /// </summary>
-        /// <param name="ignite">The ignite.</param>
+        /// <param name="socket">Connection that holds the cursor.</param>
         /// <param name="cursorId">The cursor identifier.</param>
         /// <param name="keepBinary">Keep binary flag.</param>
         /// <param name="initialBatchStream">Optional stream with initial batch.</param>
         /// <param name="getPageOp">The get page op.</param>
         /// <param name="columns">The columns.</param>
-        public ClientFieldsQueryCursor(IgniteClient ignite, long cursorId, bool keepBinary,
+        public ClientFieldsQueryCursor(ClientSocket socket, long cursorId, bool keepBinary,
             IBinaryStream initialBatchStream, ClientOp getPageOp, IList<string> columns)
-            : base(ignite, cursorId, keepBinary, initialBatchStream, getPageOp,
+            : base(socket, cursorId, keepBinary, initialBatchStream, getPageOp,
                 r =>
                 {
                     var res = new List<object>(columns.Count);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientQueryCursor.cs
@@ -29,14 +29,14 @@ namespace Apache.Ignite.Core.Impl.Client.Cache.Query
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientQueryCursor{TK, TV}" /> class.
         /// </summary>
-        /// <param name="ignite">The ignite.</param>
+        /// <param name="socket">Connection that holds the cursor.</param>
         /// <param name="cursorId">The cursor identifier.</param>
         /// <param name="keepBinary">Keep binary flag.</param>
         /// <param name="initialBatchStream">Optional stream with initial batch.</param>
         /// <param name="getPageOp">The get page op.</param>
-        public ClientQueryCursor(IgniteClient ignite, long cursorId, bool keepBinary,
+        public ClientQueryCursor(ClientSocket socket, long cursorId, bool keepBinary,
             IBinaryStream initialBatchStream, ClientOp getPageOp)
-            : base(ignite, cursorId, keepBinary, initialBatchStream, getPageOp,
+            : base(socket, cursorId, keepBinary, initialBatchStream, getPageOp,
                 r => new CacheEntry<TK, TV>(r.ReadObject<TK>(), r.ReadObject<TV>()))
         {
             // No-op.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -335,6 +335,8 @@ namespace Apache.Ignite.Core.Impl.Client
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private void WaitForMessages()
         {
+            _logger.Trace("Receiver thread #{0} started.", Thread.CurrentThread.ManagedThreadId);
+
             try
             {
                 // Null exception means active socket.
@@ -376,6 +378,10 @@ namespace Apache.Ignite.Core.Impl.Client
                 // Note that this does not include request decoding exceptions (failed request, invalid data, etc).
                 _exception = ex;
                 Dispose();
+            }
+            finally
+            {
+                _logger.Trace("Receiver thread #{0} stopped.", Thread.CurrentThread.ManagedThreadId);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Compute/ComputeClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Compute/ComputeClient.cs
@@ -34,8 +34,8 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
         private readonly IgniteClient _ignite;
 
         /** */
-        private readonly ComputeClientFlags _flags; 
-        
+        private readonly ComputeClientFlags _flags;
+
         /** */
         private readonly TimeSpan _timeout;
 
@@ -46,8 +46,8 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
         /// Initializes a new instance of <see cref="ComputeClient"/>.
         /// </summary>
         internal ComputeClient(
-            IgniteClient ignite, 
-            ComputeClientFlags flags, 
+            IgniteClient ignite,
+            ComputeClientFlags flags,
             TimeSpan? timeout,
             IClientClusterGroup clusterGroup)
         {
@@ -72,20 +72,20 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
         }
 
         /** <inheritdoc /> */
-        public Task<TRes> ExecuteJavaTaskAsync<TRes>(string taskName, object taskArg, 
+        public Task<TRes> ExecuteJavaTaskAsync<TRes>(string taskName, object taskArg,
             CancellationToken cancellationToken)
         {
             IgniteArgumentCheck.NotNullOrEmpty(taskName, "taskName");
-            
+
             var tcs = new TaskCompletionSource<TRes>();
-            cancellationToken.Register(() => tcs.SetCanceled());
+            cancellationToken.Register(() => tcs.TrySetCanceled());
 
             var keepBinary = (_flags & ComputeClientFlags.KeepBinary) == ComputeClientFlags.KeepBinary;
-            
+
             var task = _ignite.Socket.DoOutInOpAsync(
                 ClientOp.ComputeTaskExecute,
-                ctx => WriteJavaTaskRequest(taskName, taskArg, ctx),
-                ctx => ReadJavaTaskResponse(ctx, tcs, keepBinary));
+                ctx => WriteJavaTaskRequest(ctx, taskName, taskArg),
+                ctx => ReadJavaTaskResponse(ctx, tcs, cancellationToken, keepBinary));
 
             // ReSharper disable once AssignNullToNotNullAttribute (t.Exception won't be null).
             task.ContinueWith(t => tcs.TrySetException(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
@@ -97,8 +97,8 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
         /** <inheritdoc /> */
         public IComputeClient WithTimeout(TimeSpan timeout)
         {
-            return _timeout != timeout 
-                ? new ComputeClient(_ignite, _flags, timeout, _clusterGroup) 
+            return _timeout != timeout
+                ? new ComputeClient(_ignite, _flags, timeout, _clusterGroup)
                 : this;
         }
 
@@ -135,7 +135,7 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
         /// <summary>
         /// Writes the java task.
         /// </summary>
-        private void WriteJavaTaskRequest(string taskName, object taskArg, ClientRequestContext ctx)
+        private void WriteJavaTaskRequest(ClientRequestContext ctx, string taskName, object taskArg)
         {
             var writer = ctx.Writer;
 
@@ -158,18 +158,35 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
             writer.WriteLong((long) _timeout.TotalMilliseconds);
             writer.WriteString(taskName);
             writer.WriteObject(taskArg);
-            
+
             ctx.Socket.ExpectNotifications();
         }
-        
+
         /// <summary>
         /// Reads java task execution response.
         /// </summary>
         [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private static object ReadJavaTaskResponse<TRes>(ClientResponseContext ctx, TaskCompletionSource<TRes> tcs,
-            bool keepBinary)
+            CancellationToken cancellationToken, bool keepBinary)
         {
             var taskId = ctx.Stream.ReadLong();
+
+            cancellationToken.Register(() =>
+            {
+                ctx.Socket.DoOutInOpAsync<object>(ClientOp.ResourceClose,
+                    c => c.Stream.WriteLong(taskId),
+                    _ => null,
+                    (status, msg) =>
+                    {
+                        if (status == ClientStatusCode.ResourceDoesNotExist)
+                        {
+                            // Task finished before we could cancel it - ignore.
+                            return null;
+                        }
+
+                        throw new IgniteClientException(msg, null, status);
+                    });
+            });
 
             ctx.Socket.AddNotificationHandler(taskId, (stream, ex) =>
             {
@@ -181,7 +198,7 @@ namespace Apache.Ignite.Core.Impl.Client.Compute
 
                 ctx.Socket.RemoveNotificationHandler(taskId);
 
-                var reader = ctx.Marshaller.StartUnmarshal(stream, 
+                var reader = ctx.Marshaller.StartUnmarshal(stream,
                     keepBinary ? BinaryMode.ForceBinary : BinaryMode.Deserialize);
 
                 try

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/DelegateConverter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/DelegateConverter.cs
@@ -202,7 +202,7 @@ namespace Apache.Ignite.Core.Impl.Common
         /// Compiles a generic ctor with arbitrary number of arguments.
         /// </summary>
         /// <typeparam name="T">Result func type.</typeparam>
-        /// <param name="ctor">Contructor info.</param>
+        /// <param name="ctor">Constructor info.</param>
         /// <param name="argTypes">Argument types.</param>
         /// <param name="convertResultToObject">
         /// Flag that indicates whether ctor return value should be converted to object.</param>
@@ -247,7 +247,7 @@ namespace Apache.Ignite.Core.Impl.Common
         /// that takes an uninitialized object as a first arguments.
         /// </summary>
         /// <typeparam name="T">Result func type.</typeparam>
-        /// <param name="ctor">Contructor info.</param>
+        /// <param name="ctor">Constructor info.</param>
         /// <param name="argTypes">Argument types.</param>
         /// <returns>
         /// Compiled generic constructor.
@@ -307,7 +307,7 @@ namespace Apache.Ignite.Core.Impl.Common
         }
 
         /// <summary>
-        /// Compiles a contructor that reads all arguments from a binary reader.
+        /// Compiles a constructor that reads all arguments from a binary reader.
         /// </summary>
         /// <typeparam name="T">Result type</typeparam>
         /// <param name="ctor">The ctor.</param>


### PR DESCRIPTION
* Call `OP_RESOURCE_CLOSE` to cancel the task on the server
* Improve query cursors logic to make sure the same connection is used to retrieve batches and close the cursor