### PR TITLE
GG-32131 [IGNITE-13865] Support DateTime as a key or value in .NET and Java

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformDeployServiceTask.java
@@ -18,14 +18,17 @@ package org.apache.ignite.platform;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.cluster.ClusterNode;
@@ -43,6 +46,7 @@ import org.jetbrains.annotations.Nullable;
 
 import static java.util.Calendar.JANUARY;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -93,6 +97,9 @@ public class PlatformDeployServiceTask extends ComputeTaskAdapter<String, Object
      * Test service.
      */
     public static class PlatformTestService implements Service {
+        @IgniteInstanceResource
+        private Ignite ignite;
+
         /** */
         private boolean isCancelled;
 
@@ -491,6 +498,35 @@ public class PlatformDeployServiceTask extends ComputeTaskAdapter<String, Object
             m.put(new Key(3), new Value("value3"));
 
             return m;
+        }
+
+        /** */
+        public void testDateArray(Timestamp[] dates) {
+            assertNotNull(dates);
+            assertEquals(2, dates.length);
+            assertEquals(new Timestamp(new Date(82, Calendar.APRIL, 1, 0, 0, 0).getTime()), dates[0]);
+            assertEquals(new Timestamp(new Date(91, Calendar.OCTOBER, 1, 0, 0, 0).getTime()), dates[1]);
+        }
+
+        /** */
+        public Timestamp testDate(Timestamp date) {
+            if (date == null)
+                return null;
+
+            assertEquals(new Timestamp(new Date(82, Calendar.APRIL, 1, 0, 0, 0).getTime()), date);
+
+            return new Timestamp(new Date(91, Calendar.OCTOBER, 1, 0, 0, 0).getTime());
+        }
+
+        /** */
+        public void testUTCDateFromCache() {
+            IgniteCache<Integer, Timestamp> cache = ignite.cache("net-dates");
+
+            cache.put(3, new Timestamp(new Date(82, Calendar.APRIL, 1, 0, 0, 0).getTime()));
+            cache.put(4, new Timestamp(new Date(91, Calendar.OCTOBER, 1, 0, 0, 0).getTime()));
+
+            assertEquals(new Timestamp(new Date(82, Calendar.APRIL, 1, 0, 0, 0).getTime()), cache.get(1));
+            assertEquals(new Timestamp(new Date(91, Calendar.OCTOBER, 1, 0, 0, 0).getTime()), cache.get(2));
         }
 
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/IJavaService.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/IJavaService.cs
@@ -175,7 +175,16 @@ namespace Apache.Ignite.Core.Tests.Services
 
         /** */
         IDictionary testMap(IDictionary<Key, Value> dict);
-        
+
+        /** */
+        void testDateArray(DateTime?[] dates);
+
+        /** */
+        DateTime testDate(DateTime date);
+
+        /** */
+        void testUTCDateFromCache();
+
         /** */
         void sleep(long delayMs);
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/JavaServiceDynamicProxy.cs
@@ -331,6 +331,24 @@ namespace Apache.Ignite.Core.Tests.Services
         }
 
         /** <inheritDoc /> */
+        public void testDateArray(DateTime?[] dates)
+        {
+            _svc.testDateArray(dates);
+        }
+
+        /** <inheritDoc /> */
+        public DateTime testDate(DateTime date)
+        {
+            return _svc.testDate(date);
+        }
+
+        /** <inheritDoc /> */
+        public void testUTCDateFromCache()
+        {
+            _svc.testDateFromCache();
+        }
+
+        /** <inheritDoc /> */
         public void sleep(long delayMs)
         {
             _svc.sleep(delayMs);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/Model.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/Model.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+// ReSharper disable once CheckNamespace
 namespace org.apache.ignite.platform
 {
     /// <summary>
@@ -27,7 +28,7 @@ namespace org.apache.ignite.platform
         /** */
         public string Addr { get; set; }
     }
-    
+
     /// <summary>
     /// A class is a clone of Java class Department with the same namespace.
     /// </summary>
@@ -36,7 +37,7 @@ namespace org.apache.ignite.platform
         /** */
         public string Name { get; set; }
     }
