### PR TITLE
GG-31610 [IGNITE-13608] .NET: Add Partitions and UpdateBatchSize to SqlFieldsQuery

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/SqlFieldsQuery.java
@@ -457,6 +457,8 @@ public class SqlFieldsQuery extends Query<List<?>> {
      * @return {@code this} for chaining.
      */
     public SqlFieldsQuery setUpdateBatchSize(int updateBatchSize) {
+        A.ensure(updateBatchSize >= 1, "updateBatchSize cannot be lower than 1");
+
         this.updateBatchSize = updateBatchSize;
 
         return this;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -528,6 +528,17 @@ final class ClientUtils {
             out.writeLong(Math.max(qry.getTimeout(), 0));
 
         out.writeBoolean(true); // include column names
+
+        if (qry.getPartitions() != null) {
+            out.writeInt(qry.getPartitions().length);
+
+            for (int part : qry.getPartitions())
+                out.writeInt(part);
+        }
+        else
+            out.writeInt(-1);
+
+        out.writeInt(qry.getUpdateBatchSize());
     }
 
     /** Write Ignite binary object to output stream. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -43,7 +43,10 @@ public enum ProtocolBitmaskFeature {
     SERVICE_INVOKE(5),
 
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
-    DEFAULT_QRY_TIMEOUT(6);
+    DEFAULT_QRY_TIMEOUT(6),
+
+    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
+    QRY_PARTITIONS_BATCH_SIZE(7);
 
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
@@ -354,7 +354,7 @@ public class PlatformCache extends PlatformAbstractTarget {
 
     /** */
     public static final int OP_SIZE_LONG_LOC = 92;
-    
+
     /** */
     public static final int OP_ENABLE_STATISTICS = 93;
 
@@ -1454,17 +1454,21 @@ public class PlatformCache extends PlatformAbstractTarget {
         boolean replicated = reader.readBoolean();
         boolean collocated = reader.readBoolean();
         String schema = reader.readString();
+        int[] partitions = reader.readIntArray();
+        int updateBatchSize = reader.readInt();
 
         SqlFieldsQuery qry = QueryUtils.withQueryTimeout(new SqlFieldsQuery(sql), timeout, TimeUnit.MILLISECONDS)
-            .setPageSize(pageSize)
-            .setArgs(args)
-            .setLocal(loc)
-            .setDistributedJoins(distrJoins)
-            .setEnforceJoinOrder(enforceJoinOrder)
-            .setLazy(lazy)
-            .setReplicatedOnly(replicated)
-            .setCollocated(collocated)
-            .setSchema(schema);
+                .setPageSize(pageSize)
+                .setArgs(args)
+                .setLocal(loc)
+                .setDistributedJoins(distrJoins)
+                .setEnforceJoinOrder(enforceJoinOrder)
+                .setLazy(lazy)
+                .setReplicatedOnly(replicated)
+                .setCollocated(collocated)
+                .setSchema(schema)
+                .setPartitions(partitions)
+                .setUpdateBatchSize(updateBatchSize);
 
         return qry;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -38,11 +38,14 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     /** Cluster groups. */
     CLUSTER_GROUPS(4),
 
-    /** Service invocation. */
+    /** Service invocation. This flag is not necessary and exists for legacy reasons. */
     SERVICE_INVOKE(5),
 
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
-    DEFAULT_QRY_TIMEOUT(6);
+    DEFAULT_QRY_TIMEOUT(6),
+
+    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
+    QRY_PARTITIONS_BATCH_SIZE(7);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheSqlFieldsQueryRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheSqlFieldsQueryRequest.java
@@ -47,6 +47,12 @@ public class ClientCacheSqlFieldsQueryRequest extends ClientCacheDataRequest imp
     /** Include field names flag. */
     private final boolean includeFieldNames;
 
+    /** Partitions. */
+    private final int[] partitions;
+
+    /** Update batch size. */
+    private final Integer updateBatchSize;
+
     /**
      * Ctor.
      *
@@ -94,10 +100,33 @@ public class ClientCacheSqlFieldsQueryRequest extends ClientCacheDataRequest imp
             QueryUtils.withQueryTimeout(qry, timeout, TimeUnit.MILLISECONDS);
 
         this.qry = qry;
+
+        if (protocolCtx.isFeatureSupported(ClientBitmaskFeature.QRY_PARTITIONS_BATCH_SIZE)) {
+            // Set qry values in process method so that validation errors are reported to the client.
+            int partCnt = reader.readInt();
+
+            if (partCnt >= 0) {
+                partitions = new int[partCnt];
+
+                for (int i = 0; i < partCnt; i++)
+                    partitions[i] = reader.readInt();
+            } else
+                partitions = null;
+
+            updateBatchSize = reader.readInt();
+        } else {
+            partitions = null;
+            updateBatchSize = null;
+        }
     }
 
     /** {@inheritDoc} */
     @Override public ClientResponse process(ClientConnectionContext ctx) {
+        qry.setPartitions(partitions);
+
+        if (updateBatchSize != null)
+            qry.setUpdateBatchSize(updateBatchSize);
+
         ctx.incrementCursors();
 
         try {

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -34,8 +34,6 @@ import java.util.UUID;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -628,14 +626,14 @@ public class FunctionalTest extends GridCommonAbstractTest {
             );
             cache.put(0, "value0");
 
-            Future<?> fut;
+            IgniteInternalFuture<?> fut;
 
             try (ClientTransaction tx = client.transactions().txStart(PESSIMISTIC, isolation)) {
                 assertEquals("value0", cache.get(0));
 
                 CyclicBarrier barrier = new CyclicBarrier(2);
 
-                fut = ForkJoinPool.commonPool().submit(() -> {
+                fut = GridTestUtils.runAsync(() -> {
                     try (ClientTransaction tx2 = client.transactions().txStart(OPTIMISTIC, REPEATABLE_READ, 500)) {
                         cache.put(0, "value2");
                         tx2.commit();
@@ -679,7 +677,7 @@ public class FunctionalTest extends GridCommonAbstractTest {
             try (ClientTransaction tx = client.transactions().txStart(OPTIMISTIC, SERIALIZABLE)) {
                 assertEquals("value0", cache.get(0));
 
-                Future<?> fut = ForkJoinPool.commonPool().submit(() -> {
+                IgniteInternalFuture<?> fut = GridTestUtils.runAsync(() -> {
                     try (ClientTransaction tx2 = client.transactions().txStart(OPTIMISTIC, REPEATABLE_READ)) {
                         cache.put(0, "value2");
                         tx2.commit();
@@ -724,15 +722,13 @@ public class FunctionalTest extends GridCommonAbstractTest {
 
                 cache.put(0, "value1");
 
-                Future<?> f = ForkJoinPool.commonPool().submit(() -> {
+                GridTestUtils.runAsync(() -> {
                     assertEquals("value0", cache.get(0));
 
                     cache.put(0, "value2");
 
                     assertEquals("value2", cache.get(0));
-                });
-
-                f.get();
+                }).get();
 
                 tx.commit();
             }
@@ -980,7 +976,7 @@ public class FunctionalTest extends GridCommonAbstractTest {
 
                 cache.put(0, "value18");
 
-                Future<?> fut = ForkJoinPool.commonPool().submit(() -> {
+                IgniteInternalFuture<?> fut = GridTestUtils.runAsync(() -> {
                     try (ClientTransaction tx1 = client.transactions().txStart(PESSIMISTIC, READ_COMMITTED)) {
                         cache.put(1, "value19");
 
@@ -1020,7 +1016,7 @@ public class FunctionalTest extends GridCommonAbstractTest {
             try (ClientTransaction tx = client.transactions().txStart(PESSIMISTIC, READ_COMMITTED)) {
                 cache.put(0, "value20");
 
-                ForkJoinPool.commonPool().submit(() -> {
+                GridTestUtils.runAsync(() -> {
                     // Implicit transaction started here.
                     cache.put(1, "value21");
 
@@ -1059,7 +1055,7 @@ public class FunctionalTest extends GridCommonAbstractTest {
                 // Start implicit transaction after explicit transaction has been closed by another thread.
                 cache.put(0, "value22");
 
-                ForkJoinPool.commonPool().submit(() -> assertEquals("value22", cache.get(0))).get();
+                GridTestUtils.runAsync(() -> assertEquals("value22", cache.get(0))).get();
 
                 // New explicit transaction can be started after current transaction has been closed by another thread.
                 try (ClientTransaction tx1 = client.transactions().txStart(PESSIMISTIC, READ_COMMITTED)) {
@@ -1110,7 +1106,7 @@ public class FunctionalTest extends GridCommonAbstractTest {
             // Test that implicit transaction started after commit of previous one without closing.
             cache.put(0, "value24");
 
-            ForkJoinPool.commonPool().submit(() -> assertEquals("value24", cache.get(0))).get();
+            GridTestUtils.runAsync(() -> assertEquals("value24", cache.get(0))).get();
         }
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -59,6 +59,7 @@ import org.apache.ignite.cache.PartitionLossPolicy;
 import org.apache.ignite.cache.QueryEntity;
 import org.apache.ignite.cache.QueryIndex;
 import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.client.thin.ClientServerError;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
 import org.apache.ignite.internal.processors.platform.cache.expiry.PlatformExpiryPolicy;

--- a/modules/indexing/src/test/java/org/apache/ignite/client/FunctionalQueryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/client/FunctionalQueryTest.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.client;
 
 import java.lang.invoke.SerializedLambda;
+import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -265,6 +266,32 @@ public class FunctionalQueryTest {
 
             assertEquals("Person 2", client.query(
                 new SqlFieldsQuery("SELECT name FROM PUBLIC.Person WHERE key = 2")).getAll().get(0).get(0));
+        }
+    }
+
+    /** Tests {@link SqlFieldsQuery} parameter validation. */
+    @Test
+    public void testSqlParameterValidation() throws Exception {
+        try (Ignite ignored = Ignition.start(Config.getServerConfiguration());
+             IgniteClient client = Ignition.startClient(new ClientConfiguration().setAddresses(Config.SERVER))
+        ) {
+            // Set fields with reflection to bypass client-side validation and verify server-side check.
+            SqlFieldsQuery qry = new SqlFieldsQuery("SELECT * FROM Person");
+
+            Field updateBatchSize = SqlFieldsQuery.class.getDeclaredField("updateBatchSize");
+            updateBatchSize.setAccessible(true);
+            updateBatchSize.setInt(qry, -1);
+
+            GridTestUtils.assertThrowsAnyCause(null, () -> client.query(qry).getAll(),
+                    ClientException.class, "updateBatchSize cannot be lower than 1");
+
+            Field parts = SqlFieldsQuery.class.getDeclaredField("parts");
+            parts.setAccessible(true);
+            parts.set(qry, new int[] {-1});
+            qry.setUpdateBatchSize(2);
+
+            GridTestUtils.assertThrowsAnyCause(null, () -> client.query(qry).getAll(),
+                    ClientException.class, "Illegal partition");
         }
     }
 

--- a/modules/platforms/cpp/core/include/ignite/cache/query/query_sql_fields.h
+++ b/modules/platforms/cpp/core/include/ignite/cache/query/query_sql_fields.h
@@ -382,6 +382,9 @@ namespace ignite
                         writer.WriteNull();
                     else
                         writer.WriteString(schema);
+
+                    writer.WriteInt32Array(NULL, 0); // Partitions
+                    writer.WriteInt32(1);                // UpdateBatchSize
                 }
 
             private:

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesTest.cs
@@ -69,7 +69,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 });
             }
         }
-        
+
         /// <summary>
         /// Gets the name mapper.
         /// </summary>
@@ -88,7 +88,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [SetUp]
         public void BeforeTest()
@@ -97,7 +97,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [TearDown]
         public void AfterTest()
@@ -126,7 +126,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <returns></returns>
         private static ICache<int, QueryPerson> Cache()
@@ -347,7 +347,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// Check SQL query.
         /// </summary>
         [Test]
-        public void TestSqlQuery([Values(true, false)] bool loc, [Values(true, false)] bool keepBinary, 
+        public void TestSqlQuery([Values(true, false)] bool loc, [Values(true, false)] bool keepBinary,
             [Values(true, false)] bool distrJoin)
         {
             var cache = Cache();
@@ -376,7 +376,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// Check SQL fields query.
         /// </summary>
         [Test]
-        public void TestSqlFieldsQuery([Values(true, false)] bool loc, [Values(true, false)] bool distrJoin, 
+        public void TestSqlFieldsQuery([Values(true, false)] bool loc, [Values(true, false)] bool distrJoin,
             [Values(true, false)] bool enforceJoinOrder, [Values(true, false)] bool lazy)
         {
             int cnt = MaxItemCnt;
@@ -608,7 +608,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             // Exception
             exp = PopulateCache(cache, loc, cnt, x => x < 50);
             qry = new ScanQuery<int, TV>(new ScanQueryFilter<TV> {ThrowErr = true});
-            
+
             var ex = Assert.Throws<IgniteException>(() => ValidateQueryResults(cache, qry, exp, keepBinary));
             Assert.AreEqual(ScanQueryFilter<TV>.ErrMessage, ex.Message);
         }
@@ -657,7 +657,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
                 ValidateQueryResults(cache, qry, exp0, keepBinary);
             }
-            
+
         }
 
         /// <summary>
@@ -790,7 +790,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             cache[1] = new QueryPerson("John", 33);
 
             row = cache.Query(new SqlFieldsQuery("select * from QueryPerson")).GetAll()[0];
-            
+
             Assert.AreEqual(3, row.Count);
             Assert.AreEqual(33, row[0]);
             Assert.AreEqual(1, row[1]);
@@ -860,7 +860,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             var names = cur.FieldNames;
 
             Assert.AreEqual(new[] {"AGE", "NAME" }, names);
-            
+
             cur.Dispose();
             Assert.AreSame(names, cur.FieldNames);
 
@@ -877,7 +877,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             qry.Sql = "SELECT 1, AGE FROM QueryPerson";
             cur = cache.Query(qry);
             cur.Dispose();
-            
+
             Assert.AreEqual(new[] { "1", "AGE" }, cur.FieldNames);
         }
 
@@ -930,6 +930,36 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 new[] {typeof(int), typeof(int)},
                 new[] {"java.lang.Integer", "java.lang.Integer"}
             );
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.Partitions"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestPartitionsValidation()
+        {
+            var cache = Cache();
+            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson") { Partitions = new int[0] };
+
+            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Partitions must not be empty.", ex.Message);
+
+            qry.Partitions = new[] {-1, -2};
+            ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Illegal partition", ex.Message);
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.UpdateBatchSize"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestUpdateBatchSizeValidation()
+        {
+            var cache = Cache();
+            var qry = new SqlFieldsQuery("SELECT * FROM QueryPerson") { UpdateBatchSize = -1 };
+
+            var ex = Assert.Throws<ArgumentException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("updateBatchSize cannot be lower than 1", ex.Message);
         }
 
         /// <summary>
@@ -1044,7 +1074,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
         /// <summary>
         /// Asserts that all expected entries have been received.
         /// </summary>
-        private static void AssertMissingExpectedKeys(ICollection<int> exp, ICache<int, QueryPerson> cache, 
+        private static void AssertMissingExpectedKeys(ICollection<int> exp, ICache<int, QueryPerson> cache,
             IList<ICacheEntry<int, object>> all)
         {
             if (exp.Count == 0)
@@ -1057,7 +1087,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             {
                 var part = aff.GetPartition(key);
                 sb.AppendFormat(
-                    "Query did not return expected key '{0}' (exists: {1}), partition '{2}', partition nodes: ", 
+                    "Query did not return expected key '{0}' (exists: {1}), partition '{2}', partition nodes: ",
                     key, cache.Get(key) != null, part);
 
                 var partNodes = aff.MapPartitionToPrimaryAndBackups(part);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Linq/CacheLinqTest.Introspection.cs
@@ -55,7 +55,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                 ReplicatedOnly = true,
 #pragma warning restore 618
                 Colocated = true,
-                Lazy = true
+                Lazy = true,
+                UpdateBatchSize = 12,
+                EnableDistributedJoins = true
             }).Where(x => x.Key > 10).ToCacheQueryable();
 
             Assert.AreEqual(cache.Name, query.CacheName);
@@ -75,7 +77,6 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             Assert.IsTrue(fq.Local);
             Assert.AreEqual(PersonCount - 11, cache.Query(fq).GetAll().Count);
             Assert.AreEqual(999, fq.PageSize);
-            Assert.IsFalse(fq.EnableDistributedJoins);
             Assert.IsTrue(fq.EnforceJoinOrder);
 #pragma warning disable 618
             Assert.IsTrue(fq.ReplicatedOnly);
@@ -83,22 +84,30 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             Assert.IsTrue(fq.Colocated);
             Assert.AreEqual(TimeSpan.FromSeconds(2.5), fq.Timeout);
             Assert.IsTrue(fq.Lazy);
+            Assert.IsTrue(fq.EnableDistributedJoins);
+            Assert.AreEqual(12, fq.UpdateBatchSize);
+            Assert.IsNull(fq.Partitions);
 
             var str = query.ToString();
             Assert.AreEqual(GetSqlEscapeAll()
                 ? "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0._KEY, _T0._VAL from PERSON_ORG_SCHEMA.\"Person\" as _T0 where " +
                   "(_T0.\"_KEY\" > ?), Arguments=[10], " +
-                  "Local=True, PageSize=999, EnableDistributedJoins=False, EnforceJoinOrder=True, " +
-                  "Timeout=00:00:02.5000000, ReplicatedOnly=True, Colocated=True, Schema=, Lazy=True]]"
+                  "Local=True, PageSize=999, EnableDistributedJoins=True, EnforceJoinOrder=True, " +
+                  "Timeout=00:00:02.5000000, Partitions=[], UpdateBatchSize=12, " +
+                  "Colocated=True, Schema=, Lazy=True]]"
                 : "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0._KEY, _T0._VAL from PERSON_ORG_SCHEMA.Person as _T0 where " +
                   "(_T0._KEY > ?), Arguments=[10], " +
-                  "Local=True, PageSize=999, EnableDistributedJoins=False, EnforceJoinOrder=True, " +
-                  "Timeout=00:00:02.5000000, ReplicatedOnly=True, Colocated=True, Schema=, Lazy=True]]", str);
+                  "Local=True, PageSize=999, EnableDistributedJoins=True, EnforceJoinOrder=True, " +
+                  "Timeout=00:00:02.5000000, Partitions=[], UpdateBatchSize=12, " +
+                  "Colocated=True, Schema=, Lazy=True]]", str);
 
             // Check fields query
-            var fieldsQuery = cache.AsCacheQueryable().Select(x => x.Value.Name).ToCacheQueryable();
+            var fieldsQuery = cache
+                .AsCacheQueryable(new QueryOptions {Partitions = new[] {1, 2}})
+                .Select(x => x.Value.Name)
+                .ToCacheQueryable();
 
             Assert.AreEqual(cache.Name, fieldsQuery.CacheName);
 #pragma warning disable 618 // Type or member is obsolete
@@ -116,17 +125,18 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
             Assert.IsFalse(fq.EnableDistributedJoins);
             Assert.IsFalse(fq.EnforceJoinOrder);
             Assert.IsFalse(fq.Lazy);
+            Assert.AreEqual(new[] {1, 2}, fq.Partitions);
 
             str = fieldsQuery.ToString();
             Assert.AreEqual(GetSqlEscapeAll()
                 ? "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0.\"Name\" from PERSON_ORG_SCHEMA.\"Person\" as _T0, Arguments=[], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=False, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]"
+                  "Timeout=00:00:00, Partitions=[1, 2], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]"
                 : "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0.NAME from PERSON_ORG_SCHEMA.Person as _T0, Arguments=[], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=False, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]", str);
+                  "Timeout=00:00:00, Partitions=[1, 2], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]", str);
 
             // Check distributed joins flag propagation
             var distrQuery = cache.AsCacheQueryable(new QueryOptions { EnableDistributedJoins = true })
@@ -143,13 +153,13 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Linq
                   "(((_T0.\"_KEY\" > ?) and (_T0.\"age1\" > ?)) " +
                   "and (_T0.\"Name\" like \'%\' || ? || \'%\') ), Arguments=[10, 20, x], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=True, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]"
+                  "Timeout=00:00:00, Partitions=[], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]"
                 : "CacheQueryable [CacheName=person_org, TableName=Person, Query=SqlFieldsQuery " +
                   "[Sql=select _T0._KEY, _T0._VAL from PERSON_ORG_SCHEMA.Person as _T0 where " +
                   "(((_T0._KEY > ?) and (_T0.AGE1 > ?)) " +
                   "and (_T0.NAME like \'%\' || ? || \'%\') ), Arguments=[10, 20, x], Local=False, " +
                   "PageSize=1024, EnableDistributedJoins=True, EnforceJoinOrder=False, " +
-                  "Timeout=00:00:00, ReplicatedOnly=False, Colocated=False, Schema=, Lazy=False]]", str);
+                  "Timeout=00:00:00, Partitions=[], UpdateBatchSize=1, Colocated=False, Schema=, Lazy=False]]", str);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
@@ -79,7 +79,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var qry = new SqlQuery(typeof(Person),
                 string.Format("from \"{0}\".Person, \"{1}\".Person as p2 where Person.Id = 11 - p2.Id",
                     CacheName, CacheName2));
-            
+
             Assert.Greater(Count, cache.Query(qry).Count());
 
             // Distributed join fixes the problem.
@@ -135,7 +135,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             // Non-distributed join returns incomplete results.
             var qry = new SqlFieldsQuery(string.Format(
-                "select p2.Name from \"{0}\".Person, \"{1}\".Person as p2 where Person.Id = 11 - p2.Id", 
+                "select p2.Name from \"{0}\".Person, \"{1}\".Person as p2 where Person.Id = 11 - p2.Id",
                 CacheName, CacheName2));
 
             Assert.Greater(Count, cache.Query(qry).Count());
@@ -226,6 +226,36 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             Assert.AreEqual(1, res[0][0]);
             Assert.AreEqual("baz", cache[-10].Name);
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.Partitions"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestPartitionsValidation()
+        {
+            var cache = GetClientCache<Person>();
+            var qry = new SqlFieldsQuery("SELECT * FROM Person") { Partitions = new int[0] };
+
+            var ex = Assert.Throws<IgniteClientException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Partitions must not be empty.", ex.Message);
+
+            qry.Partitions = new[] {-1, -2};
+            ex = Assert.Throws<IgniteClientException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("Illegal partition", ex.Message);
+        }
+
+        /// <summary>
+        /// Tests <see cref="SqlFieldsQuery.UpdateBatchSize"/> argument propagation and validation.
+        /// </summary>
+        [Test]
+        public void TestUpdateBatchSizeValidation()
+        {
+            var cache = GetClientCache<Person>();
+            var qry = new SqlFieldsQuery("SELECT * FROM Person") { UpdateBatchSize = -1 };
+
+            var ex = Assert.Throws<IgniteClientException>(() => cache.Query(qry).GetAll());
+            StringAssert.EndsWith("updateBatchSize cannot be lower than 1", ex.Message);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/SqlFieldsQuery.cs
@@ -31,6 +31,9 @@ namespace Apache.Ignite.Core.Cache.Query
         /// <summary> Default page size. </summary>
         public const int DefaultPageSize = 1024;
 
+        /// <summary> Default value for <see cref="UpdateBatchSize"/>. </summary>
+        public const int DefaultUpdateBatchSize = 1;
+
         /// <summary>
         /// Constructor.
         /// </summary>
@@ -54,6 +57,7 @@ namespace Apache.Ignite.Core.Cache.Query
             Arguments = args;
 
             PageSize = DefaultPageSize;
+            UpdateBatchSize = DefaultUpdateBatchSize;
         }
 
         /// <summary>
@@ -152,6 +156,21 @@ namespace Apache.Ignite.Core.Cache.Query
         public bool Lazy { get; set; }
 
         /// <summary>
+        /// Gets or sets partitions for the query.
+        /// <para />
+        /// The query will be executed only on nodes which are primary for specified partitions.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public int[] Partitions { get; set; }
+
+        /// <summary>
+        /// Gets or sets batch size for update queries.
+        /// <para />
+        /// Default is 1 (<see cref="DefaultUpdateBatchSize"/>.
+        /// </summary>
+        public int UpdateBatchSize { get; set; }
+
+        /// <summary>
         /// Returns a <see cref="string" /> that represents this instance.
         /// </summary>
         /// <returns>
@@ -159,15 +178,19 @@ namespace Apache.Ignite.Core.Cache.Query
         /// </returns>
         public override string ToString()
         {
-            var args = string.Join(", ", Arguments.Select(x => x == null ? "null" : x.ToString()));
+            var args = Arguments == null
+                ? ""
+                : string.Join(", ", Arguments.Select(x => x == null ? "null" : x.ToString()));
+
+            var parts = Partitions == null
+                ? ""
+                : string.Join(", ", Partitions.Select(x => x.ToString()));
 
             return string.Format("SqlFieldsQuery [Sql={0}, Arguments=[{1}], Local={2}, PageSize={3}, " +
-                                 "EnableDistributedJoins={4}, EnforceJoinOrder={5}, Timeout={6}, ReplicatedOnly={7}" +
-                                 ", Colocated={8}, Schema={9}, Lazy={10}]", Sql, args, Local,
-#pragma warning disable 618
-                                 PageSize, EnableDistributedJoins, EnforceJoinOrder, Timeout, ReplicatedOnly,
-#pragma warning restore 618
-                                 Colocated, Schema, Lazy);
+                                 "EnableDistributedJoins={4}, EnforceJoinOrder={5}, Timeout={6}, Partitions=[{7}], " +
+                                 "UpdateBatchSize={8}, Colocated={9}, Schema={10}, Lazy={11}]", Sql, args, Local,
+                                 PageSize, EnableDistributedJoins, EnforceJoinOrder, Timeout, parts,
+                                 UpdateBatchSize, Colocated, Schema, Lazy);
         }
 
         /** <inheritdoc /> */
@@ -196,6 +219,8 @@ namespace Apache.Ignite.Core.Cache.Query
 #pragma warning restore 618
             writer.WriteBoolean(Colocated);
             writer.WriteString(Schema); // Schema
+            writer.WriteIntArray(Partitions);
+            writer.WriteInt(UpdateBatchSize);
         }
 
         /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -113,6 +113,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             return GetComplexTypeHashCode(val, marsh, affinityKeyFieldIds);
         }
 
+        // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
         private static int GetComplexTypeHashCode<T>(T val, Marshaller marsh, IDictionary<int, int> affinityKeyFieldIds)
         {
             using (var stream = new BinaryHeapStream(128))

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -330,7 +330,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             IgniteArgumentCheck.NotNull(val, "val");
 
             _ignite.Transactions.StartTxIfNeeded();
-            
+
             return DoOutInOpAffinity(ClientOp.CacheGetAndReplace, key, val, UnmarshalCacheResult<TV>);
         }
 
@@ -950,6 +950,22 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             writer.WriteBoolean(qry.Lazy);
             writer.WriteTimeSpanAsLong(qry.Timeout);
             writer.WriteBoolean(includeColumns);
+
+            if (qry.Partitions != null)
+            {
+                writer.WriteInt(qry.Partitions.Length);
+
+                foreach (var part in qry.Partitions)
+                {
+                    writer.WriteInt(part);
+                }
+            }
+            else
+            {
+                writer.WriteInt(-1);
+            }
+
+            writer.WriteInt(qry.UpdateBatchSize);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Core.Impl.Client
 {
     /// <summary>
     /// Client feature ids. Values represent the index in the bit array.
+    /// Unsupported flags must be commented out.
     /// </summary>
     internal enum ClientBitmaskFeature
     {
@@ -25,6 +26,9 @@ namespace Apache.Ignite.Core.Impl.Client
         ExecuteTaskByName = 1,
         // ClusterStates = 2,
         ClusterGroupGetNodesEndpoints = 3,
-        ClusterGroups = 4
+        ClusterGroups = 4,
+        ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
+        // DefaultQueryTimeout = 6, // IGNITE-13692
+        QueryPartitionsBatchSize = 7
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;CODE_ANALYSIS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Impl/CacheFieldsQueryExecutor.cs
@@ -37,7 +37,7 @@ namespace Apache.Ignite.Linq.Impl
     {
         /** */
         private readonly ICacheInternal _cache;
-        
+
         /** */
         private readonly QueryOptions _options;
 
@@ -209,7 +209,9 @@ namespace Apache.Ignite.Linq.Impl
                 Colocated = _options.Colocated,
                 Local = _options.Local,
                 Arguments = args,
-                Lazy = _options.Lazy
+                Lazy = _options.Lazy,
+                UpdateBatchSize = _options.UpdateBatchSize,
+                Partitions = _options.Partitions
             };
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/QueryOptions.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Linq
 {
     using System;
     using System.ComponentModel;
+    using System.Diagnostics.CodeAnalysis;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Cache.Query;
 
@@ -29,16 +30,20 @@ namespace Apache.Ignite.Linq
         /// <summary> Default page size. </summary>
         public const int DefaultPageSize = SqlFieldsQuery.DefaultPageSize;
 
+        /// <summary> Default value for <see cref="UpdateBatchSize"/>. </summary>
+        public const int DefaultUpdateBatchSize = SqlFieldsQuery.DefaultUpdateBatchSize;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="QueryOptions"/> class.
         /// </summary>
         public QueryOptions()
         {
             PageSize = DefaultPageSize;
+            UpdateBatchSize = DefaultUpdateBatchSize;
         }
 
         /// <summary>
-        /// Local flag. When set query will be executed only on local node, so only local 
+        /// Local flag. When set query will be executed only on local node, so only local
         /// entries will be returned as query result.
         /// <para />
         /// Defaults to <c>false</c>.
@@ -52,7 +57,7 @@ namespace Apache.Ignite.Linq
         public int PageSize { get; set; }
 
         /// <summary>
-        /// Gets or sets the name of the table. 
+        /// Gets or sets the name of the table.
         /// <para />
         /// Table name is equal to short class name of a cache value.
         /// When a cache has only one type of values, or only one <see cref="QueryEntity" /> defined,
@@ -123,5 +128,20 @@ namespace Apache.Ignite.Linq
         /// consumption at the cost of moderate performance hit.
         /// </summary>
         public bool Lazy { get; set; }
+
+        /// <summary>
+        /// Gets or sets partitions for the query.
+        /// <para />
+        /// The query will be executed only on nodes which are primary for specified partitions.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1819:PropertiesShouldNotReturnArrays")]
+        public int[] Partitions { get; set; }
+
+        /// <summary>
+        /// Gets or sets batch size for update queries.
+        /// <para />
+        /// Default is 1 (<see cref="DefaultUpdateBatchSize"/>.
+        /// </summary>
+        public int UpdateBatchSize { get; set; }
     }
 }


### PR DESCRIPTION
* Add `Partitions` and `UpdateBatchSize` to `SqlFieldsQuery` and `QueryOptions` (LINQ) for thick and thin APIs (new feature flag added to thin client protocol)
* Add `updateBatchSize` validation on the server side (invalid values were ignored previously)
* Propagate `updateBatchSize` and `partitions` in Java thin client