### PR TITLE
GG-33213: Update ODBC version, fix old timestamp handling

### DIFF
--- a/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
@@ -51,15 +51,6 @@ namespace ignite
         IGNITE_IMPORT_EXPORT bool IgniteGmTime(time_t in, tm& out);
 
         /**
-         * Convert time_t to struct tm (Local time).
-         *
-         * @param in Standard C type time_t value.
-         * @param out Standard C type struct tm value.
-         * @return True on success.
-         */
-        IGNITE_IMPORT_EXPORT bool IgniteLocalTime(time_t in, tm& out);
-
-        /**
          * Read system environment variable taking thread-safety in count.
          *
          * @param name Environment variable name.

--- a/modules/platforms/cpp/common/include/ignite/common/utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/utils.h
@@ -383,22 +383,6 @@ namespace ignite
             int day = 1, int hour = 0, int min = 0, int sec = 0);
 
         /**
-         * Make Date in human understandable way.
-         *
-         * Created Date uses local timezone.
-         *
-         * @param year Year.
-         * @param month Month.
-         * @param day Day.
-         * @param hour Hour.
-         * @param min Min.
-         * @param sec Sec.
-         * @return Date.
-         */
-        IGNITE_FRIEND_EXPORT Date MakeDateLocal(int year = 1900, int month = 1,
-            int day = 1, int hour = 0, int min = 0, int sec = 0);
-
-        /**
          * Make Time in human understandable way.
          *
          * Created Time uses GMT timezone.
@@ -409,18 +393,6 @@ namespace ignite
          * @return Time.
          */
         IGNITE_FRIEND_EXPORT Time MakeTimeGmt(int hour = 0, int min = 0, int sec = 0);
