### PR TITLE
GG-32932 CVE-2021-21295 in netty dependency of ignite-cassandra

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -111,7 +111,7 @@
         <checkstyle.puppycrawl.version>8.29</checkstyle.puppycrawl.version>
         <mockito.version>3.4.6</mockito.version>
         <mysql.connector.version>8.0.13</mysql.connector.version>
-        <netty.version>4.1.59.Final</netty.version>
+        <netty.version>4.1.62.Final</netty.version>
         <netlibjava.version>1.1.2</netlibjava.version>
         <oro.bundle.version>2.0.8_6</oro.bundle.version>
         <osgi.core.version>5.0.0</osgi.core.version>


### PR DESCRIPTION
(cherry picked from commit b6a927509216ce520f86aaa86d60296ec1d0688a)