### PR TITLE
GG-32643 [IGNITE-14103] .NET: Add thin client automatic binary configuration

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -44,8 +44,11 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     /** Feature for use default query timeout if the qry timeout isn't set explicitly. */
     DEFAULT_QRY_TIMEOUT(6),
 
-    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize */
-    QRY_PARTITIONS_BATCH_SIZE(7);
+    /** Additional SqlFieldsQuery properties: partitions, updateBatchSize. */
+    QRY_PARTITIONS_BATCH_SIZE(7),
+
+    /** Binary configuration retrieval. */
+    BINARY_CONFIGURATION(8);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -28,6 +28,7 @@ import org.apache.ignite.internal.processors.odbc.ClientListenerMessageParser;
 import org.apache.ignite.internal.processors.odbc.ClientListenerRequest;
 import org.apache.ignite.internal.processors.odbc.ClientListenerResponse;
 import org.apache.ignite.internal.processors.odbc.ClientMessage;
+import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryConfigurationGetRequest;
 import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryTypeGetRequest;
 import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryTypeNameGetRequest;
 import org.apache.ignite.internal.processors.platform.client.binary.ClientBinaryTypeNamePutRequest;
@@ -223,6 +224,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
     /** */
     private static final short OP_BINARY_TYPE_PUT = 3003;
 
+    /** */
+    private static final short OP_BINARY_CONFIGURATION_GET = 3004;
+
     /** Start new transaction. */
     private static final short OP_TX_START = 4000;
 
@@ -327,6 +331,9 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
             case OP_BINARY_TYPE_PUT:
                 return new ClientBinaryTypePutRequest(reader);
