### PR TITLE
GG-32284 .NET: Fix MessagingTest flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -387,7 +387,8 @@ namespace Apache.Ignite.Core.Tests
                 messaging.StopRemoteListen(listenId2);
 
             // Wait for all to unsubscribe: StopRemoteListen (both sync and async) does not remove remote listeners
-            // upon exit. Remote listeners are removed with disco messages after some delay.
+            // upon exit. Remote listeners are removed with disco messages after some delay -
+            // see TestStopRemoteListenRemovesAllCallbacksUponExit.
             TestUtils.AssertHandleRegistryHasItems(
                 timeout: (int)MessagingTestHelper.SleepTimeout.TotalMilliseconds,
                 expectedCount: 1,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -367,6 +367,7 @@ namespace Apache.Ignite.Core.Tests
             else
                 messaging.StopRemoteListen(listenId2);
 
+            // TODO: This is problematic: looks like sometimes we still receive messages from the second listener.
             CheckSend(topic, msg: messaging, remoteListen: true); // back to normal after unsubscription
 
             // Test message type mismatch

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -614,20 +614,22 @@ namespace Apache.Ignite.Core.Tests
         public static void VerifyReceive(IClusterGroup cluster, IEnumerable<string> expectedMessages,
             Func<IEnumerable<string>, IEnumerable<string>> resultFunc, int expectedRepeat)
         {
+            var origMessages = expectedMessages.ToArray();
+            expectedMessages = origMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
+            var expectedMessagesStr = string.Join(", ", expectedMessages);
+
             // check if expected message count has been received; Wait returns false if there were none.
             Assert.IsTrue(ReceivedEvent.Wait(MessageTimeout),
                 string.Format("expectedMessages: {0}, expectedRepeat: {1}, remaining: {2}",
-                    expectedMessages, expectedRepeat, ReceivedEvent.CurrentCount));
+                    expectedMessagesStr, expectedRepeat, ReceivedEvent.CurrentCount));
 
-            var origMessages = expectedMessages.ToArray();
-            expectedMessages = origMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
             var actualMessages = resultFunc(ReceivedMessages).ToArray();
 
             CollectionAssert.AreEqual(
                 expectedMessages,
                 actualMessages,
                 string.Format("Expected messages: '{0}', actual messages: '{1}', expectedRepeat: {2}",
-                    string.Join(", ", expectedMessages),
+                    expectedMessagesStr,
                     string.Join(", ", actualMessages),
                     expectedRepeat));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -714,13 +714,24 @@ namespace Apache.Ignite.Core.Tests
             private readonly string _listenerName;
 
             /** */
