### PR TITLE
GG-33143 [IGNITE-14644] .NET: Log a warning about COMPlus_EnableAlternateStackCheck

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
@@ -65,11 +65,18 @@ namespace Apache.Ignite.Core
         /// </summary>
         public const string ClientConfigurationSectionName = "igniteClientConfiguration";
 
+        /// <summary>
+        /// Environment variable name to enable alternate stack checks on .NET Core 3+ and .NET 5+.
+        /// This is required to fix "Stack smashing detected" errors that occur instead of NullReferenceException
+        /// on Linux and macOS when Java overwrites SIGSEGV handler installed by .NET in thick client or server mode.
+        /// </summary>
+        private const string EnvEnableAlternateStackCheck = "COMPlus_EnableAlternateStackCheck";
+
         /** */
         private static readonly object SyncRoot = new object();
 
         /** GC warning flag. */
-        private static int _gcWarn;
+        private static int _diagPrinted;
 
         /** */
         private static readonly IDictionary<NodeKey, Ignite> Nodes = new Dictionary<NodeKey, Ignite>();
@@ -242,8 +249,8 @@ namespace Apache.Ignite.Core
 
                 log.Debug("Starting Ignite.NET " + Assembly.GetExecutingAssembly().GetName().Version);
 
-                // 1. Check GC settings.
-                CheckServerGc(cfg, log);
+                // 1. Log diagnostics.
+                LogDiagnosticMessages(cfg, log);
 
                 // 2. Create context.
                 JvmDll.Load(cfg.JvmDllPath, log);
@@ -336,16 +343,31 @@ namespace Apache.Ignite.Core
         }
 
         /// <summary>
-        /// Check whether GC is set to server mode.
+        /// Performs system checks and logs diagnostic messages.
         /// </summary>
         /// <param name="cfg">Configuration.</param>
         /// <param name="log">Log.</param>
-        private static void CheckServerGc(IgniteConfiguration cfg, ILogger log)
+        private static void LogDiagnosticMessages(IgniteConfiguration cfg, ILogger log)
         {
-            if (!cfg.SuppressWarnings && !GCSettings.IsServerGC && Interlocked.CompareExchange(ref _gcWarn, 1, 0) == 0)
-                log.Warn("GC server mode is not enabled, this could lead to less " +
-                    "than optimal performance on multi-core machines (to enable see " +
-                    "http://msdn.microsoft.com/en-us/library/ms229357(v=vs.110).aspx).");
+            if (!cfg.SuppressWarnings &&
+                Interlocked.CompareExchange(ref _diagPrinted, 1, 0) == 0)
+            {
+                if (!GCSettings.IsServerGC)
+                {
+                    log.Warn("GC server mode is not enabled, this could lead to less " +
+                             "than optimal performance on multi-core machines (to enable see " +
+                             "https://docs.microsoft.com/en-us/dotnet/core/run-time-config/garbage-collector).");
+                }
+
+                if ((Os.IsLinux || Os.IsMacOs) &&
+                    Environment.GetEnvironmentVariable(EnvEnableAlternateStackCheck) != "1")
+                {
+                    log.Warn("Alternate stack check is not enabled, this will cause 'Stack smashing detected' " +
+                             "error when NullReferenceException occurs on .NET Core on Linux and macOS. " +
+                             "To enable alternate stack check on .NET Core 3+ and .NET 5+, " +
+                             "set {0} environment variable to 1.", EnvEnableAlternateStackCheck);
+                }
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
On Linux, Java overwrites SIGSEGV handler installed by .NET, so NullReferenceException causes a confusing "Stack smashing detected" error. This can be fixed by setting COMPlus_EnableAlternateStackCheck environment variable. Log a warning to raise user awareness.