### PR TITLE
GG-30390 [IGNITE-13128] Fix NPE when IgniteLock is removed before use

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheLockImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheLockImpl.java
@@ -1160,6 +1160,9 @@ public final class GridCacheLockImpl extends AtomicDataStructureProxy<GridCacheL
         try {
             initializeReentrantLock();
 
+            if (sync == null)
+                throw new IgniteCheckedException("Failed to find reentrant lock with given name: " + name);
+
             sync.lock();
 
             sync.validate(false);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/IgniteLockAbstractSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/datastructures/IgniteLockAbstractSelfTest.java
@@ -56,7 +56,6 @@ import org.apache.ignite.resources.LoggerResource;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.transactions.Transaction;
 import org.jetbrains.annotations.Nullable;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -1568,6 +1567,25 @@ public abstract class IgniteLockAbstractSelfTest extends IgniteAtomicsAbstractTe
     }
 
     /**
+     * Tests that closed lock throws meaningful exception.
+     */
+    @Test (expected = IgniteException.class)
+    public void testClosedLockThrowsIgniteException() {
+        final String lockName = "lock";
+
+        IgniteLock lock1 = grid(0).reentrantLock(lockName, false, false, true);
+        IgniteLock lock2 = grid(0).reentrantLock(lockName, false, false, true);
+        lock1.close();
+        try {
+            lock2.lock();
+        } catch (IgniteException e) {
+            String msg = String.format("Failed to find reentrant lock with given name: " + lockName);
+            assertEquals(msg, e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
      * Tests if lock is evenly acquired among nodes when fair flag is set on.
      * Since exact ordering of lock acquisitions cannot be guaranteed because it also depends
      * on the OS thread scheduling, certain deviation from uniform distribution is tolerated.
@@ -1678,25 +1696,6 @@ public abstract class IgniteLockAbstractSelfTest extends IgniteAtomicsAbstractTe
         l.close();
 
         ignite.close();
-    }
-
-    /**
-     * Tests that closed lock throws meaningful exception.
-     */
-    @Test
-    @Ignore("https://issues.apache.org/jira/browse/IGNITE-13128")
-    public void testClosedLockThrowsIgniteException() {
-        final String lockName = "testRemovedLockThrowsIgniteException";
-
-        Ignite srv = ignite(0);
-
-        IgniteLock lock1 = srv.reentrantLock(lockName, false, false, true);
-        IgniteLock lock2 = srv.reentrantLock(lockName, false, false, true);
-
-        lock1.close();
-
-        //noinspection ThrowableNotThrown
-        GridTestUtils.assertThrows(log, lock2::lock, IgniteException.class, "TODO");
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
When 2 IgniteLock objects are created, and one used only after the other one was closed, there was a NullPointerException due to missing initialization check.