### PR TITLE
GG-32467 [IGNITE-13957] Fix unnecessary key/val deserialization in GridQueryProcessor

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
@@ -423,7 +423,7 @@ public class QueryTypeDescriptorImpl implements GridQueryTypeDescriptor {
         if (uppercaseProps.put(name.toUpperCase(), prop) != null && failOnDuplicate)
             throw new IgniteCheckedException("Property with upper cased name '" + name + "' already exists.");
 
-        if (prop.notNull()) {
+        if (prop.notNull() && !prop.key() && !prop.name().equals(VAL_FIELD_NAME)) {
             if (validateProps == null)
                 validateProps = new ArrayList<>();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -212,6 +212,33 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 }
             }
         }
+        
+        /// <summary>
+        /// Tests query entity validation when no <see cref="QuerySqlFieldAttribute"/> has been set.
+        /// </summary>
+        [Test]
+        public void TestQueryEntityValidationWithMissingQueryAttributes()
+        {
+            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
+            {
+                var cfg = new CacheConfiguration(
+                    TestUtils.TestName,
+                    new QueryEntity(typeof(string), typeof(MissingAttributesTest)));
+
+                var cache = ignite.GetOrCreateCache<string, MissingAttributesTest>(cfg);
+
+                cache["1"] = new MissingAttributesTest {Foo = "Bar"};
+            }
+        }
+
+        /// <summary>
+        /// Class without any <see cref="QuerySqlFieldAttribute"/> attributes.
+        /// </summary>
+        private class MissingAttributesTest
+        {
+            /** */
+            public string Foo { get; set; }
+        }
 
         /// <summary>
         /// Test person.


### PR DESCRIPTION
Do not add _KEY and _VAL to validateProps when no constraints are defined for them. This restores the behavior that existed before 8.7.19.