-    
+
     /// <summary>
     /// A class is a clone of Java class Employee with the same namespace.
     /// </summary>
@@ -71,6 +72,7 @@ namespace org.apache.ignite.platform
 
         public override int GetHashCode()
         {
+            // ReSharper disable once NonReadonlyMemberInGetHashCode
             return Id.GetHashCode();
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -955,6 +955,23 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(new[] {11, 12, 13}, binSvc.testBinaryObjectArray(binArr)
                 .Select(x => x.GetField<int>("Field")));
 
+            DateTime dt1 = new DateTime(1982, 4, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dt2 = new DateTime(1991, 10, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+            Assert.AreEqual(dt2, svc.testDate(dt1));
+
+            svc.testDateArray(new DateTime?[] {dt1, dt2});
+
+            var cache = Grid1.GetOrCreateCache<int, DateTime>("net-dates");
+
+            cache.Put(1, dt1);
+            cache.Put(2, dt2);
+
+            svc.testUTCDateFromCache();
+
+            Assert.AreEqual(dt1, cache.Get(3));
+            Assert.AreEqual(dt2, cache.Get(4));
+
             Services.Cancel(javaSvcName);
         }
 
@@ -1037,6 +1054,21 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual(guid, svc.testNullUUID(guid));
             Assert.IsNull(svc.testNullUUID(null));
             Assert.AreEqual(guid, svc.testArray(new Guid?[] { guid })[0]);
+
+            DateTime dt1 = new DateTime(1982, 4, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+            DateTime dt2 = new DateTime(1991, 10, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+
+            Assert.AreEqual(dt2, svc.testDate(dt1));
+
+            var cache = Grid1.GetOrCreateCache<int, DateTime>("net-dates");
+
+            cache.Put(1, dt1);
+            cache.Put(2, dt2);
+
+            svc.testUTCDateFromCache();
+
+            Assert.AreEqual(dt1, cache.Get(3));
+            Assert.AreEqual(dt2, cache.Get(4));
         }
 
         /// <summary>
@@ -1122,7 +1154,8 @@ namespace Apache.Ignite.Core.Tests.Services
                     typeof (PlatformComputeBinarizable),
                     typeof (BinarizableObject))
                 {
-                    NameMapper = BinaryBasicNameMapper.SimpleNameInstance
+                    NameMapper = BinaryBasicNameMapper.SimpleNameInstance,
+                    ForceTimestamp = true
                 }
             };
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Binary/BinaryConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Binary/BinaryConfiguration.cs
@@ -39,6 +39,11 @@ namespace Apache.Ignite.Core.Binary
         /// </summary>
         public const bool DefaultKeepDeserialized = true;
 
+        /// <summary>
+        /// Default <see cref="ForceTimestamp"/> setting.
+        /// </summary>
+        public const bool DefaultForceTimestamp = false;
+
         /** Footer setting. */
         private bool? _compactFooter;
 
@@ -48,6 +53,7 @@ namespace Apache.Ignite.Core.Binary
         public BinaryConfiguration()
         {
             KeepDeserialized = DefaultKeepDeserialized;
+            ForceTimestamp = DefaultForceTimestamp;
         }
 
         /// <summary>
@@ -71,6 +77,7 @@ namespace Apache.Ignite.Core.Binary
             IdMapper = cfg.IdMapper;
             NameMapper = cfg.NameMapper;
             KeepDeserialized = cfg.KeepDeserialized;
+            ForceTimestamp = cfg.ForceTimestamp;
 
             if (cfg.Serializer != null)
             {
@@ -105,7 +112,7 @@ namespace Apache.Ignite.Core.Binary
         public ICollection<BinaryTypeConfiguration> TypeConfigurations { get; set; }
 
         /// <summary>
-        /// Gets or sets a collection of assembly-qualified type names 
+        /// Gets or sets a collection of assembly-qualified type names
         /// (the result of <see cref="Type.AssemblyQualifiedName"/>) for binarizable types.
         /// <para />
         /// Shorthand for creating <see cref="BinaryTypeConfiguration"/>.
@@ -136,12 +143,12 @@ namespace Apache.Ignite.Core.Binary
 
         /// <summary>
         /// Gets or sets a value indicating whether to write footers in compact form.
-        /// When enabled, Ignite will not write fields metadata when serializing objects, 
+        /// When enabled, Ignite will not write fields metadata when serializing objects,
         /// because internally metadata is distributed inside cluster.
         /// This increases serialization performance.
         /// <para/>
         /// <b>WARNING!</b> This mode should be disabled when already serialized data can be taken from some external
-        /// sources (e.g.cache store which stores data in binary form, data center replication, etc.). 
+        /// sources (e.g.cache store which stores data in binary form, data center replication, etc.).
         /// Otherwise binary objects without any associated metadata could could not be deserialized.
         /// </summary>
         [DefaultValue(DefaultCompactFooter)]
@@ -150,6 +157,21 @@ namespace Apache.Ignite.Core.Binary
             get { return _compactFooter ?? DefaultCompactFooter; }
             set { _compactFooter = value; }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether all DateTime keys, values and object fields
+        /// should be written as a Timestamp.
+        /// <para />
+        /// Timestamp format is required for values used in SQL and for interoperation with other platforms.
+        /// Only UTC values are supported in Timestamp format. Other values will cause an exception on write.
+        /// <para />
+        /// Normally Ignite serializer uses <see cref="IBinaryWriter.WriteObject{T}"/> for DateTime fields,
+        /// keys and values.
+        /// This attribute changes the behavior to <see cref="IBinaryWriter.WriteTimestamp"/>.
+        /// <para />
+        /// See also <see cref="TimestampAttribute"/>, <see cref="BinaryReflectiveSerializer.ForceTimestamp"/>.
+        /// </summary>
+        public bool ForceTimestamp { get; set; }
 
         /// <summary>
         /// Gets the compact footer internal nullable value.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Binary/BinaryReflectiveSerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Binary/BinaryReflectiveSerializer.cs
@@ -20,21 +20,21 @@ namespace Apache.Ignite.Core.Binary
     using Apache.Ignite.Core.Impl.Binary;
 
     /// <summary>
-    /// Binary serializer which reflectively writes all fields except of ones with 
+    /// Binary serializer which reflectively writes all fields except of ones with
     /// <see cref="System.NonSerializedAttribute"/>.
     /// <para />
-    /// Note that Java platform stores dates as a difference between current time 
-    /// and predefined absolute UTC date. Therefore, this difference is always the 
-    /// same for all time zones. .NET, in contrast, stores dates as a difference 
-    /// between current time and some predefined date relative to the current time 
-    /// zone. It means that this difference will be different as you change time zones. 
-    /// To overcome this discrepancy Ignite always converts .Net date to UTC form 
-    /// before serializing and allows user to decide whether to deserialize them 
-    /// in UTC or local form using <c>ReadTimestamp(..., true/false)</c> methods in 
+    /// Note that Java platform stores dates as a difference between current time
+    /// and predefined absolute UTC date. Therefore, this difference is always the
+    /// same for all time zones. .NET, in contrast, stores dates as a difference
+    /// between current time and some predefined date relative to the current time
+    /// zone. It means that this difference will be different as you change time zones.
+    /// To overcome this discrepancy Ignite always converts .Net date to UTC form
+    /// before serializing and allows user to decide whether to deserialize them
+    /// in UTC or local form using <c>ReadTimestamp(..., true/false)</c> methods in
     /// <see cref="IBinaryReader"/> and <see cref="IBinaryRawReader"/>.
     /// This serializer always read dates in UTC form. It means that if you have
     /// local date in any field/property, it will be implicitly converted to UTC
-    /// form after the first serialization-deserialization cycle. 
+    /// form after the first serialization-deserialization cycle.
     /// </summary>
     public sealed class BinaryReflectiveSerializer : IBinarySerializer
     {
@@ -93,7 +93,7 @@ namespace Apache.Ignite.Core.Binary
         /// Normally serializer uses <see cref="IBinaryWriter.WriteObject{T}"/> for DateTime fields.
         /// This attribute changes the behavior to <see cref="IBinaryWriter.WriteTimestamp"/>.
         /// <para />
-        /// See also <see cref="TimestampAttribute"/>.
+        /// See also <see cref="TimestampAttribute"/>, <see cref="BinaryConfiguration.ForceTimestamp"/>.
         /// </summary>
         public bool ForceTimestamp
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -184,6 +184,11 @@
                                 <xs:documentation>Compact footer flag.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="forceTimestamp" type="xs:boolean">
+                            <xs:annotation>
+                                <xs:documentation>Force timestamp flag.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="endpoints" minOccurs="0" maxOccurs="1">

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfigurationSection.xsd
@@ -273,6 +273,11 @@
                                 <xs:documentation>Compact footer flag.</xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
+                        <xs:attribute name="forceTimestamp" type="xs:boolean">
+                            <xs:annotation>
+                                <xs:documentation>Force timestamp flag.</xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="cacheConfiguration" minOccurs="0">

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinarySystemHandlers.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinarySystemHandlers.cs
@@ -121,9 +121,18 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// Try getting write handler for type.
         /// </summary>
         /// <param name="type"></param>
+        /// <param name="forceTimestamp"></param>
         /// <returns></returns>
-        public static IBinarySystemWriteHandler GetWriteHandler(Type type)
+        public static IBinarySystemWriteHandler GetWriteHandler(Type type, bool forceTimestamp)
         {
+            if (forceTimestamp)
+            {
+                if (type == typeof(DateTime))
+                    return new BinarySystemWriteHandler<DateTime>(WriteTimestamp, false);
+                if (type == typeof(DateTime?[]))
+                    return new BinarySystemWriteHandler<DateTime?[]>(WriteTimestampArray, true);
+            }
+
             return WriteHandlers.GetOrAdd(type, t =>
             {
                 return FindWriteHandler(t);
@@ -293,6 +302,18 @@ namespace Apache.Ignite.Core.Impl.Binary
         }
 
         /// <summary>
+        /// Write Date.
+        /// </summary>
+        /// <param name="ctx">Context.</param>
+        /// <param name="obj">Value.</param>
+        private static void WriteTimestamp(BinaryWriter ctx, DateTime obj)
+        {
+            ctx.Stream.WriteByte(BinaryTypeId.Timestamp);
+
+            BinaryUtils.WriteTimestamp(obj, ctx.Stream);
+        }
+
+        /// <summary>
         /// Write boolaen array.
         /// </summary>
         /// <param name="ctx">Context.</param>
@@ -422,6 +443,18 @@ namespace Apache.Ignite.Core.Impl.Binary
             ctx.Stream.WriteByte(BinaryTypeId.ArrayGuid);
 
             BinaryUtils.WriteGuidArray(obj, ctx.Stream);
+        }
+
+        /// <summary>
+        /// Write nullable Date array.
+        /// </summary>
+        /// <param name="ctx">Context.</param>
+        /// <param name="obj">Value.</param>
+        private static void WriteTimestampArray(BinaryWriter ctx, DateTime?[] obj)
+        {
+            ctx.Stream.WriteByte(BinaryTypeId.ArrayTimestamp);
+
+            BinaryUtils.WriteTimestampArray(obj, ctx.Stream);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -874,7 +874,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                     throw new BinaryObjectException("Type is not an enum: " + type);
                 }
 
-                var handler = BinarySystemHandlers.GetWriteHandler(type);
+                var handler = BinarySystemHandlers.GetWriteHandler(type, _marsh.ForceTimestamp);
 
                 if (handler != null)
                 {
@@ -1179,7 +1179,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                 return;
 
             // Are we dealing with a well-known type?
-            var handler = BinarySystemHandlers.GetWriteHandler(type);
+            var handler = BinarySystemHandlers.GetWriteHandler(type, _marsh.ForceTimestamp);
 
             if (handler != null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Marshaller.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Marshaller.cs
@@ -136,6 +136,14 @@ namespace Apache.Ignite.Core.Impl.Binary
         public bool RegistrationDisabled { get; set; }
 
         /// <summary>
+        /// Gets force timestamp flag value.
+        /// </summary>
+        public bool ForceTimestamp
+        {
+            get { return _cfg.ForceTimestamp; }
+        }
+
+        /// <summary>
         /// Marshal object.
         /// </summary>
         /// <param name="val">Value.</param>
@@ -375,7 +383,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             {
                 return holder;
             }
-            
+
             lock (this)
             {
                 if (!_metas.TryGetValue(desc.TypeId, out holder))
@@ -393,9 +401,9 @@ namespace Apache.Ignite.Core.Impl.Binary
 
             return holder;
         }
-        
+
         /// <summary>
-        /// Updates or creates cached binary type holder. 
+        /// Updates or creates cached binary type holder.
         /// </summary>
         private void UpdateOrCreateBinaryTypeHolder(BinaryType meta)
         {
@@ -405,7 +413,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                 holder.Merge(meta);
                 return;
             }
-            
+
             lock (this)
             {
                 if (_metas.TryGetValue(meta.TypeId, out holder))
@@ -413,7 +421,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                     holder.Merge(meta);
                     return;
                 }
-                
+
                 var metas0 = new Dictionary<int, BinaryTypeHolder>(_metas);
 
                 holder = new BinaryTypeHolder(meta.TypeId, meta.TypeName, meta.AffinityKeyFieldName, meta.IsEnum, this);
@@ -701,7 +709,10 @@ namespace Apache.Ignite.Core.Impl.Binary
                     return new SerializableSerializer(type);
                 }
 
-                serializer = new BinaryReflectiveSerializer();
+                serializer = new BinaryReflectiveSerializer
+                {
+                    ForceTimestamp = cfg != null && cfg.ForceTimestamp
+                };
             }
 
             var refSerializer = serializer as BinaryReflectiveSerializer;
@@ -876,16 +887,16 @@ namespace Apache.Ignite.Core.Impl.Binary
         {
             if (!clusterRestarted)
                 return;
-            
+
             // Reset all binary structures. Metadata must be sent again.
             // _idToDesc enumerator is thread-safe (returns a snapshot).
             // If there are new descriptors added concurrently, they are fine (we are already connected).
-            
+
             // Race is possible when serialization is started before reconnect (or even before disconnect)
             // and finished after reconnect, meta won't be sent to cluster because it is assumed to be known,
             // but operation will succeed.
             // We don't support this use case. Users should handle reconnect events properly when cluster is restarted.
-            // Supporting this very rare use case will complicate the code a lot with little benefit. 
+            // Supporting this very rare use case will complicate the code a lot with little benefit.
             foreach (var desc in _idToDesc)
             {
                 desc.Value.ResetWriteStructure();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxySerializer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxySerializer.cs
@@ -266,7 +266,7 @@ namespace Apache.Ignite.Core.Impl.Services
                     return (writer, o) => writer.WriteTimestampArray((DateTime?[]) o);
             }
 
-            var handler = BinarySystemHandlers.GetWriteHandler(type);
+            var handler = BinarySystemHandlers.GetWriteHandler(type, true);
 
             if (handler != null)
                 return null;
@@ -279,9 +279,6 @@ namespace Apache.Ignite.Core.Impl.Services
 
             if (arg is ICollection)
                 return (writer, o) => writer.WriteCollection((ICollection) o);
-
-            if (arg is DateTime)
-                return (writer, o) => writer.WriteTimestamp((DateTime) o);
 
             return null;
         }


### PR DESCRIPTION
* Add BinaryConfiguration.ForceTimestamp as an easier way to enable Timestamp mode globally
* Fix BinarySystemHandlers to allow DateTime in Timestamp format as cache key and value