-
             public ReceivedMessage(string message, Guid nodeId, int listenerId, string listenerName)
             {
                 _message = message;
                 _nodeId = nodeId;
                 _listenerId = listenerId;
                 _listenerName = listenerName;
+            }
+
+            /** */
+            public string Message
+            {
+                get { return _message; }
+            }
+
+            /** */
+            public Guid NodeId
+            {
+                get { return _nodeId; }
             }
 
             /** <inheritdoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -344,7 +344,7 @@ namespace Apache.Ignite.Core.Tests
         {
             var messaging =_grid1.GetMessaging();
 
-            var listener = MessagingTestHelper.GetListener();
+            var listener = MessagingTestHelper.GetListener("1");
             var listenId = async
                 ? messaging.RemoteListenAsync(listener, topic).Result
                 : messaging.RemoteListen(listener, topic);
@@ -356,7 +356,7 @@ namespace Apache.Ignite.Core.Tests
             CheckNoMessage(NextId());
 
             // Test multiple subscriptions for the same filter
-            var listener2 = MessagingTestHelper.GetListener();
+            var listener2 = MessagingTestHelper.GetListener("2");
             var listenId2 = async
                 ? messaging.RemoteListenAsync(listener2, topic).Result
                 : messaging.RemoteListen(listener2, topic);
@@ -621,11 +621,8 @@ namespace Apache.Ignite.Core.Tests
                 string.Format("expectedMessages: {0}, expectedRepeat: {1}, remaining: {2}",
                     expectedMessagesStr, expectedRepeat, ReceivedEvent.CurrentCount));
 
-            var actualMessages = resultFunc(ReceivedMessages.Select(m => m.Message)).ToArray();
-
-            // check that all messages came from local node.
-            var localNodeId = cluster.Ignite.GetCluster().GetLocalNode().Id;
-            Assert.AreEqual(localNodeId, ReceivedMessages.Select(m => m.NodeId).Distinct().Single());
+            var receivedMessages = ReceivedMessages.ToArray();
+            var actualMessages = resultFunc(receivedMessages.Select(m => m.Message)).ToArray();
 
             CollectionAssert.AreEqual(
                 expectedMessages,
@@ -634,6 +631,10 @@ namespace Apache.Ignite.Core.Tests
                     expectedMessagesStr,
                     string.Join(", ", actualMessages),
                     expectedRepeat));
+
+            // check that all messages came from local node.
+            var localNodeId = cluster.Ignite.GetCluster().GetLocalNode().Id;
+            Assert.AreEqual(localNodeId, ReceivedMessages.Select(m => m.NodeId).Distinct().Single());
 
             AssertFailures();
         }
@@ -728,6 +729,11 @@ namespace Apache.Ignite.Core.Tests
             public string ListenerName
             {
                 get { return _listenerName; }
+            }
+
+            public override string ToString()
+            {
+                return string.Format("ReceivedMessage [{0}, {1}, {2}, {3}]", Message, NodeId, ListenerId, ListenerName);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -30,6 +30,7 @@ namespace Apache.Ignite.Core.Tests
     using Apache.Ignite.Core.Resource;
     using Apache.Ignite.Core.Tests.Cache;
     using NUnit.Framework;
+    using NUnit.Framework.Interfaces;
 
     /// <summary>
     /// <see cref="IMessaging"/> tests.
@@ -88,9 +89,12 @@ namespace Apache.Ignite.Core.Tests
         {
             try
             {
-                TestUtils.AssertHandleRegistryIsEmpty(1000, _grid1, _grid2, _grid3);
+                if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed)
+                {
+                    TestUtils.AssertHandleRegistryIsEmpty(1000, _grid1, _grid2, _grid3);
 
-                MessagingTestHelper.AssertFailures();
+                    MessagingTestHelper.AssertFailures();
+                }
             }
             finally
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -372,7 +372,7 @@ namespace Apache.Ignite.Core.Tests
 
             // TODO: This is problematic: looks like sometimes we still receive messages from the second listener.
             // UPD: this is confirmed: the first message is sometimes from listener "2", but the message is with the new ID.
-            // Therefore, unsubscription did not yet take effect.
+            // Therefore, unsubscription did not yet take effect. This is true for both sync and async StopRemoteListen.
             CheckSend(topic, msg: messaging, remoteListen: true); // back to normal after unsubscription
 
             // Test message type mismatch

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -338,8 +338,7 @@ namespace Apache.Ignite.Core.Tests
         /// upon method exit.
         /// </summary>
         [Test]
-        [Ignore("This test fails: it demonstrates that listeners are not removed upon StopRemoteListen method exit " +
-                "- there is some delay.")]
+        [Ignore("IGNITE-14032")]
         public void TestStopRemoteListenRemovesAllCallbacksUponExit()
         {
             const string topic = "topic";

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -364,11 +364,10 @@ namespace Apache.Ignite.Core.Tests
             else
                 messaging.StopRemoteListen(listenId2);
 
-            Thread.Sleep(MessagingTestHelper.SleepTimeout); // wait for all to unsubscribe
+            // Wait for all to unsubscribe: StopRemoteListen (both sync and async) does not guarantee the subscription
+            // removal upon exit.
+            Thread.Sleep(MessagingTestHelper.SleepTimeout);
 
-            // TODO: This is problematic: looks like sometimes we still receive messages from the second listener.
-            // UPD: this is confirmed: the first message is sometimes from listener "2", but the message is with the new ID.
-            // Therefore, unsubscription did not yet take effect. This is true for both sync and async StopRemoteListen.
             CheckSend(topic, msg: messaging, remoteListen: true); // back to normal after unsubscription
 
             // Test message type mismatch

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -338,6 +338,8 @@ namespace Apache.Ignite.Core.Tests
         /// upon method exit.
         /// </summary>
         [Test]
+        [Ignore("This test fails: it demonstrates that listeners are not removed upon StopRemoteListen method exit " +
+                "- there is some delay.")]
         public void TestStopRemoteListenRemovesAllCallbacksUponExit()
         {
             const string topic = "topic";

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -629,7 +629,7 @@ namespace Apache.Ignite.Core.Tests
                 actualMessages,
                 string.Format("Expected messages: '{0}', actual messages: '{1}', expectedRepeat: {2}",
                     expectedMessagesStr,
-                    string.Join(", ", actualMessages),
+                    string.Join(", ", receivedMessages.Select(x => x.ToString())),
                     expectedRepeat));
 
             // check that all messages came from local node.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -619,10 +619,17 @@ namespace Apache.Ignite.Core.Tests
                 string.Format("expectedMessages: {0}, expectedRepeat: {1}, remaining: {2}",
                     expectedMessages, expectedRepeat, ReceivedEvent.CurrentCount));
 
-            expectedMessages = expectedMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
-            var actualMessages = resultFunc(ReceivedMessages);
+            var origMessages = expectedMessages.ToArray();
+            expectedMessages = origMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
+            var actualMessages = resultFunc(ReceivedMessages).ToArray();
 
-            CollectionAssert.AreEqual(expectedMessages, actualMessages);
+            CollectionAssert.AreEqual(
+                expectedMessages,
+                actualMessages,
+                string.Format("Expected messages: '{0}', actual messages: '{1}', expectedRepeat: {2}",
+                    string.Join(", ", expectedMessages),
+                    string.Join(", ", actualMessages),
+                    expectedRepeat));
 
             // check that all messages came from local node.
             var localNodeId = cluster.Ignite.GetCluster().GetLocalNode().Id;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -363,12 +363,12 @@ namespace Apache.Ignite.Core.Tests
 
             CheckSend(topic, msg: messaging, remoteListen: true, repeatMultiplier: 2); // expect twice the messages
 
-            Console.WriteLine(">>> Unsubscribing");
             if (async)
                 messaging.StopRemoteListenAsync(listenId2).Wait();
             else
                 messaging.StopRemoteListen(listenId2);
-            Console.WriteLine(">>> Unsubscribed");
+
+            Thread.Sleep(MessagingTestHelper.SleepTimeout); // wait for all to unsubscribe
 
             // TODO: This is problematic: looks like sometimes we still receive messages from the second listener.
             // UPD: this is confirmed: the first message is sometimes from listener "2", but the message is with the new ID.
@@ -680,7 +680,6 @@ namespace Apache.Ignite.Core.Tests
             public bool Invoke(Guid nodeId, string message)
             {
                 var receivedMessage = new ReceivedMessage(message, nodeId, GetHashCode(), _name);
-                Console.WriteLine(receivedMessage);
 
                 try
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -346,12 +346,12 @@ namespace Apache.Ignite.Core.Tests
             var messaging =_grid1.GetMessaging();
             var listenId = messaging.RemoteListen(MessagingTestHelper.GetListener("first"), topic);
 
-            TestUtils.AssertHandleRegistryHasItems(timeout: -1, expectedCount: 1, _grid1, _grid2, _grid3);
+            TestUtils.AssertHandleRegistryHasItems(-1, 1, _grid1, _grid2, _grid3);
 
             messaging.Send(1, topic);
             messaging.StopRemoteListen(listenId);
 
-            TestUtils.AssertHandleRegistryHasItems(timeout: -1, expectedCount: 0, _grid1, _grid2, _grid3);
+            TestUtils.AssertHandleRegistryHasItems(-1, 0, _grid1, _grid2, _grid3);
         }
 
         /// <summary>
@@ -389,8 +389,8 @@ namespace Apache.Ignite.Core.Tests
             // upon exit. Remote listeners are removed with disco messages after some delay -
             // see TestStopRemoteListenRemovesAllCallbacksUponExit.
             TestUtils.AssertHandleRegistryHasItems(
-                timeout: (int)MessagingTestHelper.SleepTimeout.TotalMilliseconds,
-                expectedCount: 1,
+                (int)MessagingTestHelper.SleepTimeout.TotalMilliseconds,
+                1,
                 _grid1, _grid2, _grid3);
 
             CheckSend(topic, msg: messaging, remoteListen: true); // back to normal after unsubscription

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -664,8 +664,10 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         public class RemoteListener : IMessageListener<string>
         {
+            /** */
             private readonly string _name;
 
