### PR TITLE
GG-30560 [IGNITE-13369] .NET: Clear cached node data on client disconnect

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ReconnectTest.cs
@@ -17,10 +17,13 @@
 namespace Apache.Ignite.Core.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cluster;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Lifecycle;
     using Apache.Ignite.Core.Tests.Client.Cache;
@@ -124,6 +127,9 @@ namespace Apache.Ignite.Core.Tests
 
             using (var ignite = Ignition.Start(cfg))
             {
+                var localNode = ignite.GetCluster().GetLocalNode();
+                var remoteNode = ignite.GetCluster().ForRemotes().GetNode();
+
                 var reconnected = 0;
                 var disconnected = 0;
                 ignite.ClientDisconnected += (sender, args) => { disconnected++; };
@@ -164,6 +170,13 @@ namespace Apache.Ignite.Core.Tests
 
                 Thread.Sleep(100);  // Wait for event handler
                 Assert.AreEqual(1, reconnected);
+                
+                var localNodeNew = ignite.GetCluster().GetLocalNode();
+                Assert.AreNotSame(localNode, localNodeNew);
+                Assert.AreNotEqual(localNode.Id, localNodeNew.Id);
+
+                var remoteNodeNew = ignite.GetCluster().ForRemotes().GetNode();
+                Assert.AreEqual(remoteNode.Id, remoteNodeNew.Id);
             }
         }
 #endif
@@ -189,6 +202,8 @@ namespace Apache.Ignite.Core.Tests
             var client = Ignition.Start(clientCfg);
 
             Assert.AreEqual(2, client.GetCluster().GetNodes().Count);
+            var localNode = client.GetCluster().GetLocalNode();
+            var nodes = client.GetCluster().GetNodes();
 
             var evt = new ManualResetEventSlim(false);
             client.ClientReconnected += (sender, args) => evt.Set();
@@ -220,6 +235,9 @@ namespace Apache.Ignite.Core.Tests
 
             var serverCache = server2.GetCache<int, Person>(CacheName);
             Assert.AreEqual(2, serverCache[2].Id);
+            
+            // Verify that cached node info is updated on the client.
+            CheckUpdatedNodes(client, localNode, nodes);
         }
 
         /// <summary>
@@ -235,6 +253,25 @@ namespace Apache.Ignite.Core.Tests
 #endif
 
             Ignition.ClientMode = false;
+        }
+        
+        /// <summary>
+        /// Checks that node info is up to date.
+        /// </summary>
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
+        private static void CheckUpdatedNodes(IIgnite client, IClusterNode localNode, ICollection<IClusterNode> nodes)
+        {
+            var localNodeNew = client.GetCluster().GetLocalNode();
+            Assert.AreNotSame(localNode, localNodeNew);
+            Assert.AreNotEqual(localNode.Id, localNodeNew.Id);
+
+            var nodesNew = client.GetCluster().GetNodes();
+            Assert.AreEqual(2, nodesNew.Count);
+
+            foreach (var node in nodesNew)
+            {
+                Assert.IsFalse(nodes.Any(n => n.Id == node.Id));
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cluster/ClusterGroupImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cluster/ClusterGroupImpl.cs
@@ -720,6 +720,15 @@ namespace Apache.Ignite.Core.Impl.Cluster
 #pragma warning restore 618
 
         /// <summary>
+        /// Clears cached node data.
+        /// </summary>
+        internal void ClearCachedNodeData()
+        {
+            _topVer = TopVerInit;
+            _nodes = null;
+        }
+
+        /// <summary>
         /// Creates new Cluster Group from given native projection.
         /// </summary>
         /// <param name="prj">Native projection.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -128,7 +128,7 @@ namespace Apache.Ignite.Core.Impl
         private readonly IList<LifecycleHandlerHolder> _lifecycleHandlers;
 
         /** Local node. */
-        private IClusterNode _locNode;
+        private volatile IClusterNode _locNode;
 
         /** Callbacks */
         private readonly UnmanagedCallbacks _cbs;
@@ -1155,6 +1155,12 @@ namespace Apache.Ignite.Core.Impl
         /// </summary>
         internal void OnClientDisconnected()
         {
+            // Clear cached node data.
+            // Do not clear _nodes - it is in sync with PlatformContextImpl.sentNodes.
+            _locNode = null;
+            _prj.ClearCachedNodeData();
+
+            // Raise events.
             _clientReconnectTaskCompletionSource = new TaskCompletionSource<bool>();
             
             var handler = ClientDisconnected;


### PR DESCRIPTION
Client reconnect causes local node ID to change, so cached local node info should be cleared on disconnect