### PR TITLE
GG-31846 [IGNITE-13760] .NET: Fix NullPointerException in GetAffinity on client nodes

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformProcessorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformProcessorImpl.java
@@ -42,6 +42,7 @@ import org.apache.ignite.internal.processors.platform.cache.PlatformCache;
 import org.apache.ignite.internal.processors.platform.cache.PlatformCacheExtension;
 import org.apache.ignite.internal.processors.platform.cache.PlatformCacheManager;
 import org.apache.ignite.internal.processors.platform.cache.affinity.PlatformAffinity;
+import org.apache.ignite.internal.processors.platform.cache.affinity.PlatformAffinityManager;
 import org.apache.ignite.internal.processors.platform.cache.store.PlatformCacheStore;
 import org.apache.ignite.internal.processors.platform.cluster.PlatformClusterGroup;
 import org.apache.ignite.internal.processors.platform.datastreamer.PlatformDataStreamer;
@@ -192,6 +193,9 @@ public class PlatformProcessorImpl extends GridProcessorAdapter implements Platf
 
     /** */
     private static final int OP_GET_OR_CREATE_LOCK = 38;
+
+    /** */
+    private static final int OP_GET_AFFINITY_MANAGER = 39;
 
     /** Start latch. */
     private final CountDownLatch startLatch = new CountDownLatch(1);
@@ -637,7 +641,7 @@ public class PlatformProcessorImpl extends GridProcessorAdapter implements Platf
             }
 
             case OP_GET_AFFINITY: {
-                return new PlatformAffinity(platformCtx, ctx, reader.readString());
+                return new PlatformAffinity(platformCtx, reader.readString());
             }
 
             case OP_GET_DATA_STREAMER: {
@@ -738,6 +742,12 @@ public class PlatformProcessorImpl extends GridProcessorAdapter implements Platf
                 IgniteLock lock = ctx.grid().reentrantLock(name, failoverSafe, fair, create);
 
                 return lock == null ? null : new PlatformLock(platformCtx, lock);
+            }
+
+            case OP_GET_AFFINITY_MANAGER: {
+                int cacheId = reader.readInt();
+
+                return new PlatformAffinityManager(platformCtx, cacheId);
             }
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/affinity/PlatformAffinity.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/affinity/PlatformAffinity.java
@@ -22,22 +22,17 @@ import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cache.affinity.Affinity;
 import org.apache.ignite.cluster.ClusterNode;
-import org.apache.ignite.internal.GridKernalContext;
-import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
 import org.apache.ignite.internal.binary.BinaryRawReaderEx;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
-import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
-import org.apache.ignite.internal.processors.cache.GridCacheAffinityManager;
-import org.apache.ignite.internal.processors.cache.GridCacheUtils;
+import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
 import org.apache.ignite.internal.processors.platform.PlatformAbstractTarget;
 import org.apache.ignite.internal.processors.platform.PlatformContext;
 import org.apache.ignite.internal.processors.platform.utils.PlatformUtils;
