### PR TITLE
GG-32789 [IGNITE-14243] .NET: Extend ConfigurationManager dependency version range

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientProtocolCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientProtocolCompatibilityTest.cs
@@ -18,7 +18,6 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
 {
     using System;
     using System.Linq;
-    using System.Text.RegularExpressions;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Configuration;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.nuspec
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.nuspec
@@ -16,12 +16,12 @@
  limitations under the License.
 -->
 
-<!-- 
+<!--
 
 Creating NuGet package:
 1) Build Java: mvn clean package -DskipTests -U
 2) Build Apache.Ignite.sln (AnyCPU configuration)
-3) Create package (use csproj instead of nuspec so that template substitution works): 
+3) Create package (use csproj instead of nuspec so that template substitution works):
    nuget pack Apache.Ignite.Core.csproj -Prop Configuration=Release -Prop Platform=AnyCPU
 
 -->
@@ -41,7 +41,7 @@ Creating NuGet package:
         <description>
 GridGain Ignite is a memory-centric distributed database, caching, and processing platform for transactional, analytical, and streaming workloads, delivering in-memory speeds at petabyte scale.
 Supports .NET 4+ and .NET Core 2.0+.
-            
+
 More info: https://docs.gridgain.com/
         </description>
         <copyright>Copyright 2019</copyright>
@@ -52,7 +52,7 @@ More info: https://docs.gridgain.com/
             <!-- Empty section is required to denote supported framework. -->
             <group targetFramework=".NETFramework4.0" />
             <group targetFramework=".NETStandard2.0">
-                <dependency id="System.Configuration.ConfigurationManager" version="[4.6.0, 5.0.0)" />
+                <dependency id="System.Configuration.ConfigurationManager" version="[4.6.0, 7.0.0)" />
             </group>
         </dependencies>
     </metadata>
@@ -73,7 +73,7 @@ More info: https://docs.gridgain.com/
         <file src="..\bin\libs\*.jar" target="build\output\libs" />
         <file src="..\..\..\..\config\java.util.logging.properties" target="build\output\config" />
         <file src="GridGain.Ignite.targets" target="build" />
-    
+
         <!-- LINQPad samples -->
         <file src="NuGet\LINQPad\*.*" target="linqpad-samples" />
 


### PR DESCRIPTION
Test Ignite with recent `System.Configuration.ConfigurationManager` versions (including 6.x preview), and extend supported version range accordingly.