### PR TITLE
GG-32699 [IGNITE-12941] .NET: Fix and document single file deployment on .NET 5

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
@@ -86,6 +86,53 @@ namespace Apache.Ignite.Core.Tests
                 "Invalid optimize setting in release mode: ");
         }
 
+        /// <summary>
+        /// Tests that there are no public types in Apache.Ignite.Core.Impl namespace.
+        /// </summary>
+        [Test]
+        public void TestImplNamespaceHasNoPublicTypes()
+        {
+            var excluded = new[]
+            {
+                "ProjectFilesTest.cs", 
+                "CopyOnWriteConcurrentDictionary.cs",
+                "IgniteArgumentCheck.cs",
+                "DelegateConverter.cs",
+                "IgniteHome.cs",
+                "TypeCaster.cs",
+                "FutureType.cs",
+                "CollectionExtensions.cs",
+                "IQueryEntityInternal.cs",
+                "ICacheInternal.cs",
+                "CacheEntry.cs",
+                "HandleRegistry.cs",
+                "BinaryObjectHeader.cs"
+            };
+            
+            var csFiles = TestUtils.GetDotNetSourceDir().GetFiles("*.cs", SearchOption.AllDirectories);
+
+            foreach (var csFile in csFiles)
+            {
+                if (excluded.Contains(csFile.Name))
+                {
+                    continue;
+                }
+
+                var text = File.ReadAllText(csFile.FullName);
+
+                if (!text.Contains("namespace Apache.Ignite.Core.Impl"))
+                {
+                    continue;
+                }
+
+                StringAssert.DoesNotContain("public class", text, csFile.FullName);
+                StringAssert.DoesNotContain("public static class", text, csFile.FullName);
+                StringAssert.DoesNotContain("public interface", text, csFile.FullName);
+                StringAssert.DoesNotContain("public enum", text, csFile.FullName);
+                StringAssert.DoesNotContain("public struct", text, csFile.FullName);
+            }
+        }
+
 #if NETCOREAPP
         /// <summary>
         /// Tests that all .cs files are included in the project.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Impl\Transactions\TransactionRollbackOnlyProxy.cs" />
     <Compile Include="Impl\Transactions\TransactionCollectionImpl.cs" />
     <Compile Include="Impl\Unmanaged\Jni\Jvm.CrossAppDomain.cs" />
+    <Compile Include="Impl\Unmanaged\NativeLibraryUtils.cs" />
     <Compile Include="Impl\Unmanaged\UnmanagedThread.cs" />
     <Compile Include="Log\ConsoleLogger.cs" />
     <Compile Include="Log\IDateTimeProvider.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/DllLoader.cs
@@ -46,6 +46,14 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private const int ERROR_MOD_NOT_FOUND = 126;
 
         /// <summary>
