### PR TITLE
GG-30910 [IGNITE-13462] .NET: Fix thin client socket shutdown

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformThinClientConnectionsTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformThinClientConnectionsTask.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformThinClientConnectionsTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformThinClientConnectionsTask.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobAdapter;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeTaskAdapter;
+import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.mxbean.ClientProcessorMXBean;
+import org.apache.ignite.testframework.junits.GridAbstractTest;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Task to get thin client connections.
+ */
+public class PlatformThinClientConnectionsTask extends ComputeTaskAdapter<Object, String[]> {
+    /** {@inheritDoc} */
+    @NotNull @Override public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid,
+        @Nullable Object arg) {
+        return Collections.singletonMap(new PlatformThinClientConnectionsJob((String) arg), F.first(subgrid));
+    }
+
+    /** {@inheritDoc} */
+    @Nullable @Override public String[] reduce(List<ComputeJobResult> results) {
+        return results.get(0).getData();
+    }
+
+    /**
+     * Job.
+     */
+    private static class PlatformThinClientConnectionsJob extends ComputeJobAdapter {
+        /** */
+        private final String igniteInstanceName;
+
+        /** */
+        public PlatformThinClientConnectionsJob(String igniteInstanceName) {
+            this.igniteInstanceName = igniteInstanceName;
+        }
+
+        /** {@inheritDoc} */
+        @Nullable @Override public String[] execute() {
+            ClientProcessorMXBean bean = GridAbstractTest.getMxBean(igniteInstanceName, "Clients",
+                    ClientListenerProcessor.class, ClientProcessorMXBean.class);
+
+            List<String> connections = bean.getConnections();
+
+            //noinspection ZeroLengthArrayAllocation
+            return connections.toArray(new String[0]);
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformThinClientConnectionsTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformThinClientConnectionsTask.java
@@ -29,7 +29,7 @@ import org.apache.ignite.compute.ComputeTaskAdapter;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.mxbean.ClientProcessorMXBean;
-import org.apache.ignite.testframework.junits.GridAbstractTest;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -62,8 +62,8 @@ public class PlatformThinClientConnectionsTask extends ComputeTaskAdapter<Object
 
         /** {@inheritDoc} */
         @Nullable @Override public String[] execute() {
-            ClientProcessorMXBean bean = GridAbstractTest.getMxBean(igniteInstanceName, "Clients",
-                    ClientListenerProcessor.class, ClientProcessorMXBean.class);
+            ClientProcessorMXBean bean = GridCommonAbstractTest.getMxBean(igniteInstanceName, "Clients",
+                    ClientListenerProcessor.class.getSimpleName(), ClientProcessorMXBean.class);
 
             List<String> connections = bean.getConnections();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -158,15 +158,33 @@ namespace Apache.Ignite.Core.Tests.Client
         [Test]
         public void TestMultipleClients()
         {
-            using (Ignition.Start(TestUtils.GetTestConfiguration()))
+            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
             {
-                var client1 = StartClient();
-                var client2 = StartClient();
-                var client3 = StartClient();
+                Assert.AreEqual(0, GetThinClientConnections(ignite).Length);
 
+                var client1 = StartClient();
+                var thinClientConnections = GetThinClientConnections(ignite);
+                Assert.AreEqual(1, thinClientConnections.Length);
+                StringAssert.Contains(
+                    "rmtAddr=" + client1.GetConnections().Single().LocalEndPoint,
+                    thinClientConnections.Single());
+
+                var client2 = StartClient();
+                Assert.AreEqual(2, GetThinClientConnections(ignite).Length);
+
+                var client3 = StartClient();
+                Assert.AreEqual(3, GetThinClientConnections(ignite).Length);
+
+                // ReSharper disable AccessToDisposedClosure
                 client1.Dispose();
+                TestUtils.WaitForTrueCondition(() => 2 == GetThinClientConnections(ignite).Length);
+
                 client2.Dispose();
+                TestUtils.WaitForTrueCondition(() => 1 == GetThinClientConnections(ignite).Length);
+
                 client3.Dispose();
+                TestUtils.WaitForTrueCondition(() => 0 == GetThinClientConnections(ignite).Length);
+                // ReSharper restore AccessToDisposedClosure
             }
         }
 
@@ -709,6 +727,17 @@ namespace Apache.Ignite.Core.Tests.Client
                 Password = "ignite",
                 SocketTimeout = TimeSpan.FromSeconds(10)
             };
+        }
+
+        /// <summary>
+        /// Gets thin client connections for the given server node.
+        /// </summary>
+        /// <param name="ignite">Ignite server instance.</param>
+        /// <returns>Active thin client connections.</returns>
+        private static string[] GetThinClientConnections(IIgnite ignite)
+        {
+            return ignite.GetCompute().ExecuteJavaTask<string[]>(
+                "org.apache.ignite.platform.PlatformThinClientConnectionsTask", ignite.Name);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
@@ -30,9 +30,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
     [TestFixture]
     public class ClientClusterGroupTests : ClientTestBase
     {
-        private static readonly string ExpectedErrorMessage =
-            "'name' argument should not be null or empty." + Environment.NewLine + "Parameter name: name";
-
         /// <summary>
         /// Test thin client cluster group returns the same nodes collection as thick one.
         /// </summary>
@@ -168,10 +165,8 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         [Test]
         public void TestClusterGroupForPredicateThrowsExceptionIfItNull()
         {
-            TestDelegate action = () => Client.GetCluster().ForPredicate(null);
-
-            var ex = Assert.Throws<ArgumentNullException>(action);
-            Assert.AreEqual("Value cannot be null." + Environment.NewLine + "Parameter name: p", ex.Message);
+            var ex = Assert.Throws<ArgumentNullException>(() => Client.GetCluster().ForPredicate(null));
+            Assert.AreEqual("p", ex.ParamName);
         }
 
         /// <summary>
@@ -217,10 +212,8 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         [Test]
         public void TestClusterGroupThrownExceptionForNullAttributeName()
         {
-            TestDelegate action = () => Client.GetCluster().ForAttribute(null, null);
-
-            var ex = Assert.Throws<ArgumentException>(action);
-            Assert.AreEqual(ExpectedErrorMessage, ex.Message);
+            var ex = Assert.Throws<ArgumentException>(() => Client.GetCluster().ForAttribute(null, null));
+            Assert.AreEqual("name", ex.ParamName);
         }
 
 
@@ -234,7 +227,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
             TestDelegate action = () => Client.GetCluster().ForAttribute(string.Empty, null);
 
             var ex = Assert.Throws<ArgumentException>(action);
-            Assert.AreEqual(ExpectedErrorMessage, ex.Message);
+            Assert.AreEqual("name", ex.ParamName);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compute/ComputeClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compute/ComputeClientTests.cs
@@ -410,7 +410,7 @@ namespace Apache.Ignite.Core.Tests.Client.Compute
         [Test]
         public void TestExecuteJavaTaskAsyncMultithreaded()
         {
-            var count = 10000;
+            var count = 5000;
             var compute = Client.GetCompute().WithKeepBinary();
             var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName);
             cache[1] = 1;
@@ -512,7 +512,7 @@ namespace Apache.Ignite.Core.Tests.Client.Compute
         {
             return new IgniteClientConfiguration(base.GetClientConfiguration())
             {
-                SocketTimeout = TimeSpan.FromSeconds(3),
+                SocketTimeout = TimeSpan.FromSeconds(5),
                 EnablePartitionAwareness = false
             };
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -875,7 +875,7 @@ namespace Apache.Ignite.Core.Impl.Client
         /// </summary>
         private static Stream GetSocketStream(Socket socket, IgniteClientConfiguration cfg, string host)
         {
-            var stream = new NetworkStream(socket)
+            var stream = new NetworkStream(socket, ownsSocket: true)
             {
                 WriteTimeout = (int) cfg.SocketTimeout.TotalMilliseconds
             };
@@ -998,8 +998,10 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 _exception = _exception ?? new ObjectDisposedException(typeof(ClientSocket).FullName);
                 EndRequestsWithError();
-                _stream.Dispose();
-                _socket.Dispose();
+                
+                // This will call Socket.Shutdown and Socket.Close.
+                _stream.Close();
+                
                 _listenerEvent.Set();
                 _listenerEvent.Dispose();
 


### PR DESCRIPTION
* `Socket.Shutdown` call was missing before `Socket.Dispose`. To simplify the logic, use `NetworkStream` with `ownsSocket` set to `true`, so the stream handles socket disposal for us.

* Fix argument validation tests (message has changed on .NET Core 3.x)

* Fix `TestExecuteJavaTaskAsyncMultithreaded` flakiness