+            /** */
             public RemoteListener(string name)
             {
                 _name = name;
@@ -694,15 +696,24 @@ namespace Apache.Ignite.Core.Tests
             }
         }
 
+        /// <summary>
+        /// Received message data.
+        /// </summary>
         public class ReceivedMessage
         {
+            /** */
             private readonly string _message;
 
+            /** */
             private readonly Guid _nodeId;
 
+            /** */
             private readonly int _listenerId;
 
+            /** */
             private readonly string _listenerName;
+
+            /** */
 
             public ReceivedMessage(string message, Guid nodeId, int listenerId, string listenerName)
             {
@@ -712,29 +723,11 @@ namespace Apache.Ignite.Core.Tests
                 _listenerName = listenerName;
             }
 
-            public string Message
-            {
-                get { return _message; }
-            }
-
-            public Guid NodeId
-            {
-                get { return _nodeId; }
-            }
-
-            public int ListenerId
-            {
-                get { return _listenerId; }
-            }
-
-            public string ListenerName
-            {
-                get { return _listenerName; }
-            }
-
+            /** <inheritdoc /> */
             public override string ToString()
             {
-                return string.Format("ReceivedMessage [{0}, {1}, {2}, {3}]", Message, NodeId, ListenerId, ListenerName);
+                return string.Format(
+                    "ReceivedMessage [{0}, {1}, {2}, {3}]", _message, _nodeId, _listenerId, _listenerName);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -386,7 +386,10 @@ namespace Apache.Ignite.Core.Tests
 
             // Wait for all to unsubscribe: StopRemoteListen (both sync and async) does not remove remote listeners
             // upon exit. Remote listeners are removed with disco messages after some delay.
-            Thread.Sleep(MessagingTestHelper.SleepTimeout);
+            TestUtils.AssertHandleRegistryHasItems(
+                timeout: (int)MessagingTestHelper.SleepTimeout.TotalMilliseconds,
+                expectedCount: 1,
+                _grid1, _grid2, _grid3);
 
             CheckSend(topic, msg: messaging, remoteListen: true); // back to normal after unsubscription
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -30,7 +30,6 @@ namespace Apache.Ignite.Core.Tests
     using Apache.Ignite.Core.Resource;
     using Apache.Ignite.Core.Tests.Cache;
     using NUnit.Framework;
-    using NUnit.Framework.Interfaces;
 
     /// <summary>
     /// <see cref="IMessaging"/> tests.
@@ -89,12 +88,9 @@ namespace Apache.Ignite.Core.Tests
         {
             try
             {
-                if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Passed)
-                {
-                    TestUtils.AssertHandleRegistryIsEmpty(1000, _grid1, _grid2, _grid3);
+                TestUtils.AssertHandleRegistryIsEmpty(1000, _grid1, _grid2, _grid3);
 
-                    MessagingTestHelper.AssertFailures();
-                }
+                MessagingTestHelper.AssertFailures();
             }
             finally
             {
@@ -344,7 +340,7 @@ namespace Apache.Ignite.Core.Tests
         {
             var messaging =_grid1.GetMessaging();
 
-            var listener = MessagingTestHelper.GetListener("1");
+            var listener = MessagingTestHelper.GetListener("first");
             var listenId = async
                 ? messaging.RemoteListenAsync(listener, topic).Result
                 : messaging.RemoteListen(listener, topic);
@@ -356,7 +352,7 @@ namespace Apache.Ignite.Core.Tests
             CheckNoMessage(NextId());
 
             // Test multiple subscriptions for the same filter
-            var listener2 = MessagingTestHelper.GetListener("2");
+            var listener2 = MessagingTestHelper.GetListener("second");
             var listenId2 = async
                 ? messaging.RemoteListenAsync(listener2, topic).Result
                 : messaging.RemoteListen(listener2, topic);
@@ -473,7 +469,7 @@ namespace Apache.Ignite.Core.Tests
             if (sharedResult.Length != 0)
             {
                 Assert.Fail("Unexpected messages ({0}): {1}; last sent message: {2}", sharedResult.Length,
-                    string.Join(",", sharedResult.Select(x => x.Message)), lastMsg);
+                    string.Join(",", sharedResult.Select(x => x.ToString())), lastMsg);
             }
         }
 
@@ -616,8 +612,7 @@ namespace Apache.Ignite.Core.Tests
         public static void VerifyReceive(IClusterGroup cluster, IEnumerable<string> expectedMessages,
             Func<IEnumerable<string>, IEnumerable<string>> resultFunc, int expectedRepeat)
         {
-            var origMessages = expectedMessages.ToArray();
-            expectedMessages = origMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
+            expectedMessages = expectedMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
             var expectedMessagesStr = string.Join(", ", expectedMessages);
 
             // check if expected message count has been received; Wait returns false if there were none.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -368,7 +368,8 @@ namespace Apache.Ignite.Core.Tests
             else
                 messaging.StopRemoteListen(listenId2);
 
-            // TODO: This is problematic: looks like sometimes we still receive messages from the second listener. UPD: Closed flag does not confirm this?
+            // TODO: This is problematic: looks like sometimes we still receive messages from the second listener.
+            // UPD: this is confirmed: the first message is sometimes from listener "2".
             CheckSend(topic, msg: messaging, remoteListen: true); // back to normal after unsubscription
 
             // Test message type mismatch

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/MessagingTest.cs
@@ -615,9 +615,10 @@ namespace Apache.Ignite.Core.Tests
                 string.Format("expectedMessages: {0}, expectedRepeat: {1}, remaining: {2}",
                     expectedMessages, expectedRepeat, ReceivedEvent.CurrentCount));
 
-            expectedMessages = expectedMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat));
+            expectedMessages = expectedMessages.SelectMany(x => Enumerable.Repeat(x, expectedRepeat)).ToArray();
+            var actualMessages = resultFunc(ReceivedMessages);
 