-import org.apache.ignite.internal.util.typedef.C1;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * Native cache wrapper implementation.
+ * Affinity wrapper for platforms.
  */
 public class PlatformAffinity extends PlatformAbstractTarget {
     /** */
@@ -85,45 +80,28 @@ public class PlatformAffinity extends PlatformAbstractTarget {
     /** */
     public static final int OP_PARTITIONS = 15;
 
-    /** */
-    public static final int OP_IS_ASSIGNMENT_VALID = 16;
-
-    /** */
-    private static final C1<ClusterNode, UUID> TO_NODE_ID = new C1<ClusterNode, UUID>() {
-        @Nullable @Override public UUID apply(ClusterNode node) {
-            return node != null ? node.id() : null;
-        }
-    };
-
     /** Underlying cache affinity. */
     private final Affinity<Object> aff;
 
     /** Discovery manager */
     private final GridDiscoveryManager discovery;
 
-    /** Affinity manager. */
-    private final GridCacheAffinityManager affMgr;
-
     /**
      * Constructor.
      *
      * @param platformCtx Context.
-     * @param igniteCtx Ignite context.
      * @param name Cache name.
      */
-    public PlatformAffinity(PlatformContext platformCtx, GridKernalContext igniteCtx, @Nullable String name)
+    public PlatformAffinity(PlatformContext platformCtx, @Nullable String name)
         throws IgniteCheckedException {
         super(platformCtx);
 
-        this.aff = igniteCtx.grid().affinity(name);
+        aff = platformCtx.kernalContext().grid().affinity(name);
 
         if (aff == null)
             throw new IgniteCheckedException("Cache with the given name doesn't exist: " + name);
 
-        this.affMgr = this.platformCtx.kernalContext().cache().context().cacheContext(GridCacheUtils.cacheId(name))
-                .affinity();
-
-        discovery = igniteCtx.discovery();
+        discovery = platformCtx.kernalContext().discovery();
     }
 
     /** {@inheritDoc} */
@@ -169,24 +147,6 @@ public class PlatformAffinity extends PlatformAbstractTarget {
                     return FALSE;
 
                 return aff.isPrimaryOrBackup(node, key) ? TRUE : FALSE;
-            }
-
-            case OP_IS_ASSIGNMENT_VALID: {
-                AffinityTopologyVersion ver = new AffinityTopologyVersion(reader.readLong(), reader.readInt());
-                int part = reader.readInt();
-                AffinityTopologyVersion endVer = affMgr.affinityTopologyVersion();
-
-                if (!affMgr.primaryChanged(part, ver, endVer)) {
-                    return TRUE;
-                }
-
-                if (!affMgr.partitionLocalNode(part, endVer)) {
-                    return FALSE;
-                }
-
-                // Special case: late affinity assignment when primary changes to local node due to a node join.
-                // Specified partition is local, and near cache entries are valid for primary keys.
-                return ver.topologyVersion() == endVer.topologyVersion() ? TRUE : FALSE;
             }
 
             default:

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/affinity/PlatformAffinityManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/affinity/PlatformAffinityManager.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.cache.affinity;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.internal.binary.BinaryRawReaderEx;
+import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
+import org.apache.ignite.internal.processors.cache.GridCacheAffinityManager;
+import org.apache.ignite.internal.processors.cache.GridCacheContext;
+import org.apache.ignite.internal.processors.platform.PlatformAbstractTarget;
+import org.apache.ignite.internal.processors.platform.PlatformContext;
+
+/**
+ * AffinityManager wrapper for platforms.
+ */
+public class PlatformAffinityManager extends PlatformAbstractTarget {
+    /** */
+    public static final int OP_IS_ASSIGNMENT_VALID = 1;
+
+    /** Affinity manager. */
+    private final GridCacheAffinityManager affMgr;
+
+    /**
+     * Constructor.
+     *
+     * @param platformCtx Context.
+     */
+    public PlatformAffinityManager(PlatformContext platformCtx, int cacheId) {
+        super(platformCtx);
+
+        GridCacheContext<Object, Object> ctx = platformCtx.kernalContext().cache().context().cacheContext(cacheId);
+
+        if (ctx == null)
+            throw new IgniteException("Cache doesn't exist: " + cacheId);
+
+        affMgr = ctx.affinity();
+    }
+
+    /** {@inheritDoc} */
+    @Override public long processInStreamOutLong(int type, BinaryRawReaderEx reader) throws IgniteCheckedException {
+        if (type == OP_IS_ASSIGNMENT_VALID)
+        {
+            AffinityTopologyVersion ver = new AffinityTopologyVersion(reader.readLong(), reader.readInt());
+            int part = reader.readInt();
+            AffinityTopologyVersion endVer = affMgr.affinityTopologyVersion();
+
+            if (!affMgr.primaryChanged(part, ver, endVer)) {
+                return TRUE;
+            }
+
+            if (!affMgr.partitionLocalNode(part, endVer)) {
+                return FALSE;
+            }
+
+            // Special case: late affinity assignment when primary changes to local node due to a node join.
+            // Specified partition is local, and near cache entries are valid for primary keys.
+            return ver.topologyVersion() == endVer.topologyVersion() ? TRUE : FALSE;
+        }
+
+        return super.processInStreamOutLong(type, reader);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Affinity/AffinityTest.cs
@@ -37,15 +37,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         [TestFixtureSetUp]
         public void StartGrids()
         {
-            for (int i = 0; i < 3; i++)
+            for (var i = 0; i < 3; i++)
             {
-                var cfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
-                {
-                    SpringConfigUrl = Path.Combine("Config", "native-client-test-cache-affinity.xml"),
-                    IgniteInstanceName = "grid-" + i
-                };
-
-                Ignition.Start(cfg);
+                Ignition.Start(GetConfig(i, client: i == 2));
             }
         }
 
@@ -75,6 +69,21 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         }
 
         /// <summary>
+        /// Tests that affinity can be retrieved from client node right after the cache has been started on server node.
+        /// </summary>
+        [Test]
+        public void TestAffinityRetrievalForNewCache()
+        {
+            var server = Ignition.GetIgnite("grid-0");
+            var client = Ignition.GetIgnite("grid-2");
+
+            var serverCache = server.CreateCache<int, int>(TestUtils.TestName);
+            var clientAff = client.GetAffinity(serverCache.Name);
+
+            Assert.IsNotNull(clientAff);
+        }
+
+        /// <summary>
         /// Test affinity with binary flag.
         /// </summary>
         [Test]
@@ -100,18 +109,20 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
         /// <summary>
         /// Tests that <see cref="AffinityKeyMappedAttribute"/> works when used on a property of a type that is
         /// specified as <see cref="QueryEntity.KeyType"/> or <see cref="QueryEntity.ValueType"/> and
-        /// configured in a Spring XML file. 
+        /// configured in a Spring XML file.
         /// </summary>
         [Test]
         public void TestAffinityKeyMappedWithQueryEntitySpringXml()
         {
-            TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-0"), "cache1");
-            TestAffinityKeyMappedWithQueryEntity0(Ignition.GetIgnite("grid-1"), "cache1");
+            foreach (var ignite in Ignition.GetAll())
+            {
+                TestAffinityKeyMappedWithQueryEntity0(ignite, "cache1");
+            }
         }
 
         /// <summary>
         /// Tests that <see cref="AffinityKeyMappedAttribute"/> works when used on a property of a type that is
-        /// specified as <see cref="QueryEntity.KeyType"/> or <see cref="QueryEntity.ValueType"/>. 
+        /// specified as <see cref="QueryEntity.KeyType"/> or <see cref="QueryEntity.ValueType"/>.
         /// </summary>
         [Test]
         public void TestAffinityKeyMappedWithQueryEntity()
@@ -193,7 +204,20 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
                 return _id;
             }
         }
-        
+
+        /// <summary>
+        /// Gets Ignite config.
+        /// </summary>
+        private static IgniteConfiguration GetConfig(int idx, bool client = false)
+        {
+            return new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "native-client-test-cache-affinity.xml"),
+                IgniteInstanceName = "grid-" + idx,
+                ClientMode = client
+            };
+        }
+
         /// <summary>
         /// Query entity key.
         /// </summary>