+
+            case OP_BINARY_CONFIGURATION_GET:
+                return new ClientBinaryConfigurationGetRequest(reader);
 
             case OP_QUERY_SCAN:
                 return new ClientCacheScanQueryRequest(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.binary;
+
+import org.apache.ignite.binary.BinaryBasicNameMapper;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.configuration.BinaryConfiguration;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientRequest;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Binary configuration retrieval request.
+ */
+public class ClientBinaryConfigurationGetRequest extends ClientRequest {
+    /** */
+    private static final byte NAME_MAPPER_BASIC_FULL = 0;
+
+    /** */
+    private static final byte NAME_MAPPER_BASIC_SIMPLE = 1;
+
+    /** */
+    private static final byte NAME_MAPPER_CUSTOM = 2;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientBinaryConfigurationGetRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        BinaryConfiguration cfg = ctx.kernalContext().config().getBinaryConfiguration();
+        boolean compactFooter = cfg == null ? BinaryConfiguration.DFLT_COMPACT_FOOTER : cfg.isCompactFooter();
+        byte nameMapperType = getNameMapperType(cfg);
+
+        return new ClientBinaryConfigurationGetResponse(requestId(), compactFooter, nameMapperType);
+    }
+
+    /**
+     * Gets the binary name mapper type code.
+     * @param cfg Binary configuration.
+     *
+     * @return Mapper type code.
+     */
+    private static byte getNameMapperType(@Nullable BinaryConfiguration cfg) {
+        if (cfg == null || cfg.getNameMapper() == null)
+            return BinaryBasicNameMapper.DFLT_SIMPLE_NAME ? NAME_MAPPER_BASIC_SIMPLE : NAME_MAPPER_BASIC_FULL;
+
+        if (!cfg.getNameMapper().getClass().equals(BinaryBasicNameMapper.class))
+            return NAME_MAPPER_CUSTOM;
+
+        BinaryBasicNameMapper basicNameMapper = (BinaryBasicNameMapper)cfg.getNameMapper();
+
+        return basicNameMapper.isSimpleName() ? NAME_MAPPER_BASIC_SIMPLE : NAME_MAPPER_BASIC_FULL;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/binary/ClientBinaryConfigurationGetResponse.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.binary;
+
+import org.apache.ignite.internal.binary.BinaryRawWriterEx;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Binary meta response.
+ */
+public class ClientBinaryConfigurationGetResponse extends ClientResponse {
+    /** */
+    private final boolean compactFooter;
+
+    /** */
+    private final byte nameMapperType;
+
+    /**
+     * Constructor.
+     * @param requestId Request id.
+     * @param compactFooter Compact footer flag.
+     * @param nameMapperType Name mapper type.
+     */
+    ClientBinaryConfigurationGetResponse(long requestId, boolean compactFooter, byte nameMapperType) {
+        super(requestId);
+
+        this.compactFooter = compactFooter;
+        this.nameMapperType = nameMapperType;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void encode(ClientConnectionContext ctx, BinaryRawWriterEx writer) {
+        super.encode(ctx, writer);
+
+        writer.writeBoolean(compactFooter);
+        writer.writeByte(nameMapperType);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryBasicNameMapper.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryBasicNameMapper.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Core.Impl.Client
-{
-    /// <summary>
-    /// Client feature ids. Values represent the index in the bit array.
-    /// Unsupported flags must be commented out.
-    /// </summary>
-    internal enum ClientBitmaskFeature
-    {
-        // UserAttributes = 0,
-        ExecuteTaskByName = 1,
-        // ClusterStates = 2,
-        ClusterGroupGetNodesEndpoints = 3,
-        ClusterGroups = 4,
-        ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
-        // DefaultQueryTimeout = 6, // IGNITE-13692
-        QueryPartitionsBatchSize = 7,
-        BinaryConfiguration = 8
+package org.apache.ignite.platform;
+
+import org.apache.ignite.binary.BinaryBasicNameMapper;
+
+/**
+ * Custom name mapper for tests.
+ */
+public class PlatformCustomBinaryBasicNameMapper extends BinaryBasicNameMapper {
+    /** {@inheritDoc} */
+    @Override public String typeName(String clsName) {
+        return clsName + "_";
+    }
+
+    /** {@inheritDoc} */
+    @Override public String fieldName(String fieldName) {
+        return fieldName;
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryNameMapper.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformCustomBinaryNameMapper.java
@@ -14,22 +14,21 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Core.Impl.Client
-{
-    /// <summary>
-    /// Client feature ids. Values represent the index in the bit array.
-    /// Unsupported flags must be commented out.
-    /// </summary>
-    internal enum ClientBitmaskFeature
-    {
-        // UserAttributes = 0,
-        ExecuteTaskByName = 1,
-        // ClusterStates = 2,
-        ClusterGroupGetNodesEndpoints = 3,
-        ClusterGroups = 4,
-        ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
-        // DefaultQueryTimeout = 6, // IGNITE-13692
-        QueryPartitionsBatchSize = 7,
-        BinaryConfiguration = 8
+package org.apache.ignite.platform;
+
+import org.apache.ignite.binary.BinaryNameMapper;
+
+/**
+ * Custom name mapper for tests.
+ */
+public class PlatformCustomBinaryNameMapper implements BinaryNameMapper {
+    /** {@inheritDoc} */
+    @Override public String typeName(String clsName) {
+        return clsName + "_";
+    }
+
+    /** {@inheritDoc} */
+    @Override public String fieldName(String fieldName) {
+        return fieldName;
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests.TestDll2/Properties/AssemblyInfo.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests.TestDll2/Properties/AssemblyInfo.cs
@@ -15,7 +15,6 @@
  */
 
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("Apache.Ignite.Core.Tests.TestDll2")]
 [assembly: AssemblyDescription("Apache Ignite.NET Tests Library 2")]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -96,6 +96,12 @@
     <None Update="Config\query-entity-metadata-registration.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\binary-custom-name-mapper.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Config\binary-custom-name-mapper2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
 
   </ItemGroup>
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Cache\Query\QueryEntityMetadataRegistrationTest.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestCodeConfig.cs" />
     <Compile Include="Cache\Store\CacheStoreSessionTestSharedFactory.cs" />
+    <Compile Include="Client\Binary\BinaryConfigurationRetrievalTest.cs" />
     <Compile Include="Client\Cache\ClientQueryEntityMetadataRegistrationTest.cs" />
     <Compile Include="Client\Cache\ClientQueryEntityMetadataRegistrationTestJavaOnlyServer.cs" />
     <Compile Include="Client\Cache\ContinuousQueryTest.cs" />
@@ -439,6 +440,12 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Content Include="Config\binary-custom-name-mapper.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Config\binary-custom-name-mapper2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Config\cache-attribute-node-filter.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Binary/BinaryConfigurationRetrievalTest.cs
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Binary
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using Apache.Ignite.Core.Binary;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Impl.Binary;
+    using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests automatic binary configuration retrieval.
+    /// </summary>
+    public class BinaryConfigurationRetrievalTest
+    {
+        /// <summary>
+        /// Tears down the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="BinaryConfiguration.CompactFooter"/> sets to false on the client when it is false
+        /// on the server.
+        /// </summary>
+        [Test]
+        public void TestCompactFooterDisabledOnServerAutomaticallyDisablesOnClient()
+        {
+            var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    CompactFooter = false
+                }
+            };
+
+            Ignition.Start(serverCfg);
+
+            var logger = GetLogger();
+
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
+            {
+                var resCfg = client.GetConfiguration();
+
+                Assert.IsNotNull(resCfg.BinaryConfiguration);
+                Assert.IsFalse(resCfg.BinaryConfiguration.CompactFooter);
+
+                AssertCompactFooter(client, false);
+
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Server binary configuration retrieved: " +
+                    "BinaryConfigurationClientInternal [CompactFooter=False, NameMapperMode=BasicFull]"
+                    && e.Level == LogLevel.Debug));
+
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "BinaryConfiguration.CompactFooter set to false on client " +
+                    "according to server configuration."));
+
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+            }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="BinaryConfiguration.CompactFooter"/> sets to false on the client when it is false
+        /// on the server.
+        /// </summary>
+        [Test]
+        public void TestCompactFooterEnabledOnServerDisabledOnClientProducesWarning()
+        {
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            var logger = GetLogger();
+
+            var clientConfiguration = new IgniteClientConfiguration(GetClientConfiguration(logger))
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    CompactFooter = false
+                }
+            };
+
+            using (var client = Ignition.StartClient(clientConfiguration))
+            {
+                var resCfg = client.GetConfiguration();
+
+                Assert.IsNotNull(resCfg.BinaryConfiguration);
+                Assert.IsFalse(resCfg.BinaryConfiguration.CompactFooter);
+
+                AssertCompactFooter(client, false);
+
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Server binary configuration retrieved: " +
+                    "BinaryConfigurationClientInternal [CompactFooter=True, NameMapperMode=BasicFull]"
+                    && e.Level == LogLevel.Debug));
+
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "BinaryConfiguration.CompactFooter is true on the server, but false on the client." +
+                    "Consider enabling this setting to reduce cache entry size."
+                    && e.Level == LogLevel.Info));
+
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+            }
+        }
+
+        /// <summary>
+        /// Tests that with default configuration on server and client there is no warnings and no changes at runtime.
+        /// </summary>
+        [Test]
+        public void TestDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
+        {
+            var logger = GetLogger();
+
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
+            {
+                var resCfg = client.GetConfiguration();
+                Assert.IsNull(resCfg.BinaryConfiguration);
+
+                AssertCompactFooter(client, true);
+
+                Assert.AreEqual(1, logger.Entries.Count(e => e.Message == "Server binary configuration " +
+                    "retrieved: BinaryConfigurationClientInternal [CompactFooter=True, NameMapperMode=BasicFull]"));
+
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+            }
+        }
+
+        /// <summary>
+        /// Tests that with explicit default configuration on client there is no warnings and no changes at runtime.
+        /// </summary>
+        [Test]
+        public void TestExplicitDefaultConfigurationDoesNotChangeClientSettingsOrLogWarnings()
+        {
+            var logger = GetLogger();
+            var clientCfg = new IgniteClientConfiguration(GetClientConfiguration(logger))
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    CompactFooter = true,
+                    NameMapper = new BinaryBasicNameMapper
+                    {
+                        IsSimpleName = false
+                    }
+                }
+            };
+
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                var resCfg = client.GetConfiguration().BinaryConfiguration;
+                Assert.IsNotNull(resCfg);
+                Assert.IsTrue(resCfg.CompactFooter);
+                Assert.IsFalse(((BinaryBasicNameMapper)resCfg.NameMapper).IsSimpleName);
+                Assert.IsEmpty(logger.Entries.Where(e => e.Level > LogLevel.Info));
+            }
+        }
+
+        /// <summary>
+        /// Tests that simple/full name mapping mismatch produces a warning.
+        /// </summary>
+        [Test]
+        public void TestBasicNameMapperSettingsMismatchProducesLogWarning()
+        {
+            var logger = GetLogger();
+            var clientCfg = new IgniteClientConfiguration(GetClientConfiguration(logger))
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    NameMapper = new BinaryBasicNameMapper
+                    {
+                        IsSimpleName = true
+                    }
+                }
+            };
+
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                var resCfg = client.GetConfiguration().BinaryConfiguration;
+                Assert.IsNotNull(resCfg);
+                Assert.IsTrue(((BinaryBasicNameMapper)resCfg.NameMapper).IsSimpleName);
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Binary name mapper mismatch: local=BasicSimple, server=BasicFull" &&
+                    e.Level == LogLevel.Warn));
+            }
+        }
+
+        /// <summary>
+        /// Tests that custom mapper on server and default mapper on client results in a warning.
+        /// </summary>
+        [Test]
+        public void TestCustomNameMapperOnServerProducesLogWarning()
+        {
+            var logger = GetLogger();
+
+            var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "binary-custom-name-mapper.xml")
+            };
+
+            Ignition.Start(serverCfg);
+
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
+            {
+                Assert.IsNull(client.GetConfiguration().BinaryConfiguration);
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Binary name mapper mismatch: local=BasicFull, server=Custom" &&
+                    e.Level == LogLevel.Warn));
+            }
+        }
+
+        /// <summary>
+        /// Tests that custom mapper that extends basic name mapper on server and default mapper on client
+        /// results in a warning.
+        /// </summary>
+        [Test]
+        public void TestCustomNameMapperExtendingBasicMapperOnServerProducesLogWarning()
+        {
+            var logger = GetLogger();
+
+            var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "binary-custom-name-mapper2.xml")
+            };
+
+            Ignition.Start(serverCfg);
+
+            using (var client = Ignition.StartClient(GetClientConfiguration(logger)))
+            {
+                Assert.IsNull(client.GetConfiguration().BinaryConfiguration);
+                Assert.AreEqual(1, logger.Entries.Count(e =>
+                    e.Message == "Binary name mapper mismatch: local=BasicFull, server=Custom" &&
+                    e.Level == LogLevel.Warn));
+            }
+        }
+
+        [Test]
+        public void TestCustomNameMapperOnServerAndClientProducesNoLogWarning()
+        {
+            var logger = GetLogger();
+            var clientCfg = new IgniteClientConfiguration(GetClientConfiguration(logger))
+            {
+                BinaryConfiguration = new BinaryConfiguration
+                {
+                    NameMapper = new TestNameMapper()
+                }
+            };
+
+            var serverCfg = new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "binary-custom-name-mapper.xml")
+            };
+
+            Ignition.Start(serverCfg);
+
+            using (var client = Ignition.StartClient(clientCfg))
+            {
+                var resCfg = client.GetConfiguration().BinaryConfiguration;
+                Assert.IsNotNull(resCfg);
+                Assert.IsInstanceOf<TestNameMapper>(resCfg.NameMapper);
+                Assert.AreEqual(0, logger.Entries.Count(e => e.Level > LogLevel.Info));
+            }
+        }
+
+        /// <summary>
+        /// Checks the actual compact footer behavior.
+        /// </summary>
+        private static void AssertCompactFooter(IIgniteClient client, bool expected)
+        {
+            var binObj = (BinaryObject) client.GetBinary().GetBuilder("foo").Build();
+            Assert.AreEqual(expected, binObj.Header.Flags.HasFlag(BinaryObjectHeader.Flag.CompactFooter));
+        }
+
+        /// <summary>
+        /// Gets the logger for tests.
+        /// </summary>
+        private static ListLogger GetLogger()
+        {
+            return new ListLogger(new ConsoleLogger
+            {
+                MinLevel = LogLevel.Trace
+            })
+            {
+                EnabledLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray()
+            };
+        }
+
+        /// <summary>
+        /// Gets the client configuration.
+        /// </summary>
+        private static IgniteClientConfiguration GetClientConfiguration(ListLogger logger)
+        {
+            return new IgniteClientConfiguration(IPAddress.Loopback.ToString())
+            {
+                Logger = logger
+            };
+        }
+
+        /** */
+        private class TestNameMapper : IBinaryNameMapper
+        {
+            /** */
+            public string GetTypeName(string name)
+            {
+                return name + "_";
+            }
+
+            /** */
+            public string GetFieldName(string name)
+            {
+                return name;
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientFeaturesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientFeaturesTest.cs
@@ -66,7 +66,11 @@ namespace Apache.Ignite.Core.Tests.Client
                 .Cast<int>()
                 .Aggregate(0, (a, b) => a | (1 << b));
 
-            Assert.AreEqual(expected, ClientFeatures.AllFeatures.Single());
+            var actual = ClientFeatures.AllFeatures
+                .Select((x, i) => (int) x << i * 8)
+                .Aggregate(0, (a, b) => a | b);
+
+            Assert.AreEqual(expected, actual);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="binaryConfiguration">
+            <bean class="org.apache.ignite.configuration.BinaryConfiguration">
+                <property name="nameMapper">
+                    <bean class="org.apache.ignite.platform.PlatformCustomBinaryNameMapper" />
+                </property>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper2.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/binary-custom-name-mapper2.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+    <bean id="grid.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="binaryConfiguration">
+            <bean class="org.apache.ignite.configuration.BinaryConfiguration">
+                <property name="nameMapper">
+                    <bean class="org.apache.ignite.platform.PlatformCustomBinaryBasicNameMapper" />
+                </property>
+            </bean>
+        </property>
+
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -26,7 +26,6 @@ namespace Apache.Ignite.Core.Tests.Services
     using Apache.Ignite.Core.Cluster;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Impl;
-    using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Resource;
     using Apache.Ignite.Core.Services;
     using NUnit.Framework;
@@ -298,7 +297,7 @@ namespace Apache.Ignite.Core.Tests.Services
 
             // Check err method
             Assert.Throws<ServiceInvocationException>(() => prx.ErrMethod(123));
- 
+
             Assert.AreEqual(42, svc.TestOverload(2, ServicesTypeAutoResolveTest.Emps));
             Assert.AreEqual(3, svc.TestOverload(1, 2));
             Assert.AreEqual(5, svc.TestOverload(3, 2));
@@ -364,7 +363,7 @@ namespace Apache.Ignite.Core.Tests.Services
             // Exception in service.
             ex = Assert.Throws<ServiceInvocationException>(() => prx.ErrMethod(123));
             Assert.AreEqual("ExpectedException", (ex.InnerException ?? ex).Message.Substring(0, 17));
- 
+
             Assert.AreEqual(42, svc.TestOverload(2, ServicesTypeAutoResolveTest.Emps));
             Assert.AreEqual(3, svc.TestOverload(1, 2));
             Assert.AreEqual(5, svc.TestOverload(3, 2));
@@ -989,12 +988,14 @@ namespace Apache.Ignite.Core.Tests.Services
             // Test standard java checked exception.
             Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ThreadInterruptedException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test standard java unchecked exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ArgumentException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
@@ -1005,17 +1006,20 @@ namespace Apache.Ignite.Core.Tests.Services
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test user defined unmapped exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<IgniteException>(ex);
             var javaEx = ex.InnerException as JavaException;
             Assert.IsNotNull(javaEx);
@@ -1145,12 +1149,14 @@ namespace Apache.Ignite.Core.Tests.Services
             // Test standard java checked exception.
             Exception ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("InterruptedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ThreadInterruptedException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test standard java unchecked exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("IllegalArgumentException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<ArgumentException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
@@ -1161,17 +1167,20 @@ namespace Apache.Ignite.Core.Tests.Services
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped1Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestMapped2Exception"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<TestServiceException>(ex);
             Assert.AreEqual("Test", ex.Message);
 
             // Test user defined unmapped exception.
             ex = Assert.Throws<ServiceInvocationException>(() => svc.testException("TestUnmappedException"));
             ex = ex.InnerException;
+            Assert.IsNotNull(ex);
             Assert.IsInstanceOf<IgniteException>(ex);
             var javaEx = ex.InnerException as JavaException;
             Assert.IsNotNull(javaEx);
@@ -1720,7 +1729,7 @@ namespace Apache.Ignite.Core.Tests.Services
                 // No-op.
             }
         }
-
+        
 #if NETCOREAPP
         /// <summary>
         /// Adds support of the local dates to the Ignite timestamp serialization.
@@ -1733,13 +1742,15 @@ namespace Apache.Ignite.Core.Tests.Services
                 if (date.Kind == DateTimeKind.Local)
                     date = date.ToUniversalTime();
 
-                BinaryUtils.ToJavaDate(date, out high, out low);
+                Impl.Binary.BinaryUtils.ToJavaDate(date, out high, out low);
             }
 
             /** <inheritdoc /> */
             public DateTime FromJavaTicks(long high, int low)
             {
-                return new DateTime(BinaryUtils.JavaDateTicks + high * TimeSpan.TicksPerMillisecond + low / 100, DateTimeKind.Utc);
+                return new DateTime(
+                    Impl.Binary.BinaryUtils.JavaDateTicks + high * TimeSpan.TicksPerMillisecond + low / 100,
+                    DateTimeKind.Utc);
             }
         }
 #endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Impl\Cache\Query\IQueryBaseInternal.cs" />
     <Compile Include="Impl\Cache\Query\PlatformCacheQueryCursor.cs" />
     <Compile Include="Impl\Cache\Query\QueryCursorField.cs" />
