### PR TITLE
GG-31209 [IGNITE-13592] .NET: Respect cgroup limits in DataRegionConfiguration.DefaultMaxSize

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -208,6 +208,7 @@
     <Compile Include="Client\Services\TestServiceGenericMethods.cs" />
     <Compile Include="Client\Services\TestServiceOverloads.cs" />
     <Compile Include="Common\IgniteProductVersionTests.cs" />
+    <Compile Include="Common\MemoryInfoTest.cs" />
     <Compile Include="Compute\ComputeApiTest.JavaTask.cs" />
     <Compile Include="Compute\ComputeWithExecutorTest.cs" />
     <Compile Include="Deployment\CacheGetFunc.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Common
+{
+    using Apache.Ignite.Core.Impl;
+    using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Impl.Unmanaged;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for <see cref="MemoryInfo"/>.
+    /// </summary>
+    public class MemoryInfoTest
+    {
+        /// <summary>
+        /// Tests that cgroup limit can be always determined on Linux.
+        /// </summary>
+        [Test]
+        public void TestMemoryInfoReturnsNonNullLimitOnLinux()
+        {
+            if (Os.IsWindows)
+            {
+                return;
+            }
+
+            Assert.IsNotNull(MemoryInfo.TotalPhysicalMemory);
+            Assert.Greater(MemoryInfo.TotalPhysicalMemory, 655360);
+
+            Assert.IsNotNull(MemoryInfo.MemoryLimit);
+            Assert.Greater(MemoryInfo.MemoryLimit, 655360);
+
+            Assert.IsNotNull(CGroup.MemoryLimitInBytes);
+            Assert.Greater(CGroup.MemoryLimitInBytes, 655360);
+
+            if (CGroup.MemoryLimitInBytes > MemoryInfo.TotalPhysicalMemory)
+            {
+                Assert.AreEqual(MemoryInfo.TotalPhysicalMemory, MemoryInfo.MemoryLimit,
+                    "When cgroup limit is not set, memory limit is equal to physical memory amount.");
+            }
+            else
+            {
+                Assert.AreEqual(CGroup.MemoryLimitInBytes, MemoryInfo.MemoryLimit,
+                    "When cgroup limit is set, memory limit is equal to cgroup limit.");
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -39,6 +39,7 @@ namespace Apache.Ignite.Core.Tests
     using Apache.Ignite.Core.Discovery.Tcp.Static;
     using Apache.Ignite.Core.Encryption.Keystore;
     using Apache.Ignite.Core.Events;
+    using Apache.Ignite.Core.Impl;
     using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.PersistentStore;
     using Apache.Ignite.Core.Tests.Plugin;
@@ -610,11 +611,24 @@ namespace Apache.Ignite.Core.Tests
             Assert.AreEqual(DataRegionConfiguration.DefaultEmptyPagesPoolSize, cfg.EmptyPagesPoolSize);
             Assert.AreEqual(DataRegionConfiguration.DefaultEvictionThreshold, cfg.EvictionThreshold);
             Assert.AreEqual(DataRegionConfiguration.DefaultInitialSize, cfg.InitialSize);
-            Assert.AreEqual(DataRegionConfiguration.DefaultMaxSize, cfg.MaxSize);
             Assert.AreEqual(DataRegionConfiguration.DefaultPersistenceEnabled, cfg.PersistenceEnabled);
             Assert.AreEqual(DataRegionConfiguration.DefaultMetricsRateTimeInterval, cfg.MetricsRateTimeInterval);
             Assert.AreEqual(DataRegionConfiguration.DefaultMetricsSubIntervalCount, cfg.MetricsSubIntervalCount);
             Assert.AreEqual(default(long), cfg.CheckpointPageBufferSize);
+
+            if (DataRegionConfiguration.DefaultMaxSize != cfg.MaxSize)
+            {
+                // Java respects cgroup limits only in recent JDK versions.
+                // We don't know which version is used for tests, so we should expect both variants
+                var physMem = MemoryInfo.TotalPhysicalMemory;
+                Assert.IsNotNull(physMem);
+
+                var expected = (long) physMem / 5;
+
+                Assert.AreEqual(expected, cfg.MaxSize,
+                    string.Format("Expected max size with cgroup limit: '{0}', without: '{1}'",
+                        DataRegionConfiguration.DefaultMaxSize, expected));
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgnitionStartTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgnitionStartTest.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.Core.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
     using Apache.Ignite.Core.Configuration;
@@ -114,7 +115,9 @@ namespace Apache.Ignite.Core.Tests
                         Name = "default"
                     }
                 };
-                AssertExtensions.ReflectionEqual(dsCfg, resCfg.DataStorageConfiguration);
+
+                AssertExtensions.ReflectionEqual(dsCfg, resCfg.DataStorageConfiguration,
+                    ignoredProperties: new HashSet<string> {"MaxSize"});
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -133,6 +133,7 @@
     <Compile Include="Impl\Client\Services\ServicesClient.cs" />
     <Compile Include="Impl\Client\SocketEndpoint.cs" />
     <Compile Include="Impl\Client\Transactions\ClientCacheTransactionManager.cs" />
+    <Compile Include="Impl\Common\Cgroup.cs" />
     <Compile Include="Impl\Common\PlatformType.cs" />
     <Compile Include="Impl\Client\Transactions\TransactionClient.cs" />
     <Compile Include="Impl\Client\Transactions\TransactionsClient.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/MemoryPolicyConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/MemoryPolicyConfiguration.cs
@@ -50,7 +50,7 @@ namespace Apache.Ignite.Core.Cache.Configuration
         /// The default maximum size, equals to 20% of total RAM.
         /// </summary>
         public static readonly long DefaultMaxSize =
-            (long) ((long) MemoryInfo.GetTotalPhysicalMemory(2048L * 1024 * 1024) * 0.2);
+            (long) ((long) (MemoryInfo.MemoryLimit ?? 2048L * 1024 * 1024) * 0.2);
 
         /// <summary>
         /// The default sub intervals.
@@ -186,13 +186,13 @@ namespace Apache.Ignite.Core.Cache.Configuration
         public TimeSpan RateTimeInterval { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of sub intervals to split <see cref="RateTimeInterval"/> into to calculate 
+        /// Gets or sets the number of sub intervals to split <see cref="RateTimeInterval"/> into to calculate
         /// <see cref="IMemoryMetrics.AllocationRate"/> and <see cref="IMemoryMetrics.EvictionRate"/>.
         /// <para />
         /// Bigger value results in more accurate metrics.
         /// </summary>
         [DefaultValue(DefaultSubIntervals)]
-        [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly", 
+        [SuppressMessage("Microsoft.Naming", "CA1702:CompoundWordsShouldBeCasedCorrectly",
             Justification = "Consistency with Java config")]
         public int SubIntervals { get; set; }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataRegionConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Configuration/DataRegionConfiguration.cs
@@ -26,7 +26,7 @@ namespace Apache.Ignite.Core.Configuration
 
     /// <summary>
     /// Defines custom data region configuration for Apache Ignite page memory
-    /// (see <see cref="DataStorageConfiguration"/>). 
+    /// (see <see cref="DataStorageConfiguration"/>).
     /// <para />
     /// For each configured data region Apache Ignite instantiates respective memory regions with different
     /// parameters like maximum size, eviction policy, swapping options, etc.
@@ -59,7 +59,7 @@ namespace Apache.Ignite.Core.Configuration
         /// The default maximum size, equals to 20% of total RAM.
         /// </summary>
         public static readonly long DefaultMaxSize =
-            (long)((long)MemoryInfo.GetTotalPhysicalMemory(2048L * 1024 * 1024) * 0.2);
+            (long)((long) (MemoryInfo.MemoryLimit ?? 2048L * 1024 * 1024) * 0.2);
 
         /// <summary>
         /// The default sub intervals.
@@ -170,7 +170,7 @@ namespace Apache.Ignite.Core.Configuration
 
         /// <summary>
         /// Gets or sets the page eviction mode. If <see cref="DataPageEvictionMode.Disabled"/> is used (default)
-        /// then an out of memory exception will be thrown if the memory region usage 
+        /// then an out of memory exception will be thrown if the memory region usage
         /// goes beyond <see cref="MaxSize"/>.
         /// </summary>
         public DataPageEvictionMode PageEvictionMode { get; set; }
@@ -211,7 +211,7 @@ namespace Apache.Ignite.Core.Configuration
         public TimeSpan MetricsRateTimeInterval { get; set; }
 
         /// <summary>
-        /// Gets or sets the number of sub intervals to split <see cref="MetricsRateTimeInterval"/> into to calculate 
+        /// Gets or sets the number of sub intervals to split <see cref="MetricsRateTimeInterval"/> into to calculate
         /// <see cref="IDataRegionMetrics.AllocationRate"/> and <see cref="IDataRegionMetrics.EvictionRate"/>.
         /// <para />
         /// Bigger value results in more accurate metrics.
@@ -227,7 +227,7 @@ namespace Apache.Ignite.Core.Configuration
         /// Default is <c>0</c>: Ignite will choose buffer size automatically.
         /// </summary>
         public long CheckpointPageBufferSize { get; set; }
-        
+
         /// <summary>
         /// Gets or sets the lazy memory allocation flag.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -91,9 +91,9 @@ namespace Apache.Ignite.Core.Impl.Common
                     return memLimit;
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                // Ignore
+                Console.Error.WriteLine("Failed to determine cgroup memory limit: " + e);
             }
 
             return null;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Common
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using Apache.Ignite.Core.Impl.Unmanaged;
+
+    /// <summary>
+    /// Reads cgroup limits for the current process.
+    /// <para />
+    /// Based on cgroup handling in CLR:
+    /// https://github.com/dotnet/runtime/blob/master/src/coreclr/src/gc/unix/cgroup.cpp
+    /// </summary>
+    internal static class CGroup
+    {
+        /// <summary>
+        /// Gets cgroup memory limit in bytes.
+        /// </summary>
+        public static readonly ulong? MemoryLimitInBytes = GetMemoryLimitInBytes();
+
+        /** */
+        private const string MemorySubsystem = "memory";
+
+        /** */
+        private const string MemoryLimitFileName = "memory.limit_in_bytes";
+
+        /** */
+        private const string ProcMountInfoFileName = "/proc/self/mountinfo";
+
+        /** */
+        private const string ProcCGroupFileName = "/proc/self/cgroup";
+
+        /// <summary>
+        /// Gets memory limit in bytes.
+        /// </summary>
+        private static ulong? GetMemoryLimitInBytes()
+        {
+            if (Os.IsWindows)
+            {
+                return null;
+            }
+
+            try
+            {
+                var memMount = FindHierarchyMount(MemorySubsystem);
+                if (memMount == null)
+                {
+                    return null;
+                }
+
+                var cgroupPathRelativeToMount = FindCGroupPath(MemorySubsystem);
+                if (cgroupPathRelativeToMount == null)
+                {
+                    return null;
+                }
+
+                var hierarchyMount = memMount.Value.Key;
+                var hierarchyRoot = memMount.Value.Value;
+
+                // Host CGroup: append the relative path
+                // In Docker: root and relative path are the same
+                var groupPath =
+                    string.Equals(hierarchyRoot, cgroupPathRelativeToMount, StringComparison.Ordinal)
+                        ? hierarchyMount
+                        : hierarchyMount + cgroupPathRelativeToMount;
+
+                var memLimitFilePath = Path.Combine(groupPath, MemoryLimitFileName);
+
+                var memLimitText = File.ReadAllText(memLimitFilePath);
+
+                ulong memLimit;
+                if (ulong.TryParse(memLimitText, out memLimit))
+                {
+                    return memLimit;
+                }
+            }
+            catch (Exception)
+            {
+                // Ignore
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Finds the hierarchy mount and root for the current process.
+        /// </summary>
+        private static KeyValuePair<string, string>? FindHierarchyMount(string subsystem)
+        {
+            foreach (var line in File.ReadAllLines(ProcMountInfoFileName))
+            {
+                var mount = GetHierarchyMount(line, subsystem);
+
+                if (mount != null)
+                {
+                    return mount;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Get the hierarchy mount and root.
+        /// </summary>
+        private static KeyValuePair<string, string>? GetHierarchyMount(string mountInfo, string subsystem)
+        {
+            // Example: 41 34 0:35 / /sys/fs/cgroup/memory rw,nosuid,nodev shared:17 - cgroup cgroup rw,memory
+            const string cGroup = " - cgroup ";
+
+            var cgroupIdx = mountInfo.IndexOf(cGroup, StringComparison.Ordinal);
+
+            if (cgroupIdx < 0)
+                return null;
+
+            var optionsIdx = mountInfo.LastIndexOf(" ", cgroupIdx + cGroup.Length, StringComparison.Ordinal);
+
+            if (optionsIdx < 0)
+                return null;
+
+            var memIdx = mountInfo.IndexOf(subsystem, optionsIdx + 1, StringComparison.Ordinal);
+
+            if (memIdx < 0)
+                return null;
+
+            var parts = mountInfo.Split(' ');
+
+            if (parts.Length < 5)
+                return null;
+
+            return new KeyValuePair<string, string>(parts[4], parts[3]);
+        }
+
+        /// <summary>
+        /// Finds the cgroup path for the current process.
+        /// </summary>
+        private static string FindCGroupPath(string subsystem)
+        {
+            var lines = File.ReadAllLines(ProcCGroupFileName);
+
+            foreach (var line in lines)
+            {
+                var parts = line.Split(new[] {':'}, 3);
+
+                if (parts.Length == 3 && parts[1].Split(',').Contains(subsystem, StringComparer.Ordinal))
+                {
+                    return parts[2];
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Core.Impl.Common
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Linq;
     using Apache.Ignite.Core.Impl.Unmanaged;
@@ -50,6 +51,7 @@ namespace Apache.Ignite.Core.Impl.Common
         /// <summary>
         /// Gets memory limit in bytes.
         /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private static ulong? GetMemoryLimitInBytes()
         {
             if (Os.IsWindows)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/MemoryInfo.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/MemoryInfo.cs
@@ -69,17 +69,18 @@ namespace Apache.Ignite.Core.Impl
         /// <summary>
         /// Gets total physical memory.
         /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]
         private static ulong? GetTotalPhysicalMemory()
         {
-            if (Os.IsWindows)
-            {
-                return NativeMethodsWindows.GlobalMemoryStatusExTotalPhys();
-            }
-
-            const string memInfo = "/proc/meminfo";
-
             try
             {
+                if (Os.IsWindows)
+                {
+                    return NativeMethodsWindows.GlobalMemoryStatusExTotalPhys();
+                }
+
+                const string memInfo = "/proc/meminfo";
+
                 var kbytes = File.ReadAllLines(memInfo).Select(x => Regex.Match(x, @"MemTotal:\s+([0-9]+) kB"))
                     .Where(x => x.Success)
                     .Select(x => x.Groups[1].Value).FirstOrDefault();
@@ -89,9 +90,9 @@ namespace Apache.Ignite.Core.Impl
                     return ulong.Parse(kbytes) * 1024;
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                // Ignore.
+                Console.Error.WriteLine("Failed to determine physical memory size: " + e);
             }
 
             return null;

--- a/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
+++ b/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
@@ -8,6 +8,7 @@
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertClosureToMethodGroup/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EXml_002ECodeStyle_002EFormatSettingsUpgrade_002EXmlMoveToCommonFormatterSettingsUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=cgroup/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=failover/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Multithreaded/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reentrancy/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
* Read cgroup limits to determine available memory for the current process
* Cache retrieved values in static fields
* Tweak `IgniteConfigurationTest.TestSpringXml` to account for the fact that older JDK versions ignore cgroup limits
* Skip `MaxSize` property check in `IgnitionStartTest.TestIgniteStartsFromSpringXml`