+        /// Initializes the <see cref="DllLoader"/> class.
+        /// </summary>
+        static DllLoader()
+        {
+            NativeLibraryUtils.SetDllImportResolvers();
+        }
+
+        /// <summary>
         /// Loads specified DLL.
         /// </summary>
         /// <returns>Library handle and error message.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/NativeLibraryUtils.cs
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Unmanaged
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    /// <summary>
+    /// Native library call utilities.
+    /// </summary>
+    internal static class NativeLibraryUtils
+    {
+        /** */
+        private static readonly object SyncRoot = new object();
+
+        /** */
+        private static bool _resolversInitialized;
+
+        /// <summary>
+        /// Sets dll import resolvers.
+        /// </summary>
+        public static void SetDllImportResolvers()
+        {
+            lock (SyncRoot)
+            {
+                if (_resolversInitialized)
+                {
+                    return;
+                }
+
+                if (Os.IsLinux)
+                {
+                    SetLibcoreclrResolver();
+                }
+
+                _resolversInitialized = true;
+            }
+        }
+
+        /// <summary>
+        /// Sets dll import resolvers.
+        /// </summary>
+        private static void SetLibcoreclrResolver()
+        {
+            // Init custom resolver for .NET 5+ single-file apps.
+            // Do it with Reflection, because SetDllImportResolver is not available on some frameworks,
+            // and multi-targeting is not yet implemented.
+            //
+            // The code below is equivalent to:
+            // NativeLibrary.SetDllImportResolver(typeof(Ignition).Assembly, (libName, _, _) => Resolve(libName));
+            var dllImportResolverType = Type.GetType("System.Runtime.InteropServices.DllImportResolver");
+            var dllImportSearchPathType = Type.GetType("System.Runtime.InteropServices.DllImportSearchPath");
+            var nativeLibraryType = Type.GetType("System.Runtime.InteropServices.NativeLibrary");
+
+            if (dllImportResolverType == null || dllImportSearchPathType == null || nativeLibraryType == null)
+            {
+                return;
+            }
+
+            var setDllImportResolverMethod = nativeLibraryType.GetMethod("SetDllImportResolver");
+
+            if (setDllImportResolverMethod == null)
+            {
+                return;
+            }
+
+            var libraryName = Expression.Parameter(typeof(string));
+            var assembly = Expression.Parameter(typeof(Assembly));
+            var searchPath = Expression.Parameter(typeof(Nullable<>).MakeGenericType(dllImportSearchPathType));
+
+            Expression<Func<string, IntPtr>> call = lib => Resolve(lib);
+            var resolve = Expression.Invoke(call, libraryName);
+
+            var dllImportResolver = Expression.Lambda(dllImportResolverType, resolve, libraryName, assembly, searchPath);
+            var resolveDelegate = dllImportResolver.Compile();
+
+            setDllImportResolverMethod.Invoke(null, new object[] {typeof(Ignition).Assembly, resolveDelegate});
+        }
+
+        /// <summary>
+        /// Resolves the native library.
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode", Justification = "Reflection")]
+        private static IntPtr Resolve(string libraryName)
+        {
+            return libraryName == "libcoreclr.so"
+                ? (IntPtr) (-1)  // Self-referencing binary.
+                : IntPtr.Zero;   // Skip.
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedThread.cs
@@ -33,6 +33,14 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
         public delegate void ThreadExitCallback(IntPtr threadLocalValue);
 
         /// <summary>
+        /// Initializes the <see cref="UnmanagedThread"/> class.
+        /// </summary>
+        static UnmanagedThread()
+        {
+            NativeLibraryUtils.SetDllImportResolvers();
+        }
+
+        /// <summary>
         /// Sets the thread exit callback, and returns an id to pass to <see cref="EnableCurrentThreadExitEvent"/>.
         /// </summary>
         /// <param name="callbackPtr">
@@ -102,10 +110,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             }
             else if (Os.IsLinux)
             {
-                var res = Os.IsMono 
+                var res = Os.IsMono
                     ? NativeMethodsMono.pthread_key_delete(callbackId)
                     : NativeMethodsLinux.pthread_key_delete(callbackId);
-                
+
                 NativeMethodsLinux.CheckResult(res);
             }
             else
@@ -138,10 +146,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             }
             else if (Os.IsLinux)
             {
-                var res = Os.IsMono 
+                var res = Os.IsMono
                     ? NativeMethodsMono.pthread_setspecific(callbackId, threadLocalValue)
                     : NativeMethodsLinux.pthread_setspecific(callbackId, threadLocalValue);
-                
+
                 NativeMethodsLinux.CheckResult(res);
             }
             else
@@ -219,7 +227,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             [DllImport("libSystem.dylib")]
             public static extern int pthread_setspecific(int key, IntPtr value);
         }
-        
+
         /// <summary>
         /// Mono on Linux requires __Internal instead of libcoreclr.so.
         /// </summary>
@@ -228,7 +236,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Reviewed.")]
             [DllImport("__Internal")]
             public static extern int pthread_key_create(IntPtr key, IntPtr destructorCallback);
-            
+
             [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass", Justification = "Reviewed.")]
             [DllImport("__Internal")]
             public static extern int pthread_key_delete(int key);

--- a/modules/platforms/dotnet/DEVNOTES.txt
+++ b/modules/platforms/dotnet/DEVNOTES.txt
@@ -54,10 +54,10 @@ Getting started:
   dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj
 
 * Run specific test:
+  dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter CacheTest  
+
+* Run a smaller subset of tests - exclude long tests and examples tests:
   dotnet test Apache.Ignite.Core.Tests.DotNetCore.csproj --filter "TestCategory!=LONG_TEST&TestCategory!=EXAMPLES_TEST"
-
-* Run a smaller subset of tests:
-
 
 * IDE: Open Apache.Ignite.DotNetCore.sln
 


### PR DESCRIPTION
Fix `DllNotFoundException: Unable to load shared library 'libcoreclr.so'` error in single file mode on .NET 5 by adding a custom `DllImportResolver`