-            Assert.AreEqual(expectedMessages, resultFunc(ReceivedMessages));
+            CollectionAssert.AreEqual(expectedMessages, actualMessages);
 
             // check that all messages came from local node.
             var localNodeId = cluster.Ignite.GetCluster().GetLocalNode().Id;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
@@ -148,7 +148,7 @@ namespace Apache.Ignite.Core.Tests
         private static void Main()
         {
             // TODO: Revert!
-            for (int i = 0; i < 1000; i++)
+            for (int i = 0; i < int.MaxValue; i++)
             {
                 Console.WriteLine(">>> " + i);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
@@ -135,8 +135,6 @@ namespace Apache.Ignite.Core.Tests
 #else
 namespace Apache.Ignite.Core.Tests
 {
-    using System;
-
     /// <summary>
     /// Test runner.
     /// </summary>
@@ -147,15 +145,7 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         private static void Main()
         {
-            for (var i = 0; i < int.MaxValue; i++)
-            {
-                Console.WriteLine(">>> " + i);
-
-                var t = new MessagingTest();
-                t.SetUp();
-                t.TestRemoteListen(false);
-                t.TearDown();
-            }
+            new IgniteStartStopTest().TestStartDefault();
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
@@ -154,7 +154,7 @@ namespace Apache.Ignite.Core.Tests
 
                 var t = new MessagingTest();
                 t.SetUp();
-                t.TestRemoteListen(true);
+                t.TestRemoteListen(false);
                 t.TearDown();
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
@@ -135,6 +135,8 @@ namespace Apache.Ignite.Core.Tests
 #else
 namespace Apache.Ignite.Core.Tests
 {
+    using System;
+
     /// <summary>
     /// Test runner.
     /// </summary>
@@ -145,7 +147,18 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         private static void Main()
         {
-            new IgniteStartStopTest().TestStartDefault();
+            // TODO: Revert!
+            for (int i = 0; i < 1000; i++)
+            {
+                Console.WriteLine(">>> " + i);
+
+                var t = new MessagingTest();
+                t.SetUp();
+                t.TestRemoteListen(true);
+                t.TearDown();
+            }
+
+            Console.WriteLine(">>> END");
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestRunner.cs
@@ -147,8 +147,7 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         private static void Main()
         {
-            // TODO: Revert!
-            for (int i = 0; i < int.MaxValue; i++)
+            for (var i = 0; i < int.MaxValue; i++)
             {
                 Console.WriteLine(">>> " + i);
 
@@ -157,8 +156,6 @@ namespace Apache.Ignite.Core.Tests
                 t.TestRemoteListen(false);
                 t.TearDown();
             }
-
-            Console.WriteLine(">>> END");
         }
     }
 }


### PR DESCRIPTION
* Improve assertions to understand the failures easier
* Add `TestStopRemoteListenRemovesAllCallbacksUponExit` to demonstrate the problem, ignore with a ticket link
* Add `AssertHandleRegistryHasItems` with a delay to fix the flakiness