@@ -203,12 +227,12 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             /** */
             [QuerySqlField]
             public string Data { get; set; }
-            
+
             /** */
             [AffinityKeyMapped]
             public long AffinityKey { get; set; }
         }
-        
+
         /// <summary>
         /// Query entity key.
         /// </summary>
@@ -218,7 +242,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Affinity
             /** */
             [QuerySqlField]
             public string Name { get; set; }
-            
+
             /** */
             [AffinityKeyMapped]
             public long AffKey { get; set; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -101,6 +101,7 @@
     <Compile Include="IIgniteLock.cs" />
     <Compile Include="Impl\Binary\BinaryHashCodeUtils.cs" />
     <Compile Include="Impl\Binary\IgniteBiTuple.cs" />
+    <Compile Include="Impl\Cache\CacheAffinityManager.cs" />
     <Compile Include="Impl\Cache\Event\CacheEntryExpireEvent.cs" />
     <Compile Include="Impl\Cache\Platform\IPlatformCache.cs" />
     <Compile Include="Impl\Cache\Platform\PlatformCache.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheAffinityImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheAffinityImpl.cs
@@ -19,7 +19,6 @@ namespace Apache.Ignite.Core.Impl.Cache
     using System;
     using System.Collections.Generic;
     using Apache.Ignite.Core.Cache;
-    using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cluster;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
@@ -76,11 +75,8 @@ namespace Apache.Ignite.Core.Impl.Cache
         private const int OpPartitions = 15;
 
         /** */
-        private const int OpIsAssignmentValid = 16;
-
-        /** */
         private readonly bool _keepBinary;
-        
+
         /** Grid. */
         private readonly IIgniteInternal _ignite;
 
@@ -114,7 +110,7 @@ namespace Apache.Ignite.Core.Impl.Cache
         public bool IsPrimary<TK>(IClusterNode n, TK key)
         {
             IgniteArgumentCheck.NotNull(n, "n");
-            
+
             IgniteArgumentCheck.NotNull(key, "key");
 
             return DoOutOp(OpIsPrimary, n.Id, key) == True;
@@ -217,19 +213,6 @@ namespace Apache.Ignite.Core.Impl.Cache
         public IList<IClusterNode> MapPartitionToPrimaryAndBackups(int part)
         {
             return DoOutInOp(OpMapPartitionToPrimaryAndBackups, w => w.WriteObject(part), r => ReadNodes(r));
-        }
-
-        /// <summary>
-        /// Checks whether given partition is still assigned to the same node as in specified version.
-        /// </summary>
-        internal bool IsAssignmentValid(AffinityTopologyVersion version, int partition)
-        {
-            return DoOutOp(OpIsAssignmentValid, (IBinaryStream s) =>
-            {
-                s.WriteLong(version.Version);
-                s.WriteInt(version.MinorVersion);
-                s.WriteInt(partition);
-            }) != 0;
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheAffinityManager.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheAffinityManager.cs
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Cache
+{
+    using Apache.Ignite.Core.Cache.Affinity;
+    using Apache.Ignite.Core.Impl.Binary.IO;
+
+    /// <summary>
+    /// Affinity manager.
+    /// </summary>
+    internal class CacheAffinityManager : PlatformTargetAdapter
+    {
+        /** */
+        private const int OpIsAssignmentValid = 1;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="CacheAffinityManager"/> class.
+        /// </summary>
+        /// <param name="target">Target.</param>
+        internal CacheAffinityManager(IPlatformTargetInternal target) : base(target)
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Checks whether given partition is still assigned to the same node as in specified version.
+        /// </summary>
+        internal bool IsAssignmentValid(AffinityTopologyVersion version, int partition)
+        {
+            return DoOutOp(OpIsAssignmentValid, (IBinaryStream s) =>
+            {
+                s.WriteLong(version.Version);
+                s.WriteInt(version.MinorVersion);
+                s.WriteInt(partition);
+            }) != 0;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Platform/PlatformCache.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Platform/PlatformCache.cs
@@ -31,8 +31,8 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
     internal sealed class PlatformCache<TK, TV> : IPlatformCache
     {
         /** Affinity. */
-        private readonly CacheAffinityImpl _affinity;
-        
+        private readonly CacheAffinityManager _affinity;
+
         /** Keep binary flag. */
         private readonly bool _keepBinary;
 
@@ -43,7 +43,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         private readonly Func<object> _affinityTopologyVersionFunc;
 
         /** Underlying map. */
-        private readonly ConcurrentDictionary<TK, PlatformCacheEntry<TV>> _map = 
+        private readonly ConcurrentDictionary<TK, PlatformCacheEntry<TV>> _map =
             new ConcurrentDictionary<TK, PlatformCacheEntry<TV>>();
 
         /** Stopped flag. */
@@ -51,9 +51,9 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PlatformCache{TK,TV}"/> class.
-        /// Called via reflection from <see cref="PlatformCacheManager.CreatePlatformCache"/>. 
+        /// Called via reflection from <see cref="PlatformCacheManager.CreatePlatformCache"/>.
         /// </summary>
-        public PlatformCache(Func<object> affinityTopologyVersionFunc, CacheAffinityImpl affinity, bool keepBinary)
+        public PlatformCache(Func<object> affinityTopologyVersionFunc, CacheAffinityManager affinity, bool keepBinary)
         {
             _affinityTopologyVersionFunc = affinityTopologyVersionFunc;
             _affinity = affinity;
@@ -77,7 +77,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
 
             PlatformCacheEntry<TV> entry;
             var key0 = (TK) (object) key;
-            
+
             if (_map.TryGetValue(key0, out entry))
             {
                 if (IsValid(entry))
@@ -105,7 +105,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
             }
 
             var count = 0;
-            
+
             foreach (var e in _map)
             {
                 if (!IsValid(e.Value))
@@ -117,7 +117,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
                 {
                     continue;
                 }
-                
+
                 count++;
             }
 
@@ -178,7 +178,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
             _stopped = true;
             Clear();
         }
-        
+
         /** <inheritdoc /> */
         public void Clear()
         {
@@ -226,19 +226,19 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         /// When primary node changes for a key, GridNearCacheEntry stops receiving updates for that key,
         /// because reader ("subscription") on new primary is not yet established.
         /// <para />
-        /// This method is similar to GridNearCacheEntry.valid(). 
+        /// This method is similar to GridNearCacheEntry.valid().
         /// </summary>
         /// <param name="entry">Entry to validate.</param>
         /// <typeparam name="TVal">Value type.</typeparam>
         /// <returns>True if entry is valid and can be returned to the user; false otherwise.</returns>
         private bool IsValid<TVal>(PlatformCacheEntry<TVal> entry)
         {
-            // See comments on _affinityTopologyVersionFunc about boxed copy approach. 
+            // See comments on _affinityTopologyVersionFunc about boxed copy approach.
             var currentVerBoxed = _affinityTopologyVersionFunc();
             var entryVerBoxed = entry.Version;
-            
+
             Debug.Assert(currentVerBoxed != null);
-            
+
             if (ReferenceEquals(currentVerBoxed, entryVerBoxed))
             {
                 // Happy path: true on stable topology.
@@ -266,7 +266,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
 
             return valid;
         }
-        
+
         /// <summary>
         /// Gets boxed affinity version. Reuses existing boxing copy to reduce allocations.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Platform/PlatformCacheManager.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Platform/PlatformCacheManager.cs
@@ -37,12 +37,12 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         /// Holds thread-local key/val pair to be used for updating platform cache.
         /// </summary>
         internal static readonly ThreadLocal<object> ThreadLocalPair = new ThreadLocal<object>();
-        
+
         /// <summary>
         /// Platform caches per cache id.
         /// Multiple <see cref="CacheImpl{TK,TV}"/> instances can point to the same Ignite cache,
-        /// and share one <see cref="PlatformCache{TK,TV}"/> instance. 
-        /// </summary> 
+        /// and share one <see cref="PlatformCache{TK,TV}"/> instance.
+        /// </summary>
         private readonly CopyOnWriteConcurrentDictionary<int, IPlatformCache> _caches
             = new CopyOnWriteConcurrentDictionary<int, IPlatformCache>();
 
@@ -55,9 +55,9 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         /// Current topology version. Store as object for atomic updates.
         /// </summary>
         private volatile object _affinityTopologyVersion;
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="PlatformCacheManager"/> class. 
+        /// Initializes a new instance of the <see cref="PlatformCacheManager"/> class.
         /// </summary>
         /// <param name="ignite">Ignite.</param>
         public PlatformCacheManager(IIgniteInternal ignite)
@@ -76,7 +76,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
             Debug.Assert(cacheConfiguration != null);
 
             var cacheId = BinaryUtils.GetCacheId(cacheConfiguration.Name);
-            
+
             return _caches.GetOrAdd(cacheId, _ => CreatePlatformCache(cacheConfiguration));
         }
 
@@ -88,15 +88,15 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
             IPlatformCache platformCache;
             return _caches.TryGetValue(cacheId, out platformCache) ? platformCache : null;
         }
-        
+
         /// <summary>
         /// Reads cache entry from a stream and updates the platform cache.
         /// </summary>
         public void Update(int cacheId, IBinaryStream stream, Marshaller marshaller)
         {
-            var cache = _caches.GetOrAdd(cacheId, 
+            var cache = _caches.GetOrAdd(cacheId,
                 _ => CreatePlatformCache(_ignite.GetCacheConfiguration(cacheId)));
-            
+
             cache.Update(stream, marshaller);
         }
 
@@ -132,7 +132,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         {
             _affinityTopologyVersion = affinityTopologyVersion;
         }
-        
+
         /// <summary>
         /// Creates platform cache.
         /// </summary>
@@ -140,9 +140,9 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         {
             var platformCfg = cacheConfiguration.PlatformCacheConfiguration;
             Debug.Assert(platformCfg != null);
-            
+
             Func<object> affinityTopologyVersionFunc = () => _affinityTopologyVersion;
-            var affinity = _ignite.GetAffinity(cacheConfiguration.Name);
+            var affinity = _ignite.GetAffinityManager(cacheConfiguration.Name);
             var keepBinary = platformCfg.KeepBinary;
 
             TypeResolver resolver = null;
@@ -163,7 +163,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
                 if (resolved == null)
                 {
                     throw new InvalidOperationException(string.Format(
-                        "Can not create .NET Platform Cache: {0}.{1} is invalid. Failed to resolve type: '{2}'", 
+                        "Can not create .NET Platform Cache: {0}.{1} is invalid. Failed to resolve type: '{2}'",
                         typeof(PlatformCacheConfiguration).Name, fieldName, typeName));
                 }
 
@@ -173,16 +173,16 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
             var keyType = resolve(platformCfg.KeyTypeName, "KeyTypeName");
             var valType = resolve(platformCfg.ValueTypeName, "ValueTypeName");
             var cacheType = typeof(PlatformCache<,>).MakeGenericType(keyType, valType);
-            
+
             var platformCache = Activator.CreateInstance(
-                cacheType, 
-                affinityTopologyVersionFunc, 
+                cacheType,
+                affinityTopologyVersionFunc,
                 affinity,
                 keepBinary);
-            
+
             return (IPlatformCache) platformCache;
         }
-        
+
         /// <summary>
         /// Handles client disconnect.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
@@ -229,6 +229,12 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        public CacheAffinityManager GetAffinityManager(string cacheName)
+        {
+            throw GetClientNotSupportedException();
+        }
+
+        /** <inheritDoc /> */
         public CacheConfiguration GetCacheConfiguration(int cacheId)
         {
             throw GetClientNotSupportedException();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/IIgniteInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/IIgniteInternal.cs
@@ -92,6 +92,13 @@ namespace Apache.Ignite.Core.Impl
         CacheAffinityImpl GetAffinity(string cacheName);
 
         /// <summary>
+        /// Gets internal affinity manager for a given cache.
+        /// </summary>
+        /// <param name="cacheName">Cache name.</param>
+        /// <returns>Cache affinity manager.</returns>
+        CacheAffinityManager GetAffinityManager(string cacheName);
+
+        /// <summary>
         /// Gets cache name by id.
         /// </summary>
         /// <param name="cacheId">Cache id.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Ignite.cs
@@ -34,6 +34,7 @@ namespace Apache.Ignite.Core.Impl
     using Apache.Ignite.Core.DataStructures;
     using Apache.Ignite.Core.Events;
     using Apache.Ignite.Core.Impl.Binary;
+    using Apache.Ignite.Core.Impl.Binary.IO;
     using Apache.Ignite.Core.Impl.Cache;
     using Apache.Ignite.Core.Impl.Cache.Platform;
     using Apache.Ignite.Core.Impl.Cluster;
@@ -100,7 +101,8 @@ namespace Apache.Ignite.Core.Impl
             SetBaselineAutoAdjustTimeout = 35,
             GetCacheConfig = 36,
             GetThreadLocal = 37,
-            GetOrCreateLock = 38
+            GetOrCreateLock = 38,
+            GetAffinityManager = 39,
         }
 
         /** */
@@ -138,7 +140,7 @@ namespace Apache.Ignite.Core.Impl
             new ConcurrentDictionary<Guid, ClusterNodeImpl>();
 
         /** Client reconnect task completion source. */
-        private volatile TaskCompletionSource<bool> _clientReconnectTaskCompletionSource = 
+        private volatile TaskCompletionSource<bool> _clientReconnectTaskCompletionSource =
             new TaskCompletionSource<bool>();
 
         /** Plugin processor. */
@@ -188,7 +190,7 @@ namespace Apache.Ignite.Core.Impl
             SetCompactFooter();
 
             _pluginProcessor = new PluginProcessor(this);
-            
+
             _platformCacheManager = new PlatformCacheManager(this);
         }
 
@@ -469,7 +471,7 @@ namespace Apache.Ignite.Core.Impl
         public ICache<TK, TV> GetOrCreateCache<TK, TV>(CacheConfiguration configuration, NearCacheConfiguration nearConfiguration,
             PlatformCacheConfiguration platformCacheConfiguration)
         {
-            return GetOrCreateCache<TK, TV>(configuration, nearConfiguration, platformCacheConfiguration, 
+            return GetOrCreateCache<TK, TV>(configuration, nearConfiguration, platformCacheConfiguration,
                 Op.GetOrCreateCacheFromConfig);
         }
 
@@ -490,7 +492,7 @@ namespace Apache.Ignite.Core.Impl
         }
 
         /** <inheritdoc /> */
-        public ICache<TK, TV> CreateCache<TK, TV>(CacheConfiguration configuration, 
+        public ICache<TK, TV> CreateCache<TK, TV>(CacheConfiguration configuration,
             NearCacheConfiguration nearConfiguration)
         {
             return CreateCache<TK, TV>(configuration, nearConfiguration, null);
@@ -500,14 +502,14 @@ namespace Apache.Ignite.Core.Impl
         public ICache<TK, TV> CreateCache<TK, TV>(CacheConfiguration configuration, NearCacheConfiguration nearConfiguration,
             PlatformCacheConfiguration platformCacheConfiguration)
         {
-            return GetOrCreateCache<TK, TV>(configuration, nearConfiguration, platformCacheConfiguration, 
+            return GetOrCreateCache<TK, TV>(configuration, nearConfiguration, platformCacheConfiguration,
                 Op.CreateCacheFromConfig);
         }
 
         /// <summary>
         /// Gets or creates the cache.
         /// </summary>
-        private ICache<TK, TV> GetOrCreateCache<TK, TV>(CacheConfiguration configuration, 
+        private ICache<TK, TV> GetOrCreateCache<TK, TV>(CacheConfiguration configuration,
             NearCacheConfiguration nearConfiguration, PlatformCacheConfiguration platformCacheConfiguration, Op op)
         {
             IgniteArgumentCheck.NotNull(configuration, "configuration");
@@ -645,8 +647,19 @@ namespace Apache.Ignite.Core.Impl
             IgniteArgumentCheck.NotNull(cacheName, "cacheName");
 
             var aff = DoOutOpObject((int) Op.GetAffinity, w => w.WriteString(cacheName));
-            
+
             return new CacheAffinityImpl(aff, false);
+        }
+
+        /** <inheritdoc /> */
+        public CacheAffinityManager GetAffinityManager(string cacheName)
+        {
+            IgniteArgumentCheck.NotNull(cacheName, "cacheName");
+
+            var mgr = DoOutOpObject((int) Op.GetAffinityManager,
+                (IBinaryStream s) => s.WriteInt(BinaryUtils.GetCacheId(cacheName)));
+
+            return new CacheAffinityManager(mgr);
         }
 
         /** <inheritdoc /> */
@@ -917,7 +930,7 @@ namespace Apache.Ignite.Core.Impl
         public void EnableWal(string cacheName)
         {
             IgniteArgumentCheck.NotNull(cacheName, "cacheName");
-            
+
             DoOutOp((int) Op.EnableWal, w => w.WriteString(cacheName));
         }
 
@@ -932,7 +945,7 @@ namespace Apache.Ignite.Core.Impl
         /** <inheritdoc /> */
         public void SetTxTimeoutOnPartitionMapExchange(TimeSpan timeout)
         {
-            DoOutOp((int) Op.SetTxTimeoutOnPartitionMapExchange, 
+            DoOutOp((int) Op.SetTxTimeoutOnPartitionMapExchange,
                 (BinaryWriter w) => w.WriteLong((long) timeout.TotalMilliseconds));
         }
 
@@ -1004,7 +1017,7 @@ namespace Apache.Ignite.Core.Impl
             {
                 Name = name
             };
-            
+
             return GetOrCreateLock(configuration, true);
         }
 
@@ -1013,7 +1026,7 @@ namespace Apache.Ignite.Core.Impl
         {
             IgniteArgumentCheck.NotNull(configuration, "configuration");
             IgniteArgumentCheck.NotNullOrEmpty(configuration.Name, "configuration.Name");
-            
+
             // Create a copy to ignore modifications from outside.
             var cfg = new LockConfiguration(configuration);
 
@@ -1024,7 +1037,7 @@ namespace Apache.Ignite.Core.Impl
                 w.WriteBoolean(configuration.IsFair);
                 w.WriteBoolean(create);
             });
-            
+
             return target == null ? null : new IgniteLock(target, cfg);
         }
 
@@ -1122,13 +1135,13 @@ namespace Apache.Ignite.Core.Impl
         internal ITransactions GetTransactionsWithLabel(string label)
         {
             Debug.Assert(label != null);
-            
+
             var platformTargetInternal = DoOutOpObject((int) Op.GetTransactions, s =>
             {
                 var w = BinaryUtils.Marshaller.StartMarshal(s);
                 w.WriteString(label);
             });
-            
+
             return new TransactionsImpl(this, platformTargetInternal, GetLocalNode().Id, label);
         }
 
@@ -1162,7 +1175,7 @@ namespace Apache.Ignite.Core.Impl
 
             // Raise events.
             _clientReconnectTaskCompletionSource = new TaskCompletionSource<bool>();
-            
+
             var handler = ClientDisconnected;
             if (handler != null)
                 handler.Invoke(this, EventArgs.Empty);
@@ -1175,7 +1188,7 @@ namespace Apache.Ignite.Core.Impl
         internal void OnClientReconnected(bool clusterRestarted)
         {
             _marsh.OnClientReconnected(clusterRestarted);
-            
+
             _clientReconnectTaskCompletionSource.TrySetResult(clusterRestarted);
 
             var handler = ClientReconnected;


### PR DESCRIPTION
Cache context does not exist on client nodes unless `GetCache` was called, so `GridCacheAffinityManager` retrieval in `PlatformAffinity` constructor can cause NPE.

`GridCacheAffinityManager` was added to `PlatformAffinity` solely for Platform Cache needs and is not used otherwise, so it makes sense to move this functionality to a dedicated `PlatformAffinityManager` class. This fixes the bug, because cache context always exists by the time Platform Cache is created.