### PR TITLE
GG-32476 [IGNITE-13588] .NET: Fix SQL type name for generic query types

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/CacheQueriesCodeConfigurationTest.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Cache.Query;
+    using Apache.Ignite.Core.Impl.Binary;
     using NUnit.Framework;
 
     /// <summary>
@@ -32,6 +33,15 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
     public class CacheQueriesCodeConfigurationTest
     {
         const string CacheName = "personCache";
+
+        /// <summary>
+        /// Tears down the test fixture.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Ignition.StopAll(true);
+        }
 
         /// <summary>
         /// Tests the SQL query.
@@ -146,7 +156,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             Assert.AreEqual(-1, idx[1].InlineSize);
             Assert.AreEqual(513, idx[2].InlineSize);
             Assert.AreEqual(-1, idx[3].InlineSize);
-            
+
             Assert.AreEqual(3, idxField.Precision);
             Assert.AreEqual(4, idxField.Scale);
         }
@@ -212,7 +222,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 }
             }
         }
-        
+
         /// <summary>
         /// Tests query entity validation when no <see cref="QuerySqlFieldAttribute"/> has been set.
         /// </summary>
@@ -229,6 +239,72 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 
                 cache["1"] = new MissingAttributesTest {Foo = "Bar"};
             }
+        }
+
+        /// <summary>
+        /// Tests that key and value types can be generic.
+        /// </summary>
+        [Test]
+        public void TestGenericQueryTypes()
+        {
+            var ignite = Ignition.Start(TestUtils.GetTestConfiguration());
+
+            var cfg = new CacheConfiguration(TestUtils.TestName)
+            {
+                QueryEntities = new[] {new QueryEntity(typeof(GenericTest<int>), typeof(GenericTest2<string>))}
+            };
+
+            var cache = ignite.GetOrCreateCache<GenericTest<int>, GenericTest2<string>>(cfg);
+            var key = new GenericTest<int>(1);
+            var value = new GenericTest2<string>("foo");
+            cache[key] = value;
+
+            var binType = ignite.GetBinary().GetBinaryType(value.GetType());
+            var expectedTypeName = BinaryBasicNameMapper.FullNameInstance.GetTypeName(value.GetType().FullName);
+            var expectedTypeId = BinaryUtils.GetStringHashCodeLowerCase(expectedTypeName);
+
+            Assert.AreEqual(expectedTypeName, binType.TypeName);
+            Assert.AreEqual(expectedTypeId, binType.TypeId);
+
+            var queryEntity = cache.GetConfiguration().QueryEntities.Single();
+            Assert.AreEqual(expectedTypeName, queryEntity.ValueTypeName);
+
+            var tableName = cache.Query(new SqlFieldsQuery(
+                "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
+                .Single().Single(); // The table name is weird, see IGNITE-14064.
+
+            var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Foo, Bar from \"{0}\"", tableName)))
+                .Single();
+
+            Assert.AreEqual(key.Foo, sqlRes[0]);
+            Assert.AreEqual(value.Bar, sqlRes[1]);
+        }
+
+        /// <summary>
+        /// Tests that query types can be nested generic.
+        /// </summary>
+        [Test]
+        public void TestNestedGenericQueryTypes()
+        {
+            var ignite = Ignition.Start(TestUtils.GetTestConfiguration());
+
+            var cfg = new CacheConfiguration(TestUtils.TestName)
+            {
+                QueryEntities = new[] {new QueryEntity(typeof(int), typeof(GenericTest<GenericTest2<string>>))}
+            };
+
+            var cache = ignite.GetOrCreateCache<int, GenericTest<GenericTest2<string>>>(cfg);
+            var value = new GenericTest<GenericTest2<string>>(new GenericTest2<string>("foobar"));
+            cache[1] = value;
+
+            var tableName = cache.Query(new SqlFieldsQuery(
+                    "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA=?", cache.Name))
+                .Single().Single(); // The table name is weird, see IGNITE-14064.
+
+            var sqlRes = cache.Query(new SqlFieldsQuery(string.Format("SELECT Bar from \"{0}\"", tableName)))
+                .Single().Single();
+
+            Assert.AreEqual(value.Foo.Bar, sqlRes);
         }
 
         /// <summary>
@@ -387,6 +463,38 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
             /// </value>
             [QuerySqlField]
             public string Foo { get; set; }
+        }
+
+        /// <summary>
+        /// Generic query type.
+        /// </summary>
+        private class GenericTest<T>
+        {
+            /** */
+            public GenericTest(T foo)
+            {
+                Foo = foo;
+            }
+
+            /** */
+            [QuerySqlField]
+            public T Foo { get; set; }
+        }
+
+        /// <summary>
+        /// Generic query type.
+        /// </summary>
+        private class GenericTest2<T>
+        {
+            /** */
+            public GenericTest2(T bar)
+            {
+                Bar = bar;
+            }
+
+            /** */
+            [QuerySqlField]
+            public T Bar { get; set; }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1529,8 +1529,13 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         public static string GetSqlTypeName(Type type)
         {
-            // SQL always uses simple type name without namespace, parent class, etc.
-            return type.FullName;
+            // Ignite SQL engine always uses simple type name without namespace, parent class, etc -
+            // see QueryUtils.typeName.
+            // GridQueryProcessor.store uses this type name to ensure that we put correct data to the cache:
+            // cacheObjects().typeId(QueryEntity.ValueTypeName) is matched against BinaryObject.typeId.
+            // Additionally, this type name is passed back to UnmanagedCallbacks.BinaryTypeGet to register the
+            // query types on cache start.
+            return BinaryBasicNameMapper.FullNameInstance.GetTypeName(type.AssemblyQualifiedName);
         }
 
         /**


### PR DESCRIPTION
`BinaryUtils.GetSqlTypeName` used to return `Type.FullName`, which includes assembly-qualified type names for all generic type arguments, which causes the following problems:
* SQL type name includes assembly versions, so queries stop working if there is a version change
* Incorrect binary type id is registered through the `UnmanagedCallbacks.BinaryTypeGet`

Remove assembly part from the SQL type name to tolerate version changes in the same way as we do for regular binary types.