-
-        /**
-         * Make Time in human understandable way.
-         *
-         * Created Time uses Local timezone.
-         *
-         * @param hour Hour.
-         * @param min Minute.
-         * @param sec Second.
-         * @return Time.
-         */
-        IGNITE_FRIEND_EXPORT Time MakeTimeLocal(int hour = 0, int min = 0, int sec = 0);
 
         /**
          * Make Timestamp in human understandable way.
@@ -437,23 +409,6 @@ namespace ignite
          * @return Timestamp.
          */
         IGNITE_FRIEND_EXPORT Timestamp MakeTimestampGmt(int year = 1900, int month = 1,
-            int day = 1, int hour = 0, int min = 0, int sec = 0, long ns = 0);
-
-        /**
-         * Make Date in human understandable way.
-         *
-         * Created Timestamp uses Local timezone.
-         *
-         * @param year Year.
-         * @param month Month.
-         * @param day Day.
-         * @param hour Hour.
-         * @param min Minute.
-         * @param sec Second.
-         * @param ns Nanosecond.
-         * @return Timestamp.
-         */
-        IGNITE_FRIEND_EXPORT Timestamp MakeTimestampLocal(int year = 1900, int month = 1,
             int day = 1, int hour = 0, int min = 0, int sec = 0, long ns = 0);
 
         /**

--- a/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
@@ -50,11 +50,6 @@ namespace ignite
             return gmtime_r(&in, &out) != NULL;
         }
 
-        bool IgniteLocalTime(time_t in, tm& out)
-        {
-            return localtime_r(&in, &out) == 0;
-        }
-
         std::string GetEnv(const std::string& name)
         {
             static const std::string empty;

--- a/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
@@ -24,13 +24,30 @@
 // Original code is suggested by MSDN at
 // https://docs.microsoft.com/en-us/windows/win32/sysinfo/converting-a-time-t-value-to-a-file-time
 // Modified to fit larger time values
-void TimetToFileTime(time_t tt, LPFILETIME pft)
+void TimeToFileTime(time_t tt, FILETIME& ft)
 {
     ULARGE_INTEGER uli;
     uli.QuadPart = tt * 10000000 + 116444736000000000LL;
 
-    pft->dwLowDateTime = uli.LowPart;
-    pft->dwHighDateTime = uli.HighPart;
+    ft.dwLowDateTime = uli.LowPart;
+    ft.dwHighDateTime = uli.HighPart;
+}
+
+bool SystemTimeToTime(const SYSTEMTIME& sysTime, time_t& tt)
+{
+    FILETIME ft;
+    if (!SystemTimeToFileTime(&sysTime, &ft))
+        return false;
+
+    ULARGE_INTEGER uli;
+    uli.LowPart = ft.dwLowDateTime;
+    uli.HighPart = ft.dwHighDateTime;
+
+    long long sli = static_cast<long long>(uli.QuadPart);
+
+    tt = static_cast<time_t>((sli - 116444736000000000LL) / 10000000);
+
+    return true;
 }
 
 namespace ignite
@@ -39,29 +56,29 @@ namespace ignite
     {
         time_t IgniteTimeGm(const tm& time)
         {
-            tm tmc = time;
+            SYSTEMTIME sysTime;
+            memset(&sysTime, 0, sizeof(sysTime));
 
-            return _mkgmtime(&tmc);
-        }
+            sysTime.wYear = time.tm_year + 1900;
+            sysTime.wMonth = time.tm_mon + 1;
+            sysTime.wDay = time.tm_mday;
+            sysTime.wHour = time.tm_hour;
+            sysTime.wMinute = time.tm_min;
+            sysTime.wSecond = time.tm_sec;
 
-        time_t IgniteTimeLocal(const tm& time)
-        {
-            tm tmc = time;
+            time_t res;
+            SystemTimeToTime(sysTime, res);
 
-            return mktime(&tmc);
+            return res;
         }
 
         bool IgniteGmTime(time_t in, tm& out)
         {
             FILETIME fileTime;
-            TimetToFileTime(in, &fileTime);
-
-            SYSTEMTIME localTime;
-            if (!FileTimeToSystemTime(&fileTime, &localTime))
-                return false;
+            TimeToFileTime(in, fileTime);
 
             SYSTEMTIME systemTime;
-            if (!SystemTimeToTzSpecificLocalTime(NULL, &localTime, &systemTime))
+            if (!FileTimeToSystemTime(&fileTime, &systemTime))
                 return false;
 
             out.tm_year = systemTime.wYear - 1900;
@@ -70,24 +87,6 @@ namespace ignite
             out.tm_hour = systemTime.wHour;
             out.tm_min = systemTime.wMinute;
             out.tm_sec = systemTime.wSecond;
-
-            return true;
-        }
-
-        bool IgniteLocalTime(time_t in, tm& out)
-        {            FILETIME fileTime;
-            TimetToFileTime(in, &fileTime);
-
-            SYSTEMTIME localTime;
-            if (!FileTimeToSystemTime(&fileTime, &localTime))
-                return false;
-
-            out.tm_year = localTime.wYear - 1900;
-            out.tm_mon = localTime.wMonth - 1;
-            out.tm_mday = localTime.wDay;
-            out.tm_hour = localTime.wHour;
-            out.tm_min = localTime.wMinute;
-            out.tm_sec = localTime.wSecond;
 
             return true;
         }

--- a/modules/platforms/cpp/common/src/common/utils.cpp
+++ b/modules/platforms/cpp/common/src/common/utils.cpp
@@ -103,25 +103,6 @@ namespace ignite
             return CTmToDate(date);
         }
 
-        IGNITE_FRIEND_EXPORT Date MakeDateLocal(int year, int month, int day, int hour,
-            int min, int sec)
-        {
-            tm date;
-
-            std::memset(&date, 0, sizeof(date));
-
-            date.tm_year = year - 1900;
-            date.tm_mon = month - 1;
-            date.tm_mday = day;
-            date.tm_hour = hour;
-            date.tm_min = min;
-            date.tm_sec = sec;
-
-            time_t localTime = common::IgniteTimeLocal(date);
-
-            return CTimeToDate(localTime);
-        }
-
         IGNITE_FRIEND_EXPORT Time MakeTimeGmt(int hour, int min, int sec)
         {
             tm date;
@@ -136,24 +117,6 @@ namespace ignite
             date.tm_sec = sec;
 
             return CTmToTime(date);
-        }
-
-        IGNITE_FRIEND_EXPORT Time MakeTimeLocal(int hour, int min, int sec)
-        {
-            tm date;
-
-            std::memset(&date, 0, sizeof(date));
-
-            date.tm_year = 70;
-            date.tm_mon = 0;
-            date.tm_mday = 1;
-            date.tm_hour = hour;
-            date.tm_min = min;
-            date.tm_sec = sec;
-
-            time_t localTime = common::IgniteTimeLocal(date);
-
-            return CTimeToTime(localTime);
         }
 
         IGNITE_FRIEND_EXPORT Timestamp MakeTimestampGmt(int year, int month, int day,
@@ -171,25 +134,6 @@ namespace ignite
             date.tm_sec = sec;
 
             return CTmToTimestamp(date, ns);
-        }
-
-        IGNITE_FRIEND_EXPORT Timestamp MakeTimestampLocal(int year, int month, int day,
-            int hour, int min, int sec, long ns)
-        {
-            tm date;
-
-            std::memset(&date, 0, sizeof(date));
-
-            date.tm_year = year - 1900;
-            date.tm_mon = month - 1;
-            date.tm_mday = day;
-            date.tm_hour = hour;
-            date.tm_min = min;
-            date.tm_sec = sec;
-
-            time_t localTime = common::IgniteTimeLocal(date);
-
-            return CTimeToTimestamp(localTime, ns);
         }
 
         IGNITE_IMPORT_EXPORT std::string GetDynamicLibraryName(const char* name)

--- a/modules/platforms/cpp/core-test/src/date_time_test.cpp
+++ b/modules/platforms/cpp/core-test/src/date_time_test.cpp
@@ -261,22 +261,35 @@ BOOST_AUTO_TEST_CASE(CastTimeToTm)
 
 BOOST_AUTO_TEST_CASE(CastDateToTm)
 {
+    CheckDate(1850, 3, 20);
+    CheckDate(1900, 1, 1);
+    CheckDate(1969, 12, 31);
+    CheckDate(1970, 1, 1);
+    CheckDate(1970, 3, 20);
     CheckDate(2024, 8, 5);
     CheckDate(1987, 1, 1);
     CheckDate(1999, 2, 18);
     CheckDate(1997, 12, 9);
     CheckDate(2007, 12, 31);
     CheckDate(2001, 6, 21);
+    CheckDate(2521, 1, 1);
+    CheckDate(2521, 3, 20);
 }
 
 BOOST_AUTO_TEST_CASE(CastTimestampToTm)
 {
+    CheckTimestamp(1850, 3, 20, 18, 43, 19, 170038645);
+    CheckTimestamp(1900, 1, 1, 0, 0, 0, 0);
+    CheckTimestamp(1969, 12, 31, 23, 59, 59, 999999999);
     CheckTimestamp(1970, 1, 1, 0, 0, 0, 0);
+    CheckTimestamp(1970, 3, 20, 18, 43, 19, 170038645);
     CheckTimestamp(2000, 12, 31, 23, 59, 59, 999999999);
     CheckTimestamp(2001, 9, 9, 1, 46, 39, 999999999);
     CheckTimestamp(2017, 3, 20, 18, 43, 19, 170038645);
     CheckTimestamp(2007, 12, 31, 19, 24, 44, 894375963);
     CheckTimestamp(2001, 6, 21, 13, 53, 2, 25346547);
+    CheckTimestamp(2521, 1, 1, 0, 0, 0, 0);
+    CheckTimestamp(2521, 3, 20, 18, 43, 19, 170038645);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/odbc-test/src/sql_get_info_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/sql_get_info_test.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(TestValues)
 
     CheckStrInfo(SQL_DRIVER_NAME, "Apache Ignite");
     CheckStrInfo(SQL_DBMS_NAME, "Apache Ignite");
-    CheckStrInfo(SQL_DRIVER_ODBC_VER, "03.00");
+    CheckStrInfo(SQL_DRIVER_ODBC_VER, "03.50");
     CheckStrInfo(SQL_DRIVER_VER, "02.04.0000");
     CheckStrInfo(SQL_DBMS_VER, "02.04.0000");
     CheckStrInfo(SQL_COLUMN_ALIAS, "Y");

--- a/modules/platforms/cpp/odbc-test/src/sql_types_test.cpp
+++ b/modules/platforms/cpp/odbc-test/src/sql_types_test.cpp
@@ -404,7 +404,7 @@ BOOST_AUTO_TEST_CASE(TestFetchLiteralTime)
 
 BOOST_AUTO_TEST_CASE(TestFetchLiteralTimeLegacy)
 {
-    FetchAndCheckTime(stmt, "select TIME '12:42:13'", SQL_C_TYPE_TIME);
+    FetchAndCheckTime(stmt, "select TIME '12:42:13'", SQL_C_TIME);
 }
 
 BOOST_AUTO_TEST_CASE(TestFetchFieldTimeAsIs)
@@ -425,6 +425,66 @@ BOOST_AUTO_TEST_CASE(TestFetchFieldTimeAsIsLegacy)
     testCache.Put(1, val1);
 
     FetchAndCheckTime(stmt, "select timeField from TestType", SQL_C_TIME);
+}
+
+void FetchAndCheckTimestamp(SQLHSTMT stmt, int year, int mon, int day, int hour, int mmin, int sec)
+{
+    std::stringstream reqStream;
+
+    reqStream << "select TIMESTAMP '"
+        << year << "-"
+        << mon << "-"
+        << day << " "
+        << hour << ":"
+        << mmin << ":"
+        << sec << "'";
+
+    std::string req = reqStream.str();
+
+    std::vector<SQLCHAR> req0(req.begin(), req.end());
+    req0.push_back(0);
+
+    SQLExecDirect(stmt, &req0[0], SQL_NTS);
+
+    SQL_TIMESTAMP_STRUCT res;
+
+    memset(&res, 0, sizeof(res));
+
+    SQLLEN resLen = 0;
+    SQLRETURN ret = SQLBindCol(stmt, 1, SQL_C_TYPE_TIMESTAMP, &res, 0, &resLen);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    ret = SQLFetch(stmt);
+
+    if (!SQL_SUCCEEDED(ret))
+        BOOST_FAIL(GetOdbcErrorMessage(SQL_HANDLE_STMT, stmt));
+
+    BOOST_CHECK_EQUAL(res.year,   year);
+    BOOST_CHECK_EQUAL(res.month,  mon);
+    BOOST_CHECK_EQUAL(res.day,    day);
+    BOOST_CHECK_EQUAL(res.hour,   hour);
+    BOOST_CHECK_EQUAL(res.minute, mmin);
+    BOOST_CHECK_EQUAL(res.second, sec);
+
+    SQLCloseCursor(stmt);
+}
+
+BOOST_AUTO_TEST_CASE(TestFetchLiteralTimestamp)
+{
+    FetchAndCheckTimestamp(stmt, 1850, 3, 20, 18, 43, 19);
+    FetchAndCheckTimestamp(stmt, 1900, 1, 1, 0, 0, 0);
+    FetchAndCheckTimestamp(stmt, 1969, 12, 31, 23, 59, 59);
+    FetchAndCheckTimestamp(stmt, 1970, 1, 1, 0, 0, 0);
+    FetchAndCheckTimestamp(stmt, 1970, 3, 20, 18, 43, 19);
+    FetchAndCheckTimestamp(stmt, 2000, 12, 31, 23, 59, 59);
+    FetchAndCheckTimestamp(stmt, 2001, 9, 9, 1, 46, 39);
+    FetchAndCheckTimestamp(stmt, 2017, 3, 20, 18, 43, 19);
+    FetchAndCheckTimestamp(stmt, 2007, 12, 31, 19, 24, 44);
+    FetchAndCheckTimestamp(stmt, 2001, 6, 21, 13, 53, 2);
+    FetchAndCheckTimestamp(stmt, 2521, 1, 1, 0, 0, 0);
+    FetchAndCheckTimestamp(stmt, 2521, 3, 20, 18, 43, 19);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/odbc/src/config/connection_info.cpp
+++ b/modules/platforms/cpp/odbc/src/config/connection_info.cpp
@@ -597,7 +597,7 @@ namespace ignite
 
                 // ODBC version.
 #ifdef SQL_DRIVER_ODBC_VER
-                strParams[SQL_DRIVER_ODBC_VER] = "03.00";
+                strParams[SQL_DRIVER_ODBC_VER] = "03.50";
 #endif // SQL_DRIVER_ODBC_VER
 
 #ifdef SQL_DRIVER_VER


### PR DESCRIPTION
PR fixes several issues:
1. Issue with the reading of GUID fields with Windows Driver Manager. Fixed by increase of the SQL_DRIVER_ODBC_VER
2. Issue with negative timestamps (timestamps older than UNIX epoch, i.e. 1970). Fixed by switching from `gmtime` to WinAPI.
3. Flakiness of TestWal test