### PR TITLE
GG-30987 .NET: Disable ClientServerCompatibilityTest on .NET Core

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#if !NETCOREAPP
 namespace Apache.Ignite.Core.Tests.Client.Compatibility
 {
     using System;
@@ -289,3 +290,4 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
         }
     }
 }
+#endif


### PR DESCRIPTION
ClientServerCompatibilityTest does not work on Linux - creates zombie processes.
This test is already disabled in Ignite, but was enabled in GG due to a mistake with #1335 merge.