### PR TITLE
GG-31126 [IGNITE-13563] .NET: Fix deserializing IBinaryObject containing an IBinaryObject field

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySelfTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySelfTest.cs
@@ -1634,6 +1634,28 @@ namespace Apache.Ignite.Core.Tests.Binary
             Assert.AreEqual(GetCompactFooter(), _marsh.CompactFooter);
         }
 
+        /// <summary>
+        /// Tests serializing/deserializing objects with IBinaryObject fields.
+        /// </summary>
+        [Test]
+        public void TestBinaryField()
+        {
+            byte[] dataInner = _marsh.Marshal(new BinaryObjectWrapper());
+
+            IBinaryObject innerObject = _marsh.Unmarshal<IBinaryObject>(dataInner, BinaryMode.ForceBinary);
+            BinaryObjectWrapper inner = innerObject.Deserialize<BinaryObjectWrapper>();
+            
+            Assert.NotNull(inner);
+
+            byte[] dataOuter = _marsh.Marshal(new BinaryObjectWrapper() { Val = innerObject });
+
+            IBinaryObject outerObject = _marsh.Unmarshal<IBinaryObject>(dataOuter, BinaryMode.ForceBinary);
+            BinaryObjectWrapper outer = outerObject.Deserialize<BinaryObjectWrapper>();
+            
+            Assert.NotNull(outer);
+            Assert.IsTrue(outer.Val.Equals(innerObject));
+        }
+
         private static void CheckKeepSerialized(BinaryConfiguration cfg, bool expKeep)
         {
             if (cfg.TypeConfigurations == null)
@@ -2744,6 +2766,11 @@ namespace Apache.Ignite.Core.Tests.Binary
             public byte* ByteP { get; set; }
             public int* IntP { get; set; }
             public void* VoidP { get; set; }
+        }
+
+        private class BinaryObjectWrapper
+        {
+            public IBinaryObject Val;
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
@@ -123,7 +123,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /** <inheritdoc /> */
         public T Deserialize<T>()
         {
-            return Deserialize<T>(BinaryMode.Deserialize);
+            return Deserialize<T>(BinaryMode.KeepBinary);
         }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -899,9 +899,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             var desc = _marsh.GetDescriptor(type);
 
-            _stream.WriteByte(BinaryTypeId.Enum);
-            _stream.WriteInt(desc.TypeId);
-            _stream.WriteInt(val);
+            WriteEnum(val, desc.TypeId);
 
             var binaryTypeHolder = Marshaller.GetCachedBinaryTypeHolder(desc.TypeId);
             if (binaryTypeHolder == null || !binaryTypeHolder.IsSaved)
@@ -912,6 +910,18 @@ namespace Apache.Ignite.Core.Impl.Binary
                 
                 SaveMetadata(desc, binaryFields);
             }
+        }
+
+        /// <summary>
+        /// Write enum value.
+        /// </summary>
+        /// <param name="val">Enum value.</param>
+        /// <param name="typeId">Enum type id.</param>
+        private void WriteEnum(int val, int typeId)
+        {
+            _stream.WriteByte(BinaryTypeId.Enum);
+            _stream.WriteInt(typeId);
+            _stream.WriteInt(val);
         }
 
         /// <summary>
@@ -1383,6 +1393,16 @@ namespace Apache.Ignite.Core.Impl.Binary
                 {
                     if (!WriteHandle(_stream.Position, portObj))
                         _builder.ProcessBinary(_stream, portObj);
+
+                    return true;
+                }
+
+                // Special case for binary enum during build.
+                BinaryEnum binEnum = obj as BinaryEnum;
+
+                if (binEnum != null)
+                {
+                    WriteEnum(binEnum.EnumValue, binEnum.TypeId);
 
                     return true;
                 }


### PR DESCRIPTION
Change `BinaryObject.Deserialize<T>()` to use `BinaryMode.KeepBinary`:

`BinaryObject.Deserialize<T>()` uses `BinaryMode.Deserialize`. This, in turn, causes `BinaryReader.ReadBinaryObject()` to call `BinaryReader.Deserialize()` for the first `BinaryTypeId.Binary` object found (while switching to `BinaryMode.KeepBinary` for nested objects). Then, `BinaryReader.ReadFullObject()` gets called, and not knowing better, tries to deserialize the object of a nonexistent type.

Now, `BinaryMode.Deserialize` is also used by `CacheClient`. However, upon further investigation of the values passed to `Marshaller.Unmarshal`, `CacheClient` unmarshals values starting with `BinaryTypeId.Binary`, while `BinaryObject` unmarshals values starting directly with `BinaryUtils.HdrFull`; thus, `BinaryReader` functions correctly for caches but fails with binary objects.