### PR TITLE
GG-30894 [IGNITE-13485] Java thin: increase test coverage for transactions and partition awareness

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/configuration/distributed/DistributedConfigurationProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/configuration/distributed/DistributedConfigurationProcessor.java
@@ -18,7 +18,6 @@ package org.apache.ignite.internal.processors.configuration.distributed;
 
 import java.io.Serializable;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -599,7 +599,6 @@ public class FunctionalTest extends GridCommonAbstractTest {
         );
     }
 
-
     /**
      * Test PESSIMISTIC REPEATABLE_READ tx holds lock and other tx should be timed out.
      */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractAffinityAwarenessTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractAffinityAwarenessTest.java
@@ -59,7 +59,7 @@ public abstract class ThinClientAbstractAffinityAwarenessTest extends GridCommon
     /** Partitioned with custom affinity cache name. */
     protected static final String PART_CUSTOM_AFFINITY_CACHE_NAME = "partitioned_custom_affinity_cache";
 
-    /** Name of a partitioned cache with 0 backups. */
+    /* Name of a partitioned cache with 0 backups. */
     protected static final String PART_CACHE_0_BACKUPS_NAME = "partitioned_0_backup_cache";
 
     /** Name of a partitioned cache with 1 backups. */
@@ -109,9 +109,9 @@ public abstract class ThinClientAbstractAffinityAwarenessTest extends GridCommon
                 new CacheKeyConfiguration(TestAnnotatedAffinityKey.class));
 
         CacheConfiguration ccfg3 = new CacheConfiguration()
-            .setName(PART_CACHE_0_BACKUPS_NAME)
-            .setCacheMode(CacheMode.PARTITIONED)
-            .setBackups(0);
+                .setName(PART_CACHE_0_BACKUPS_NAME)
+                .setCacheMode(CacheMode.PARTITIONED)
+                .setBackups(0);
 
         CacheConfiguration ccfg4 = new CacheConfiguration()
                 .setName(PART_CACHE_1_BACKUPS_NAME)

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractAffinityAwarenessTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractAffinityAwarenessTest.java
@@ -59,7 +59,7 @@ public abstract class ThinClientAbstractAffinityAwarenessTest extends GridCommon
     /** Partitioned with custom affinity cache name. */
     protected static final String PART_CUSTOM_AFFINITY_CACHE_NAME = "partitioned_custom_affinity_cache";
 
-    /* Name of a partitioned cache with 0 backups. */
+    /** Name of a partitioned cache with 0 backups. */
     protected static final String PART_CACHE_0_BACKUPS_NAME = "partitioned_0_backup_cache";
 
     /** Name of a partitioned cache with 1 backups. */
@@ -109,9 +109,9 @@ public abstract class ThinClientAbstractAffinityAwarenessTest extends GridCommon
                 new CacheKeyConfiguration(TestAnnotatedAffinityKey.class));
 
         CacheConfiguration ccfg3 = new CacheConfiguration()
-                .setName(PART_CACHE_0_BACKUPS_NAME)
-                .setCacheMode(CacheMode.PARTITIONED)
-                .setBackups(0);
+            .setName(PART_CACHE_0_BACKUPS_NAME)
+            .setCacheMode(CacheMode.PARTITIONED)
+            .setBackups(0);
 
         CacheConfiguration ccfg4 = new CacheConfiguration()
                 .setName(PART_CACHE_1_BACKUPS_NAME)


### PR DESCRIPTION
* Add partition awareness tests for partitioned caches with backups
* Add transactions tests for pessimistic and optimistic modes
* Fix `new Thread()` usage: assertion errors were ignored in some tests