+    <Compile Include="Impl\Client\Binary\BinaryConfigurationClientInternal.cs" />
+    <Compile Include="Impl\Client\Binary\BinaryNameMapperMode.cs" />
     <Compile Include="Impl\Client\Cache\Query\ClientContinuousQueryHandle.cs" />
     <Compile Include="Impl\Client\ClientBitmaskFeature.cs" />
     <Compile Include="Impl\Client\ClientConnection.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryConfigurationClientInternal.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client.Binary
+{
+    using System.Diagnostics;
+    using Apache.Ignite.Core.Impl.Binary.IO;
+
+    /// <summary>
+    /// Thin client binary configuration.
+    /// </summary>
+    internal class BinaryConfigurationClientInternal
+    {
+        /** */
+        private readonly bool _compactFooter;
+
+        /** */
+        private readonly BinaryNameMapperMode _nameMapperMode;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="BinaryConfigurationClientInternal"/> class.
+        /// </summary>
+        public BinaryConfigurationClientInternal(IBinaryStream stream)
+        {
+            Debug.Assert(stream != null);
+
+            _compactFooter = stream.ReadBool();
+            _nameMapperMode = (BinaryNameMapperMode) stream.ReadByte();
+        }
+
+        /// <summary>
+        /// Gets a flag indicating whether compact footer mode should be used.
+        /// </summary>
+        public bool CompactFooter
+        {
+            get { return _compactFooter; }
+        }
+
+        /// <summary>
+        /// Gets the binary name mapper mode.
+        /// </summary>
+        public BinaryNameMapperMode NameMapperMode
+        {
+            get { return _nameMapperMode; }
+        }
+
+        /** <inheritDoc /> */
+        public override string ToString()
+        {
+            return string.Format("BinaryConfigurationClientInternal [CompactFooter={0}, NameMapperMode={1}]",
+                CompactFooter, NameMapperMode);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryNameMapperMode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Binary/BinaryNameMapperMode.cs
@@ -14,22 +14,28 @@
  * limitations under the License.
  */
 
-namespace Apache.Ignite.Core.Impl.Client
+namespace Apache.Ignite.Core.Impl.Client.Binary
 {
+    using Apache.Ignite.Core.Binary;
+
     /// <summary>
-    /// Client feature ids. Values represent the index in the bit array.
-    /// Unsupported flags must be commented out.
+    /// Represents the binary name mapper mode.
     /// </summary>
-    internal enum ClientBitmaskFeature
+    internal enum BinaryNameMapperMode
     {
-        // UserAttributes = 0,
-        ExecuteTaskByName = 1,
-        // ClusterStates = 2,
-        ClusterGroupGetNodesEndpoints = 3,
-        ClusterGroups = 4,
-        ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
-        // DefaultQueryTimeout = 6, // IGNITE-13692
-        QueryPartitionsBatchSize = 7,
-        BinaryConfiguration = 8
+        /// <summary>
+        /// Default full name mapper, see <see cref="BinaryBasicNameMapper.FullNameInstance"/>.
+        /// </summary>
+        BasicFull = 0,
+
+        /// <summary>
+        /// Simple name mapper, see <see cref="BinaryBasicNameMapper.SimpleNameInstance"/>.
+        /// </summary>
+        BasicSimple = 1,
+
+        /// <summary>
+        /// Custom user-defined mapper.
+        /// </summary>
+        Custom = 2
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -25,10 +25,12 @@ namespace Apache.Ignite.Core.Impl.Client
     using System.Net.Sockets;
     using System.Threading;
     using System.Threading.Tasks;
+    using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
+    using Apache.Ignite.Core.Impl.Client.Binary;
     using Apache.Ignite.Core.Impl.Client.Cache;
     using Apache.Ignite.Core.Impl.Client.Transactions;
     using Apache.Ignite.Core.Impl.Log;
@@ -41,7 +43,7 @@ namespace Apache.Ignite.Core.Impl.Client
     {
         /** Unknown topology version. */
         private const long UnknownTopologyVersion = -1;
-        
+
         /** Underlying socket. */
         private ClientSocket _socket;
 
@@ -128,14 +130,15 @@ namespace Apache.Ignite.Core.Impl.Client
             }
 
             _logger = (_config.Logger ?? NoopLogger.Instance).GetLogger(GetType());
-            
+
             Connect();
+            OnFirstConnect();
         }
 
         /// <summary>
         /// Performs a send-receive operation.
         /// </summary>
-        public T DoOutInOp<T>(ClientOp opId, Action<ClientRequestContext> writeAction, 
+        public T DoOutInOp<T>(ClientOp opId, Action<ClientRequestContext> writeAction,
             Func<ClientResponseContext, T> readFunc,
             Func<ClientStatusCode, string, T> errorFunc = null)
         {
@@ -177,7 +180,7 @@ namespace Apache.Ignite.Core.Impl.Client
         /// <summary>
         /// Performs an async send-receive operation.
         /// </summary>
-        public Task<T> DoOutInOpAsync<T>(ClientOp opId, Action<ClientRequestContext> writeAction, 
+        public Task<T> DoOutInOpAsync<T>(ClientOp opId, Action<ClientRequestContext> writeAction,
             Func<ClientResponseContext, T> readFunc, Func<ClientStatusCode, string, T> errorFunc = null)
         {
             return GetSocket().DoOutInOpAsync(opId, writeAction, readFunc, errorFunc);
@@ -245,7 +248,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 {
                     continue;
                 }
-                
+
                 yield return new ClientConnection(socket.LocalEndPoint, socket.RemoteEndPoint,
                     socket.ServerNodeId.GetValueOrDefault());
             }
@@ -278,7 +281,7 @@ namespace Apache.Ignite.Core.Impl.Client
         private ClientSocket GetAffinitySocket<TKey>(int cacheId, TKey key)
         {
             ThrowIfDisposed();
-            
+
             if (!_config.EnablePartitionAwareness)
             {
                 return null;
@@ -420,7 +423,13 @@ namespace Apache.Ignite.Core.Impl.Client
         private void Connect()
         {
             _socket = GetNextSocket();
+        }
 
+        /// <summary>
+        /// Performs initial checks when the first connection to the cluster has been established.
+        /// </summary>
+        private void OnFirstConnect()
+        {
             if (_config.EnablePartitionAwareness && !_socket.Features.HasOp(ClientOp.CachePartitions))
             {
                 _config.EnablePartitionAwareness = false;
@@ -437,6 +446,48 @@ namespace Apache.Ignite.Core.Impl.Client
                 _enableDiscovery = false;
 
                 _logger.Warn("Automatic server node discovery is not supported by the server");
+            }
+
+            if (_socket.Features.HasFeature(ClientBitmaskFeature.BinaryConfiguration))
+            {
+                var serverBinaryCfg = _socket.DoOutInOp(
+                    ClientOp.BinaryConfigurationGet,
+                    ctx => { },
+                    ctx => new BinaryConfigurationClientInternal(ctx.Reader.Stream));
+
+                _logger.Debug("Server binary configuration retrieved: " + serverBinaryCfg);
+
+                if (serverBinaryCfg.CompactFooter && !_marsh.CompactFooter)
+                {
+                    // Changing from full to compact is not safe: some clients do not support compact footers.
+                    // Log information, but don't change the configuration.
+                    _logger.Info("BinaryConfiguration.CompactFooter is true on the server, but false on the client." +
+                                 "Consider enabling this setting to reduce cache entry size.");
+                }
+
+                if (!serverBinaryCfg.CompactFooter && _marsh.CompactFooter)
+                {
+                    // Changing from compact to full footer is safe, do it automatically.
+                    _marsh.CompactFooter = false;
+
+                    if (_config.BinaryConfiguration == null)
+                    {
+                        _config.BinaryConfiguration = new BinaryConfiguration();
+                    }
+
+                    _config.BinaryConfiguration.CompactFooter = false;
+
+                    _logger.Info("BinaryConfiguration.CompactFooter set to false on client " +
+                                  "according to server configuration.");
+                }
+
+                var localNameMapperMode = GetLocalNameMapperMode();
+
+                if (localNameMapperMode != serverBinaryCfg.NameMapperMode)
+                {
+                    _logger.Warn("Binary name mapper mismatch: local={0}, server={1}",
+                        localNameMapperMode, serverBinaryCfg.NameMapperMode);
+                }
             }
         }
 
@@ -698,7 +749,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 // Dispose and remove any connections not in current topology.
                 var toRemove = new List<Guid>();
-                
+
                 foreach (var pair in map)
                 {
                     if (!_discoveryNodes.ContainsKey(pair.Key))
@@ -738,7 +789,7 @@ namespace Apache.Ignite.Core.Impl.Client
                     }
                 }
             }
-            
+
             _nodeSocketMap = map;
         }
 
@@ -785,7 +836,7 @@ namespace Apache.Ignite.Core.Impl.Client
             {
                 return;
             }
-            
+
             var newVer = GetTopologyVersion();
 
             if (newVer <= _discoveryTopologyVersion)
@@ -799,7 +850,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
             _discoveryTopologyVersion = GetServerEndpoints(
                 _discoveryTopologyVersion, newVer, discoveryNodes);
-            
+
             _discoveryNodes = discoveryNodes;
         }
 
@@ -827,7 +878,7 @@ namespace Apache.Ignite.Core.Impl.Client
                         var id = BinaryUtils.ReadGuid(s);
                         var port = s.ReadInt();
                         var addresses = ctx.Reader.ReadStringCollection();
-                        
+
                         dict[id] = new ClientDiscoveryNode(id, port, addresses);
                     }
 
@@ -837,7 +888,7 @@ namespace Apache.Ignite.Core.Impl.Client
                     {
                         dict.Remove(BinaryUtils.ReadGuid(s));
                     }
-                    
+
                     return topVer;
                 });
         }
@@ -848,8 +899,27 @@ namespace Apache.Ignite.Core.Impl.Client
         private long GetTopologyVersion()
         {
             var ver = _affinityTopologyVersion;
-            
+
             return ver == null ? UnknownTopologyVersion : ((AffinityTopologyVersion) ver).Version;
+        }
+
+        /// <summary>
+        /// Gets the local binary name mapper mode.
+        /// </summary>
+        private BinaryNameMapperMode GetLocalNameMapperMode()
+        {
+            if (_config.BinaryConfiguration == null || _config.BinaryConfiguration.NameMapper == null)
+            {
+                return BinaryNameMapperMode.BasicFull;
+            }
+
+            var basicMapper = _config.BinaryConfiguration.NameMapper as BinaryBasicNameMapper;
+
+            return basicMapper == null
+                ? BinaryNameMapperMode.Custom
+                : basicMapper.IsSimpleName
+                    ? BinaryNameMapperMode.BasicSimple
+                    : BinaryNameMapperMode.BasicFull;
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFeatures.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFeatures.cs
@@ -57,6 +57,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 {ClientOp.ClusterGroupGetNodesEndpoints, ClientBitmaskFeature.ClusterGroupGetNodesEndpoints},
                 {ClientOp.ComputeTaskExecute, ClientBitmaskFeature.ExecuteTaskByName}
             };
+
         /** */
         private readonly ClientProtocolVersion _protocolVersion;
 
@@ -212,14 +213,16 @@ namespace Apache.Ignite.Core.Impl.Client
                 .Cast<int>()
                 .ToArray();
 
-            var bits = new BitArray(values.Max() + 1);
+            var max = values.Max();
+
+            var bits = new BitArray(max + 1);
 
             foreach (var feature in values)
             {
                 bits.Set(feature, true);
             }
 
-            var bytes = new byte[1 + values.Length / 8];
+            var bytes = new byte[1 + max / 8];
             bits.CopyTo(bytes, 0);
 
             return bytes;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
@@ -70,6 +70,7 @@ namespace Apache.Ignite.Core.Impl.Client
         BinaryTypeNamePut = 3001,
         BinaryTypeGet = 3002,
         BinaryTypePut = 3003,
+        BinaryConfigurationGet = 3004,
 
         // Transactions
         TxStart = 4000,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
@@ -101,7 +101,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
             _binProc = _configuration.BinaryProcessor ?? new BinaryProcessorClient(_socket);
 
-            _binary = new Binary(_marsh);
+            _binary = new Impl.Binary.Binary(_marsh);
 
             _cluster = new ClientCluster(this);
 


### PR DESCRIPTION
* Add `OP_BINARY_CONFIGURATION_GET` to the protocol, and `BINARY_CONFIGURATION` feature flag.
* Retrieve the configuration in .NET thin client.
* The only automatic adjustment: change `CompactFooter` from `true` to `false` on the client.
* Log warnings in other cases of configuration mismatch: we can't change name mapper automatically, and we can't enable compact footers automatically, because it can break other clients which don't have compact footer support or rely on a specific name mapping.