### PR TITLE
GG-32187: CVE in apache-http-client version prior to 4.5.13

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -77,7 +77,7 @@
         <guava.version>25.1-jre</guava.version>
         <hadoop.version>2.9.2</hadoop.version>
         <hamcrest.version>1.2</hamcrest.version>
-        <httpclient.version>4.5.10</httpclient.version>
+        <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.3</httpcore.version>
         <jackson.version>2.11.0</jackson.version>
         <jackson1.version>1.9.13</jackson1.version>


### PR DESCRIPTION
update apache-http-client version to 4.5.13