### PR TITLE
GG-32694 [IGNITE-14173] .NET: Fix partition awareness auto-disable on old servers

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientReconnectCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientReconnectCompatibilityTest.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#if !NETCOREAPP
 namespace Apache.Ignite.Core.Tests.Client.Compatibility
 {
     using System;
@@ -106,4 +105,3 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
         }
     }
 }
-#endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -136,7 +136,9 @@ namespace Apache.Ignite.Core.Tests
         /// </summary>
         public static IgniteClientConfiguration GetClientConfiguration()
         {
-            return new IgniteClientConfiguration("127.0.0.1:" + ClientPort);
+            var endpoint = string.Format("127.0.0.1:{0}..{1}", ClientPort, ClientPort + 5);
+
+            return new IgniteClientConfiguration(endpoint);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -131,8 +131,8 @@ namespace Apache.Ignite.Core.Impl.Client
 
             _logger = (_config.Logger ?? NoopLogger.Instance).GetLogger(GetType());
 
-            Connect();
-            OnFirstConnect();
+            ConnectDefaultSocket();
+            OnFirstConnection();
         }
 
         /// <summary>
@@ -271,7 +271,7 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 if (_socket == null || (_socket.IsDisposed && !_config.ReconnectDisabled))
                 {
-                    Connect();
+                    ConnectDefaultSocket();
                 }
 
                 return _socket;
@@ -418,17 +418,19 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /// <summary>
-        /// Connects the socket.
+        /// Connects the default socket.
         /// </summary>
-        private void Connect()
+        private void ConnectDefaultSocket()
         {
             _socket = GetNextSocket();
+
+            OnNewDefaultConnection();
         }
 
         /// <summary>
-        /// Performs initial checks when the first connection to the cluster has been established.
+        /// Performs feature checks when a new default connection is established.
         /// </summary>
-        private void OnFirstConnect()
+        private void OnNewDefaultConnection()
         {
             if (_config.EnablePartitionAwareness && !_socket.Features.HasOp(ClientOp.CachePartitions))
             {
@@ -447,7 +449,13 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 _logger.Warn("Automatic server node discovery is not supported by the server");
             }
+        }
 
+        /// <summary>
+        /// Performs initial checks when the first connection to the cluster has been established.
+        /// </summary>
+        private void OnFirstConnection()
+        {
             if (_socket.Features.HasFeature(ClientBitmaskFeature.BinaryConfiguration))
             {
                 var serverBinaryCfg = _socket.DoOutInOp(


### PR DESCRIPTION
* Fix failing `TestReconnectToOldNodeDisablesPartitionAwareness`: when thin client reconnects to a new "default" node, and that node does not support partition awareness, the feature should be disabled automatically.
* Enable the test on .NET Core
* Fix compatibility test flakiness: add port range to `JavaServer.GetClientConfiguration`