### PR TITLE
GG-33301 [IGNITE-14187] .NET: Add thin client DataStreamer

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastreamer/DataStreamerImpl.java
@@ -588,8 +588,6 @@ public class DataStreamerImpl<K, V> implements IgniteDataStreamer<K, V>, Delayed
     @Override public IgniteFuture<?> addData(Collection<? extends Map.Entry<K, V>> entries) {
         A.notEmpty(entries, "entries");
 
-        checkSecurityPermission(SecurityPermission.CACHE_PUT);
-
         Collection<DataStreamerEntry> batch = new ArrayList<>(entries.size());
 
         for (Map.Entry<K, V> entry : entries) {
@@ -633,6 +631,8 @@ public class DataStreamerImpl<K, V> implements IgniteDataStreamer<K, V>, Delayed
      * @return Future.
      */
     public IgniteFuture<?> addDataInternal(Collection<? extends DataStreamerEntry> entries, boolean useThreadBuffer) {
+        checkSecurityPermissions(entries);
+
         IgniteCacheFutureImpl fut = null;
 
         GridFutureAdapter internalFut = null;
@@ -737,11 +737,6 @@ public class DataStreamerImpl<K, V> implements IgniteDataStreamer<K, V>, Delayed
     /** {@inheritDoc} */
     @Override public IgniteFuture<?> addData(K key, V val) {
         A.notNull(key, "key");
-
-        if (val == null)
-            checkSecurityPermission(SecurityPermission.CACHE_REMOVE);
-        else
-            checkSecurityPermission(SecurityPermission.CACHE_PUT);
 
         KeyCacheObject key0 = cacheObjProc.toCacheKeyObject(cacheObjCtx, null, key, true);
         CacheObject val0 = cacheObjProc.toCacheObject(cacheObjCtx, val, true);
@@ -1452,17 +1447,37 @@ public class DataStreamerImpl<K, V> implements IgniteDataStreamer<K, V>, Delayed
     }
 
     /**
-     * Check permissions for streaming.
+     * Checks permissions for specified entries.
      *
-     * @param perm Security permission.
+     * @param entries Streamer entries.
      * @throws org.apache.ignite.plugin.security.SecurityException If permissions are not enough for streaming.
      */
-    private void checkSecurityPermission(SecurityPermission perm)
-        throws org.apache.ignite.plugin.security.SecurityException {
+    private void checkSecurityPermissions(Collection<? extends DataStreamerEntry> entries)
+            throws org.apache.ignite.plugin.security.SecurityException {
         if (!ctx.security().enabled())
             return;
 
-        ctx.security().authorize(cacheName, perm);
+        boolean add = false;
+        boolean remove = false;
+
+        for (DataStreamerEntry e : entries) {
+            if (e.val == null) {
+                remove = true;
+            }
+            else {
+                add = true;
+            }
+
+            if (add && remove) {
+                break;
+            }
+        }
+
+        if (add)
+            ctx.security().authorize(cacheName, SecurityPermission.CACHE_PUT);
+
+        if (remove)
+            ctx.security().authorize(cacheName, SecurityPermission.CACHE_REMOVE);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -78,6 +78,8 @@ import org.apache.ignite.internal.processors.platform.client.cluster.ClientClust
 import org.apache.ignite.internal.processors.platform.client.cluster.ClientClusterWalGetStateRequest;
 import org.apache.ignite.internal.processors.platform.client.compute.ClientExecuteTaskRequest;
 import org.apache.ignite.internal.processors.platform.client.service.ClientServiceInvokeRequest;
+import org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerAddDataRequest;
+import org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerStartRequest;
 import org.apache.ignite.internal.processors.platform.client.tx.ClientTxEndRequest;
 import org.apache.ignite.internal.processors.platform.client.tx.ClientTxStartRequest;
 
@@ -264,6 +266,13 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
     /** Service invocation. */
     private static final short OP_SERVICE_INVOKE = 7000;
+
+    /** Data streamers. */
+    /** */
+    private static final short OP_DATA_STREAMER_START = 8000;
+
+    /** */
+    private static final short OP_DATA_STREAMER_ADD_DATA = 8001;
 
     /* Custom queries working through processors registry. */
     private static final short OP_CUSTOM_QUERY = 32_000;
@@ -478,6 +487,12 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
             case OP_SERVICE_INVOKE:
                 return new ClientServiceInvokeRequest(reader);
+
+            case OP_DATA_STREAMER_START:
+                return new ClientDataStreamerStartRequest(reader);
+
+            case OP_DATA_STREAMER_ADD_DATA:
+                return new ClientDataStreamerAddDataRequest(reader);
 
             case OP_CUSTOM_QUERY:
                 return new ClientCustomQueryRequest(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientRequestHandler.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.internal.processors.platform.client;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteIllegalStateException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProtocolVersion;
@@ -105,8 +106,7 @@ public class ClientRequestHandler implements ClientListenerRequestHandler {
         assert req != null;
         assert e != null;
 
-        int status = e instanceof IgniteClientException ?
-            ((IgniteClientException)e).statusCode() : ClientStatus.FAILED;
+        int status = getStatus(e);
 
         return new ClientResponse(req.requestId(), status, e.getMessage());
     }
@@ -145,5 +145,32 @@ public class ClientRequestHandler implements ClientListenerRequestHandler {
     /** {@inheritDoc} */
     @Override public ClientListenerProtocolVersion protocolVersion() {
         return protocolCtx.version();
+    }
+
+    /**
+     * Gets the status based on the provided exception.
+     *
+     * @param e Exception.
+     * @return Status code.
+     */
+    private int getStatus(Throwable e) {
+        if (e instanceof IgniteClientException)
+            return ((IgniteClientException) e).statusCode();
+
+        if (e instanceof IgniteIllegalStateException) {
+            IgniteIllegalStateException ex = (IgniteIllegalStateException) e;
+
+            if (ex.getMessage().startsWith("Grid is in invalid state"))
+                return ClientStatus.INVALID_NODE_STATE;
+        }
+
+        if (e instanceof IllegalStateException) {
+            IllegalStateException ex = (IllegalStateException) e;
+
+            if (ex.getMessage().contains("grid is stopping"))
+                return ClientStatus.INVALID_NODE_STATE;
+        }
+
+        return ClientStatus.FAILED;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientStatus.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientStatus.java
@@ -36,6 +36,9 @@ public final class ClientStatus {
     /** Invalid op code. */
     public static final int INVALID_OP_CODE = 2;
 
+    /** Invalid node status. */
+    public static final int INVALID_NODE_STATE = 10;
+
     /** Functionality is disabled. */
     public static final int FUNCTIONALITY_DISABLED = 100;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheRequest.java
@@ -30,7 +30,7 @@ import javax.cache.expiry.ExpiryPolicy;
 /**
  * Cache request.
  */
-class ClientCacheRequest extends ClientRequest {
+public class ClientCacheRequest extends ClientRequest {
     /** "Keep binary" flag mask. */
     private static final byte KEEP_BINARY_FLAG_MASK = 0x01;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheScanQueryRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheScanQueryRequest.java
@@ -107,7 +107,7 @@ public class ClientCacheScanQueryRequest extends ClientCacheDataRequest implemen
      * @return Filter.
      * @param ctx Context.
      */
-    public static IgniteBiPredicate createFilter(GridKernalContext ctx, Object filterObj, byte filterPlatform) {
+    private static IgniteBiPredicate createFilter(GridKernalContext ctx, Object filterObj, byte filterPlatform) {
         if (filterObj == null)
             return null;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerAddDataRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerAddDataRequest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.streamer;
+
+import java.util.Collection;
+
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
+import org.apache.ignite.internal.processors.cache.CacheObject;
+import org.apache.ignite.internal.processors.cache.KeyCacheObject;
+import org.apache.ignite.internal.processors.datastreamer.DataStreamerEntry;
+import org.apache.ignite.internal.processors.datastreamer.DataStreamerImpl;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.CLOSE;
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.FLUSH;
+
+/**
+ * Adds data to the existing streamer.
+ */
+public class ClientDataStreamerAddDataRequest extends ClientDataStreamerRequest {
+    /** */
+    private final long streamerId;
+
+    /** */
+    private final byte flags;
+
+    /** */
+    private final Collection<DataStreamerEntry> entries;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Data reader.
+     */
+    public ClientDataStreamerAddDataRequest(BinaryReaderExImpl reader) {
+        super(reader);
+
+        streamerId = reader.readLong();
+        flags = reader.readByte();
+        entries = ClientDataStreamerReader.read(reader);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        ClientDataStreamerHandle handle = ctx.resources().get(streamerId);
+        DataStreamerImpl<KeyCacheObject, CacheObject> dataStreamer =
+                (DataStreamerImpl<KeyCacheObject, CacheObject>)handle.getStreamer();
+
+        try {
+            if (entries != null)
+                dataStreamer.addData(entries);
+
+            if ((flags & FLUSH) != 0)
+                dataStreamer.flush();
+
+            if ((flags & CLOSE) != 0) {
+                dataStreamer.close();
+                ctx.resources().release(streamerId);
+            }
+        }
+        catch (IllegalStateException unused) {
+            return getInvalidNodeStateResponse();
+        }
+
+        return new ClientResponse(requestId());
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerFlags.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerFlags.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.streamer;
+
+/**
+ * Data streamer flags.
+ */
+public class ClientDataStreamerFlags {
+    /** Allow overwrite flag mask. */
+    public static final byte ALLOW_OVERWRITE = 0x01;
+
+    /** Skip store flag mask. */
+    public static final byte SKIP_STORE = 0x02;
+
+    /** Keep binary flag mask. */
+    public static final byte KEEP_BINARY = 0x04;
+
+    /** Streamer flush flag mask. */
+    public static final byte FLUSH = 0x08;
+
+    /** Streamer close flag mask. */
+    public static final byte CLOSE = 0x10;
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerHandle.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerHandle.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.streamer;
+
+import org.apache.ignite.IgniteDataStreamer;
+import org.apache.ignite.internal.processors.cache.CacheObject;
+import org.apache.ignite.internal.processors.cache.KeyCacheObject;
+import org.apache.ignite.internal.processors.platform.client.ClientCloseableResource;
+
+/**
+ * Streamer handle.
+ */
+public class ClientDataStreamerHandle implements ClientCloseableResource {
+    /** */
+    private final IgniteDataStreamer<KeyCacheObject, CacheObject> streamer;
+
+    /**
+     * Ctor.
+     *
+     * @param streamer Streamer instance.
+     */
+    public ClientDataStreamerHandle(IgniteDataStreamer<KeyCacheObject, CacheObject> streamer) {
+        assert streamer != null;
+
+        this.streamer = streamer;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void close() {
+        streamer.close(true);
+    }
+
+    /**
+     * Gets the wrapped streamer.
+     *
+     * @return Wrapped streamer.
+     */
+    public IgniteDataStreamer<KeyCacheObject, CacheObject> getStreamer() {
+        return streamer;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerReader.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerReader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.streamer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
+import org.apache.ignite.internal.binary.streams.BinaryInputStream;
+import org.apache.ignite.internal.processors.cache.CacheObject;
+import org.apache.ignite.internal.processors.cache.CacheObjectImpl;
+import org.apache.ignite.internal.processors.cache.KeyCacheObjectImpl;
+import org.apache.ignite.internal.processors.datastreamer.DataStreamerEntry;
+
+/**
+ * Data streamer deserialization helpers.
+ */
+class ClientDataStreamerReader {
+    /**
+     * Reads an entry.
+     *
+     * @param reader Data reader.
+     * @return Streamer entry.
+     */
+    public static Collection<DataStreamerEntry> read(BinaryReaderExImpl reader) {
+        int entriesCnt = reader.readInt();
+
+        if (entriesCnt == 0)
+            return null;
+
+        Collection<DataStreamerEntry> entries = new ArrayList<>(entriesCnt);
+
+        for (int i = 0; i < entriesCnt; i++) {
+            entries.add(new DataStreamerEntry(readCacheObject(reader, true),
+                    readCacheObject(reader, false)));
+        }
+
+        return entries;
+    }
+
+    /**
+     * Read cache object from the stream as raw bytes to avoid marshalling.
+     */
+    private static <T extends CacheObject> T readCacheObject(BinaryReaderExImpl reader, boolean isKey) {
+        BinaryInputStream in = reader.in();
+
+        int pos0 = in.position();
+
+        Object obj = reader.readObjectDetached();
+
+        if (obj == null)
+            return null;
+
+        int pos1 = in.position();
+
+        in.position(pos0);
+
+        byte[] objBytes = in.readByteArray(pos1 - pos0);
+
+        return isKey ? (T) new KeyCacheObjectImpl(obj, objBytes, -1) : (T) new CacheObjectImpl(obj, objBytes);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.streamer;
+
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientRequest;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientStatus;
+
+/**
+ * Base class for streamer requests.
+ */
+abstract class ClientDataStreamerRequest extends ClientRequest {
+    /**
+     * Constructor.
+     *
+     * @param reader Data reader.
+     */
+    protected ClientDataStreamerRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /**
+     * Returns invalid node state response.
+     *
+     * @return Invalid node state response.
+     */
+    protected ClientResponse getInvalidNodeStateResponse() {
+        return new ClientResponse(requestId(), ClientStatus.INVALID_NODE_STATE,
+                "Data streamer has been closed because node is stopping.");
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerStartRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerStartRequest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.streamer;
+
+import java.util.Collection;
+
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.binary.BinaryObject;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
+import org.apache.ignite.internal.processors.cache.CacheObject;
+import org.apache.ignite.internal.processors.cache.KeyCacheObject;
+import org.apache.ignite.internal.processors.datastreamer.DataStreamerEntry;
+import org.apache.ignite.internal.processors.datastreamer.DataStreamerImpl;
+import org.apache.ignite.internal.processors.platform.PlatformContext;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientLongResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientPlatform;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+import org.apache.ignite.internal.processors.platform.client.cache.ClientCacheRequest;
+import org.apache.ignite.internal.processors.platform.utils.PlatformUtils;
+import org.apache.ignite.stream.StreamReceiver;
+
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.ALLOW_OVERWRITE;
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.CLOSE;
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.FLUSH;
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.KEEP_BINARY;
+import static org.apache.ignite.internal.processors.platform.client.streamer.ClientDataStreamerFlags.SKIP_STORE;
+
+/**
+ * Starts the data streamer.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class ClientDataStreamerStartRequest extends ClientDataStreamerRequest {
+    /** */
+    private final int cacheId;
+
+    /** */
+    private final byte flags;
+
+    /** */
+    private final int perNodeBufferSize;
+
+    /** */
+    private final int perThreadBufferSize;
+
+    /** Receiver object */
+    private final Object receiverObj;
+
+    /** Receiver platform. */
+    private final byte receiverPlatform;
+
+    /** Data entries. */
+    private final Collection<DataStreamerEntry> entries;
+
+    /**
+     * Ctor.
+     *
+     * @param reader Data reader.
+     */
+    public ClientDataStreamerStartRequest(BinaryReaderExImpl reader) {
+        super(reader);
+
+        cacheId = reader.readInt();
+        flags = reader.readByte();
+        perNodeBufferSize = reader.readInt();
+        perThreadBufferSize = reader.readInt();
+        receiverObj = reader.readObjectDetached();
+        receiverPlatform = receiverObj == null ? 0 : reader.readByte();
+        entries = ClientDataStreamerReader.read(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        String cacheName = ClientCacheRequest.cacheDescriptor(ctx, cacheId).cacheName();
+        DataStreamerImpl<KeyCacheObject, CacheObject> dataStreamer = (DataStreamerImpl<KeyCacheObject, CacheObject>)
+                ctx.kernalContext().grid().<KeyCacheObject, CacheObject>dataStreamer(cacheName);
+
+        try {
+            boolean close = (flags & CLOSE) != 0;
+            boolean keepBinary = (flags & KEEP_BINARY) != 0;
+            boolean flush = (flags & FLUSH) != 0;
+            boolean allowOverwrite = (flags & ALLOW_OVERWRITE) != 0;
+            boolean skipStore = (flags & SKIP_STORE) != 0;
+
+            // Don't use thread buffer for a one-off streamer operation.
+            boolean useThreadBuffer = !close;
+
+            if (perNodeBufferSize >= 0)
+                dataStreamer.perNodeBufferSize(perNodeBufferSize);
+            else if (entries != null && !entries.isEmpty() && close)
+                dataStreamer.perNodeBufferSize(entries.size());
+
+            if (perThreadBufferSize >= 0 && useThreadBuffer)
+                dataStreamer.perThreadBufferSize(perThreadBufferSize);
+
+            dataStreamer.allowOverwrite(allowOverwrite);
+            dataStreamer.skipStore(skipStore);
+            dataStreamer.keepBinary(keepBinary);
+
+            if (receiverObj != null)
+                dataStreamer.receiver(createReceiver(ctx.kernalContext(), receiverObj, receiverPlatform, keepBinary));
+
+            if (entries != null)
+                dataStreamer.addDataInternal(entries, useThreadBuffer);
+
+            if (flush)
+                dataStreamer.flush();
+
+            if (close) {
+                dataStreamer.close();
+
+                return new ClientLongResponse(requestId(), 0);
+            } else {
+                long rsrcId = ctx.resources().put(new ClientDataStreamerHandle(dataStreamer));
+
+                return new ClientLongResponse(requestId(), rsrcId);
+            }
+        }
+        catch (IllegalStateException unused) {
+            return getInvalidNodeStateResponse();
+        }
+    }
+
+    /**
+     * Creates the receiver.
+     *
+     * @param ctx Kernal context.
+     * @param receiverObj Receiver.
+     * @param platform Platform code.
+     * @param keepBinary Keep binary flag.
+     * @return Receiver.
+     */
+    private static StreamReceiver createReceiver(GridKernalContext ctx,
+                                                 Object receiverObj,
+                                                 byte platform,
+                                                 boolean keepBinary) {
+        if (receiverObj == null)
+            return null;
+
+        switch (platform) {
+            case ClientPlatform.JAVA:
+                return ((BinaryObject)receiverObj).deserialize();
+
+            case ClientPlatform.DOTNET:
+                PlatformContext platformCtx = ctx.platform().context();
+
+                String curPlatform = platformCtx.platform();
+
+                if (!PlatformUtils.PLATFORM_DOTNET.equals(curPlatform)) {
+                    throw new IgniteException("Stream receiver platform is " + PlatformUtils.PLATFORM_DOTNET +
+                            ", current platform is " + curPlatform);
+                }
+
+                return platformCtx.createStreamReceiver(receiverObj, 0, keepBinary);
+
+            case ClientPlatform.CPP:
+
+            default:
+                throw new UnsupportedOperationException("Invalid stream receiver platform code: " + platform);
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformStartIgniteUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformStartIgniteUtils.java
@@ -16,8 +16,6 @@
 
 package org.apache.ignite.platform;
 
-import java.security.Permissions;
-
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.IgniteConfiguration;

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformStartIgniteUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformStartIgniteUtils.java
@@ -52,7 +52,7 @@ public class PlatformStartIgniteUtils {
                         SecurityPermissionSetBuilder.create().defaultAllowAll(false)
                                 .appendCachePermissions("DEFAULT_CACHE", CACHE_READ, CACHE_PUT, CACHE_REMOVE)
                                 .appendCachePermissions("FORBIDDEN_CACHE")
-                                .build(), new Permissions())
+                                .build())
         );
 
         IgniteConfiguration cfg = new IgniteConfiguration()

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformStartIgniteUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformStartIgniteUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import java.security.Permissions;
+
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.processors.security.impl.TestSecurityData;
+import org.apache.ignite.internal.processors.security.impl.TestSecurityPluginProvider;
+import org.apache.ignite.plugin.security.SecurityPermissionSetBuilder;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
+import org.apache.ignite.testframework.junits.GridAbstractTest;
+
+import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_PUT;
+import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_READ;
+import static org.apache.ignite.plugin.security.SecurityPermission.CACHE_REMOVE;
+import static org.apache.ignite.plugin.security.SecurityPermissionSetBuilder.ALLOW_ALL;
+
+/**
+ * Ignite start/stop utils.
+ */
+public class PlatformStartIgniteUtils {
+    /**
+     * Starts an Ignite instance with test security plugin provider.
+     *
+     * @param name Ignite instance name.
+     * @throws IgniteException Exception.
+     */
+    public static void startWithSecurity(String name) throws IgniteException {
+        TestSecurityPluginProvider securityPluginProvider = new TestSecurityPluginProvider(
+                "login1",
+                "pass1",
+                ALLOW_ALL,
+                false,
+                new TestSecurityData("CLIENT", "pass1",
+                        SecurityPermissionSetBuilder.create().defaultAllowAll(false)
+                                .appendCachePermissions("DEFAULT_CACHE", CACHE_READ, CACHE_PUT, CACHE_REMOVE)
+                                .appendCachePermissions("FORBIDDEN_CACHE")
+                                .build(), new Permissions())
+        );
+
+        IgniteConfiguration cfg = new IgniteConfiguration()
+                .setPluginProviders(securityPluginProvider)
+                .setDiscoverySpi(new TcpDiscoverySpi().setIpFinder(GridAbstractTest.LOCAL_IP_FINDER))
+                .setLocalHost("127.0.0.1")
+                .setIgniteInstanceName(name);
+
+        Ignition.start(cfg);
+    }
+
+    /**
+     * Stops an Ignite instance with the specified name.
+     *
+     * @param name Ignite instance name.
+     */
+    public static void stop(String name) {
+        Ignition.stop(name, true);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/DataStreamer/DataStreamerBatchSizeBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/DataStreamer/DataStreamerBatchSizeBenchmark.cs
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.BenchmarkDotNet.DataStreamer
+{
+    using Apache.Ignite.Core;
+    using Apache.Ignite.Core.Cache;
+    using global::BenchmarkDotNet.Attributes;
+
+    public class DataStreamerBatchSizeBenchmark
+    {
+        private const int BaseCount = 1024;
+        private const int Count = BaseCount * 100;
+
+        public IIgnite Ignite { get; set; }
+
+        public ICache<int, int> Cache { get; set; }
+
+        /// <summary>
+        /// Sets up the benchmark.
+        /// </summary>
+        [GlobalSetup]
+        public virtual void GlobalSetup()
+        {
+            Ignite = Ignition.Start(Utils.GetIgniteConfiguration());
+            Cache = Ignite.GetOrCreateCache<int, int>("c");
+        }
+
+        /// <summary>
+        /// Cleans up the benchmark.
+        /// </summary>
+        [GlobalCleanup]
+        public virtual void GlobalCleanup()
+        {
+            Ignite.Dispose();
+        }
+
+        [Benchmark]
+        public void OneStreamerManyBatches()
+        {
+            using (var streamer = Ignite.GetDataStreamer<int, int>(Cache.Name))
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    streamer.Add(i, i);
+                }
+            }
+        }
+
+        [Benchmark]
+        public void OneBatchManyStreamers()
+        {
+            const int batchSize = BaseCount * 10;
+
+            for (int i = 0; i < (Count / batchSize); i++)
+            {
+                using (var streamer = Ignite.GetDataStreamer<int, int>(Cache.Name))
+                {
+                    var offs = i * batchSize;
+
+                    for (int j = 0; j < batchSize; j++)
+                    {
+                        streamer.Add(offs + j, offs + j);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/DataStreamer/DataStreamerBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/DataStreamer/DataStreamerBenchmark.cs
@@ -24,7 +24,7 @@ namespace Apache.Ignite.BenchmarkDotNet.DataStreamer
     /// <summary>
     /// Data streamer benchmark.
     /// <para />
-    /// Results on Core i7-9700K, Ubuntu 20.04, .NET Core 2.0:
+    /// Results on Core i7-9700K, Ubuntu 20.04, .NET Core 5.0.5:
     /// |                 Method |     Mean |   Error |  StdDev | Ratio | RatioSD |
     /// |----------------------- |---------:|--------:|--------:|------:|--------:|
     /// |               Streamer | 182.6 ms | 3.60 ms | 5.05 ms |  1.00 |    0.00 |

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientBenchmarkBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientBenchmarkBase.cs
@@ -48,7 +48,7 @@ namespace Apache.Ignite.BenchmarkDotNet.ThinClient
         public virtual void GlobalCleanup()
         {
             Client.Dispose();
-            Ignite.Dispose();
+            Ignition.StopAll(true);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientDataStreamerBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientDataStreamerBenchmark.cs
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.BenchmarkDotNet.ThinClient
+{
+    using Apache.Ignite.Core;
+    using Apache.Ignite.Core.Cache;
+    using global::BenchmarkDotNet.Attributes;
+
+    /// <summary>
+    /// Thin vs Thick client data streamer benchmark.
+    /// <para />
+    /// Results on Core i7-9700K, Ubuntu 20.04, .NET 5.0.5:
+    /// |            Method |     Mean |   Error |  StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 | Allocated |
+    /// |------------------ |---------:|--------:|--------:|------:|--------:|----------:|------:|------:|----------:|
+    /// |  StreamThinClient | 106.5 ms | 3.25 ms | 9.52 ms |  0.99 |    0.08 | 2000.0000 |     - |     - |  17.14 MB |
+    /// | StreamThickClient | 109.7 ms | 2.19 ms | 4.17 ms |  1.00 |    0.00 | 2000.0000 |     - |     - |  13.61 MB |
+    /// </summary>
+    [MemoryDiagnoser]
+    public class ThinClientDataStreamerBenchmark : ThinClientBenchmarkBase
+    {
+        /** */
+        private const string CacheName = "c";
+
+        /** */
+        private const int EntryCount = 150000;
+
+        /** */
+        public IIgnite ThickClient { get; set; }
+
+        /** */
+        public ICache<int,int> Cache { get; set; }
+
+        /** <inheritdoc /> */
+        public override void GlobalSetup()
+        {
+            base.GlobalSetup();
+
+            // 3 servers in total.
+            Ignition.Start(Utils.GetIgniteConfiguration());
+            Ignition.Start(Utils.GetIgniteConfiguration());
+
+            ThickClient = Ignition.Start(Utils.GetIgniteConfiguration(client: true));
+
+            Cache = ThickClient.CreateCache<int, int>(CacheName);
+        }
+
+        [IterationSetup]
+        public void Setup()
+        {
+            Cache.Clear();
+        }
+
+        /// <summary>
+        /// Benchmark: thin client streamer.
+        /// </summary>
+        [Benchmark]
+        public void StreamThinClient()
+        {
+            using (var streamer = Client.GetDataStreamer<int, int>(CacheName))
+            {
+                for (var i = 0; i < EntryCount; i++)
+                {
+                    streamer.Add(i, -i);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Benchmark: thick client streamer.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public void StreamThickClient()
+        {
+            using (var streamer = ThickClient.GetDataStreamer<int, int>(CacheName))
+            {
+                for (var i = 0; i < EntryCount; i++)
+                {
+                    streamer.Add(i, -i);
+                }
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientDataStreamerBenchmarkMultithreaded.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientDataStreamerBenchmarkMultithreaded.cs
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.BenchmarkDotNet.ThinClient
+{
+    using System.Threading.Tasks;
+    using Apache.Ignite.Core;
+    using Apache.Ignite.Core.Cache;
+    using global::BenchmarkDotNet.Attributes;
+
+    /// <summary>
+    /// Thin vs Thick client data streamer benchmark.
+    /// <para />
+    /// Results on Core i7-9700K, Ubuntu 20.04, .NET 5.0.5:
+    /// |            Method |      Mean |    Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 | Gen 2 | Allocated |
+    /// |------------------ |----------:|---------:|---------:|------:|--------:|----------:|----------:|------:|----------:|
+    /// |  StreamThinClient | 107.65 ms | 2.931 ms | 8.504 ms |  1.45 |    0.14 | 2000.0000 | 1000.0000 |     - |  17.29 MB |
+    /// | StreamThickClient |  74.69 ms | 1.829 ms | 5.278 ms |  1.00 |    0.00 | 2000.0000 | 1000.0000 |     - |  13.85 MB |
+    /// </summary>
+    [MemoryDiagnoser]
+    public class ThinClientDataStreamerBenchmarkMultithreaded : ThinClientBenchmarkBase
+    {
+        /** */
+        private const string CacheName = "c";
+
+        /** */
+        private const int EntryCount = 150000;
+
+        /** */
+        public IIgnite ThickClient { get; set; }
+
+        /** */
+        public ICache<int,int> Cache { get; set; }
+
+        /** <inheritdoc /> */
+        public override void GlobalSetup()
+        {
+            base.GlobalSetup();
+
+            // 3 servers in total.
+            Ignition.Start(Utils.GetIgniteConfiguration());
+            Ignition.Start(Utils.GetIgniteConfiguration());
+
+            ThickClient = Ignition.Start(Utils.GetIgniteConfiguration(client: true));
+
+            Cache = ThickClient.CreateCache<int, int>(CacheName);
+        }
+
+        [IterationSetup]
+        public void Setup()
+        {
+            Cache.Clear();
+        }
+
+        /// <summary>
+        /// Benchmark: thin client streamer.
+        /// </summary>
+        [Benchmark]
+        public void StreamThinClient()
+        {
+            using (var streamer = Client.GetDataStreamer<int, int>(CacheName))
+            {
+                // ReSharper disable once AccessToDisposedClosure
+                Parallel.For(0, EntryCount, i => streamer.Add(i, -i));
+            }
+        }
+
+        /// <summary>
+        /// Benchmark: thick client streamer.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public void StreamThickClient()
+        {
+            using (var streamer = ThickClient.GetDataStreamer<int, int>(CacheName))
+            {
+                // ReSharper disable once AccessToDisposedClosure
+                Parallel.For(0, EntryCount, i => streamer.Add(i, -i));
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientDataStreamerFlushBenchmark.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/ThinClient/ThinClientDataStreamerFlushBenchmark.cs
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.BenchmarkDotNet.ThinClient
+{
+    using Apache.Ignite.Core;
+    using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Client.Datastream;
+    using Apache.Ignite.Core.Datastream;
+    using global::BenchmarkDotNet.Attributes;
+
+    /// <summary>
+    /// Thin vs Thick client data streamer flush benchmark:
+    /// measure warmed-up streamer flush performance, excluding open/close.
+    /// <para />
+    /// Results on Core i7-9700K, Ubuntu 20.04, .NET Core 5.0.5:
+    /// </summary>
+    [MemoryDiagnoser]
+    public class ThinClientDataStreamerFlushBenchmark : ThinClientBenchmarkBase
+    {
+        /** */
+        private const string CacheName = "c";
+
+        /** */
+        private const int EntryCount = 250000;
+
+        /** */
+        public IIgnite ThickClient { get; set; }
+
+        /** */
+        public ICache<int,int> Cache { get; set; }
+
+        /** */
+        public IDataStreamer<int,int> ThickStreamer { get; set; }
+
+        /** */
+        public IDataStreamerClient<int,int> ThinStreamer { get; set; }
+
+        /** <inheritdoc /> */
+        public override void GlobalSetup()
+        {
+            base.GlobalSetup();
+
+            // 3 servers in total.
+            Ignition.Start(Utils.GetIgniteConfiguration());
+            Ignition.Start(Utils.GetIgniteConfiguration());
+
+            ThickClient = Ignition.Start(Utils.GetIgniteConfiguration(client: true));
+
+            Cache = ThickClient.CreateCache<int, int>(CacheName);
+        }
+
+        [IterationSetup]
+        public void Setup()
+        {
+            // Create streamers and warm them up.
+            ThinStreamer = Client.GetDataStreamer<int, int>(CacheName);
+            ThickStreamer = ThickClient.GetDataStreamer<int, int>(CacheName);
+
+            for (int i = 0; i < DataStreamerDefaults.DefaultPerNodeBufferSize * 10; i++)
+            {
+                ThinStreamer.Add(-i, -i);
+                ThickStreamer.Add(i, i);
+            }
+
+            ThickStreamer.Flush();
+            ThinStreamer.Flush();
+
+            Cache.Clear();
+        }
+
+        [IterationCleanup]
+        public void Cleanup()
+        {
+            ThickStreamer.Dispose();
+            ThinStreamer.Dispose();
+        }
+
+        /// <summary>
+        /// Benchmark: thin client streamer.
+        /// </summary>
+        [Benchmark]
+        public void StreamThinClient()
+        {
+            for (var i = 0; i < EntryCount; i++)
+            {
+                ThinStreamer.Add(i, -i);
+            }
+
+            ThinStreamer.Flush();
+        }
+
+        /// <summary>
+        /// Benchmark: thick client streamer.
+        /// </summary>
+        [Benchmark(Baseline = true)]
+        public void StreamThickClient()
+        {
+            for (var i = 0; i < EntryCount; i++)
+            {
+                ThickStreamer.Add(i, -i);
+            }
+
+            ThickStreamer.Flush();
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Utils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Utils.cs
@@ -31,7 +31,7 @@ namespace Apache.Ignite.BenchmarkDotNet
         /// <summary>
         /// Gets Ignite config.
         /// </summary>
-        public static IgniteConfiguration GetIgniteConfiguration()
+        public static IgniteConfiguration GetIgniteConfiguration(bool client = false)
         {
             Environment.SetEnvironmentVariable("IGNITE_NATIVE_TEST_CLASSPATH", "true");
             Environment.SetEnvironmentVariable("IGNITE_NET_SUPPRESS_JAVA_ILLEGAL_ACCESS_WARNINGS", "true");
@@ -60,7 +60,9 @@ namespace Apache.Ignite.BenchmarkDotNet
                     {
                         MaxActiveComputeTasksPerConnection = 100
                     }
-                }
+                },
+                AutoGenerateIgniteInstanceName = true,
+                ClientMode = client
             };
         }
 
@@ -69,7 +71,10 @@ namespace Apache.Ignite.BenchmarkDotNet
         /// </summary>
         public static IgniteClientConfiguration GetIgniteClientConfiguration()
         {
-            return new IgniteClientConfiguration("127.0.0.1");
+            return new IgniteClientConfiguration("127.0.0.1")
+            {
+                EnablePartitionAwareness = true
+            };
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Client\Cache\TestKeyWithAffinity.cs" />
     <Compile Include="Client\ClientFeaturesTest.cs" />
     <Compile Include="Client\ClientProtocolVersionTest.cs" />
+    <Compile Include="Client\ClientSecurityPermissionsTest.cs" />
     <Compile Include="Client\ClientServerCacheAdapter.cs" />
     <Compile Include="Client\ClientServerCacheAdapterExtensions.cs" />
     <Compile Include="Client\ClientTestBase.cs" />
@@ -198,6 +199,10 @@
     <Compile Include="Client\Compatibility\ClientServerCompatibilityTest.cs" />
     <Compile Include="Client\Compute\ComputeClientDisabledTests.cs" />
     <Compile Include="Client\Compute\ComputeClientTests.cs" />
+    <Compile Include="Client\Datastream\DataStreamerClientTest.cs" />
+    <Compile Include="Client\Datastream\DataStreamerClientTestPartitionAware.cs" />
+    <Compile Include="Client\Datastream\DataStreamerClientTopologyChangeTest.cs" />
+    <Compile Include="Client\Datastream\DataStreamerClientTopologyChangeTestPartitionAware.cs" />
     <Compile Include="Client\EndpointTest.cs" />
     <Compile Include="Client\RawSecureSocketTest.cs" />
     <Compile Include="Client\RawSocketTest.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -47,7 +47,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// <summary>
         /// Initializes a new instance of <see cref="ContinuousQueryTest"/>.
         /// </summary>
-        public ContinuousQueryTest() : base(2)
+        public ContinuousQueryTest() : base(gridCount: 2, enableServerListLogging: true)
         {
             // No-op.
         }
@@ -653,7 +653,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         {
             var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName)
                 .WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null));
-            
+
             var events = new ConcurrentQueue<ICacheEntryEvent<int, int>>();
             var qry = new ContinuousQueryClient<int, int>(new DelegateListener<int, int>(events.Enqueue));
             Assert.IsFalse(qry.IncludeExpired);
@@ -666,7 +666,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
                 cache[2] = 3;
             }
-            
+
             Assert.AreEqual(2, events.Count);
             Assert.AreEqual(CacheEntryEventType.Created, events.First().EventType);
             Assert.AreEqual(CacheEntryEventType.Created, events.Last().EventType);
@@ -685,7 +685,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         {
             var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName)
                 .WithExpiryPolicy(new ExpiryPolicy(TimeSpan.FromMilliseconds(100), null, null));
-            
+
             var events = new ConcurrentQueue<ICacheEntryEvent<int, int>>();
             var qry = new ContinuousQueryClient<int, int>(new DelegateListener<int, int>(events.Enqueue))
             {
@@ -698,11 +698,11 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
                 TestUtils.WaitForTrueCondition(() => events.Count == 2, 5000);
             }
-            
+
             Assert.AreEqual(2, events.Count);
             Assert.AreEqual(CacheEntryEventType.Created, events.First().EventType);
             Assert.AreEqual(CacheEntryEventType.Expired, events.Last().EventType);
-            
+
             Assert.IsTrue(events.Last().HasValue);
             Assert.IsTrue(events.Last().HasOldValue);
             Assert.AreEqual(2, events.Last().Value);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SerializableObjectsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SerializableObjectsTest.cs
@@ -34,7 +34,11 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
         /** */
         private static readonly int[] Keys = Enumerable.Range(0, EntryCount).ToArray();
-        
+
+        public SerializableObjectsTest() : base(1, enableServerListLogging: true)
+        {
+        }
+
         /// <summary>
         /// Tests DateTime metadata caching.
         /// </summary>
@@ -43,7 +47,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         {
             var requestName = scanQuery ? "ClientCacheScanQuery" : "ClientCacheGetAll";
             var cache = GetPopulatedCache();
-            
+
             var res = scanQuery
                 ? cache.Query(new ScanQuery<int, DateTimeTest>()).GetAll()
                 : cache.GetAll(Keys);
@@ -68,29 +72,29 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             // Retrieve data from a different client which does not yet have cached meta.
             var requestName = scanQuery ? "ClientCacheScanQuery" : "ClientCacheGetAll";
             var cache = GetClient().GetCache<int, DateTimeTest>(GetPopulatedCache().Name);
-            
+
             var res = scanQuery
                 ? cache.Query(new ScanQuery<int, DateTimeTest>()).GetAll()
                 : cache.GetAll(Keys);
-            
+
             var requests = GetAllServerRequestNames().ToArray();
 
             // Verify that only one BinaryTypeGet request per type is sent to the server.
             var expectedRequests = new[]
             {
-                requestName, 
+                requestName,
                 "ClientBinaryTypeNameGet",
                 "ClientBinaryTypeGet",
                 "ClientBinaryTypeNameGet",
                 "ClientBinaryTypeGet"
             };
             Assert.AreEqual(expectedRequests, requests);
-            
+
             // Verify results.
             Assert.AreEqual(EntryCount, res.Count);
             Assert.AreEqual(DateTimeTest.DefaultDateTime, res.Min(x => x.Value.Date));
         }
-        
+
         /// <summary>
         /// Gets the populated cache.
         /// </summary>
@@ -124,10 +128,10 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         {
             /** */
             public static readonly DateTime DefaultDateTime = new DateTime(2002, 2, 2);
-            
+
             /** */
             public int Id { get; set; }
-            
+
             /** */
             public DateTime Date { get; set; }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientSecurityPermissionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientSecurityPermissionsTest.cs
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Datastream;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests thin client security permissions.
+    /// </summary>
+    public class ClientSecurityPermissionsTest
+    {
+        /** */
+        private const string Login = "CLIENT";
+
+        /** */
+        private const string AllowAllLogin = "CLIENT_";
+
+        /** */
+        private const string ForbiddenCache = "FORBIDDEN_CACHE";
+
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            TestUtils.EnsureJvmCreated();
+            TestUtilsJni.StartIgnite("server");
+        }
+
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            TestUtilsJni.StopIgnite("server");
+        }
+
+        [Test]
+        public void TestCreateCacheNoPermissionThrowsSecurityViolationClientException()
+        {
+            using (var client = StartClient())
+            {
+                var ex = Assert.Throws<IgniteClientException>(() => client.CreateCache<int, int>(ForbiddenCache));
+
+                Assert.AreEqual(ClientStatusCode.SecurityViolation, ex.StatusCode);
+            }
+        }
+
+        [Test]
+        public void TestDataStreamerNoPermissionThrowsSecurityViolationClientException([Values(true, false)] bool add)
+        {
+            using (var client = StartClient(AllowAllLogin))
+            {
+                client.GetOrCreateCache<int, int>(ForbiddenCache);
+            }
+
+            using (var client = StartClient())
+            {
+                var options = new DataStreamerClientOptions {AllowOverwrite = true};
+                var streamer = client.GetDataStreamer<int, int>(ForbiddenCache, options);
+
+                if (add)
+                {
+                    streamer.Add(1, 1);
+                }
+                else
+                {
+                    streamer.Remove(1);
+                }
+
+                var ex = Assert.Throws<AggregateException>(() => streamer.Flush());
+                var clientEx = (IgniteClientException)ex.GetBaseException();
+
+                Assert.AreEqual(ClientStatusCode.SecurityViolation, clientEx.StatusCode);
+                Assert.AreEqual("Client is not authorized to perform this operation", clientEx.Message);
+            }
+        }
+
+        private static IIgniteClient StartClient(string login = Login)
+        {
+            return Ignition.StartClient(GetClientConfiguration(login));
+        }
+
+        private static IgniteClientConfiguration GetClientConfiguration(string login)
+        {
+            return new IgniteClientConfiguration("127.0.0.1")
+            {
+                UserName = login,
+                Password = "pass1"
+            };
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientSecurityPermissionsTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientSecurityPermissionsTest.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.Core.Tests.Client
 {
     using System;
+    using System.Text.RegularExpressions;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Datastream;
     using NUnit.Framework;
@@ -85,7 +86,14 @@ namespace Apache.Ignite.Core.Tests.Client
                 var clientEx = (IgniteClientException)ex.GetBaseException();
 
                 Assert.AreEqual(ClientStatusCode.SecurityViolation, clientEx.StatusCode);
-                Assert.AreEqual("Client is not authorized to perform this operation", clientEx.Message);
+
+                var perm = add ? "CACHE_PUT" : "CACHE_REMOVE";
+                var message = Regex.Replace(clientEx.Message, "id=.*?, ", string.Empty);
+
+                Assert.AreEqual(
+                    "Authorization failed [perm=" + perm +
+                    ", name=FORBIDDEN_CACHE, subject=TestSecuritySubject{type=REMOTE_CLIENT, login=CLIENT}]",
+                    message);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientTestBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientTestBase.cs
@@ -44,7 +44,7 @@ namespace Apache.Ignite.Core.Tests.Client
         protected const string RequestNamePrefixCache = "cache.ClientCache";
 
         /** */
-        protected const string RequestNamePrefixBinary = "binary.ClientBinary";
+        protected const string RequestNamePrefixStreamer = "streamer.ClientDataStreamer";
 
         /** Grid count. */
         private readonly int _gridCount = 1;
@@ -54,6 +54,9 @@ namespace Apache.Ignite.Core.Tests.Client
 
         /** Partition Awareness */
         private readonly bool _enablePartitionAwareness;
+
+        /** Enable logging to a list logger for checks and assertions. */
+        private readonly bool _enableServerListLogging;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientTestBase"/> class.
@@ -67,13 +70,15 @@ namespace Apache.Ignite.Core.Tests.Client
         /// Initializes a new instance of the <see cref="ClientTestBase"/> class.
         /// </summary>
         public ClientTestBase(
-            int gridCount, 
-            bool enableSsl = false, 
-            bool enablePartitionAwareness = false)
+            int gridCount,
+            bool enableSsl = false,
+            bool enablePartitionAwareness = false,
+            bool enableServerListLogging = false)
         {
             _gridCount = gridCount;
             _enableSsl = enableSsl;
             _enablePartitionAwareness = enablePartitionAwareness;
+            _enableServerListLogging = enableServerListLogging;
         }
 
         /// <summary>
@@ -208,7 +213,9 @@ namespace Apache.Ignite.Core.Tests.Client
         {
             return new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
-                Logger = new ListLogger(new TestUtils.TestContextLogger()),
+                Logger = _enableServerListLogging
+                    ? (ILogger) new ListLogger(new TestUtils.TestContextLogger())
+                    : new TestUtils.TestContextLogger(),
                 SpringConfigUrl = _enableSsl ? Path.Combine("Config", "Client", "server-with-ssl.xml") : null
             };
         }
@@ -312,7 +319,7 @@ namespace Apache.Ignite.Core.Tests.Client
             return Ignition.GetAll()
                 .OrderBy(i => i.Name)
                 .Select(i => i.Logger)
-                .Cast<ListLogger>();
+                .OfType<ListLogger>();
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBase.cs
@@ -41,7 +41,8 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         /// <summary>
         /// Initializes a new instance of <see cref="ClientClusterDiscoveryTests"/>.
         /// </summary>
-        public ClientClusterDiscoveryTestsBase(bool noLocalhost, bool enableSsl) : base(3, enableSsl)
+        public ClientClusterDiscoveryTestsBase(bool noLocalhost, bool enableSsl)
+            : base(3, enableSsl, enableServerListLogging: true)
         {
             _noLocalhost = noLocalhost;
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTest.cs
@@ -1,0 +1,824 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Datastream
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Apache.Ignite.Core.Binary;
+    using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Store;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Datastream;
+    using Apache.Ignite.Core.Common;
+    using Apache.Ignite.Core.Datastream;
+    using Apache.Ignite.Core.Impl.Client.Datastream;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for <see cref="IDataStreamerClient{TK,TV}"/>.
+    /// </summary>
+    public class DataStreamerClientTest : ClientTestBase
+    {
+        /** */
+        private const int GridCount = 3;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientTest"/>.
+        /// </summary>
+        public DataStreamerClientTest()
+            : this(false)
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientTest"/>.
+        /// </summary>
+        public DataStreamerClientTest(bool enablePartitionAwareness)
+            : base(GridCount, enableSsl: false, enablePartitionAwareness: enablePartitionAwareness)
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Tests basic streaming with default options.
+        /// </summary>
+        [Test]
+        public void TestBasicStreaming()
+        {
+            var cache = GetClientCache<string>();
+
+            using (var streamer = Client.GetDataStreamer<int, string>(cache.Name))
+            {
+                Assert.AreEqual(cache.Name, streamer.CacheName);
+
+                streamer.Add(1, "1");
+                streamer.Add(2, "2");
+            }
+
+            Assert.AreEqual("1", cache[1]);
+            Assert.AreEqual("2", cache[2]);
+        }
+
+        /// <summary>
+        /// Tests add and remove operations combined.
+        /// </summary>
+        [Test]
+        public void TestAddRemoveOverwrite()
+        {
+            var cache = GetClientCache<int>();
+            cache.PutAll(Enumerable.Range(1, 10).ToDictionary(x => x, x => x + 1));
+
+            var options = new DataStreamerClientOptions {AllowOverwrite = true};
+
+            using (var streamer = Client.GetDataStreamer<int, object>(cache.Name, options))
+            {
+                streamer.Add(1, 11);
+                streamer.Add(20, 20);
+
+                foreach (var key in new[] {2, 4, 6, 7, 8, 9})
+                {
+                    streamer.Remove(key);
+                }
+
+                // Remove with null
+                streamer.Add(10, null);
+            }
+
+            var resKeys = cache.GetAll(Enumerable.Range(1, 30))
+                .Select(x => x.Key)
+                .OrderBy(x => x)
+                .ToArray();
+
+            Assert.AreEqual(11, cache.Get(1));
+            Assert.AreEqual(20, cache.Get(20));
+            Assert.AreEqual(4, cache.GetSize());
+            Assert.AreEqual(new[] {1, 3, 5, 20}, resKeys);
+        }
+
+        /// <summary>
+        /// Tests automatic flush when buffer gets full.
+        /// </summary>
+        [Test]
+        public void TestAutoFlushOnFullBuffer()
+        {
+            var cache = GetClientCache<string>();
+            var keys = TestUtils.GetPrimaryKeys(GetIgnite(), cache.Name).Take(10).ToArray();
+
+            // Set server buffers to 1 so that server always flushes the data.
+            var options = new DataStreamerClientOptions<int, int>
+            {
+                PerNodeBufferSize = 3
+            };
+
+            using (var streamer = Client.GetDataStreamer(
+                cache.Name,
+                options))
+            {
+                streamer.Add(keys[1], 1);
+                Assert.AreEqual(0, cache.GetSize());
+
+                streamer.Add(keys[2], 2);
+                Assert.AreEqual(0, cache.GetSize());
+
+                streamer.Add(keys[3], 3);
+                TestUtils.WaitForTrueCondition(() => cache.GetSize() == 3);
+            }
+        }
+
+        /// <summary>
+        /// Tests manual (explicit) flush.
+        /// </summary>
+        [Test]
+        public void TestManualFlush()
+        {
+            var cache = GetClientCache<int>();
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                streamer.Add(1, 1);
+                streamer.Add(2, 2);
+
+                streamer.Flush();
+
+                streamer.Add(3, 3);
+
+                Assert.AreEqual(2, cache.GetSize());
+                Assert.AreEqual(1, cache[1]);
+                Assert.AreEqual(2, cache[2]);
+
+                streamer.Flush();
+
+                Assert.AreEqual(3, cache.GetSize());
+                Assert.AreEqual(3, cache[3]);
+            }
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IDataStreamerClient{TK,TV}.Remove"/> throws an exception when
+        /// <see cref="DataStreamerClientOptions.AllowOverwrite"/> is not enabled.
+        /// </summary>
+        [Test]
+        public void TestRemoveNoAllowOverwriteThrows()
+        {
+            var cache = GetClientCache<string>();
+
+            using (var streamer = Client.GetDataStreamer<int, string>(cache.Name))
+            {
+                var ex = Assert.Throws<IgniteClientException>(() => streamer.Remove(1));
+
+                Assert.AreEqual("DataStreamer can't remove data when AllowOverwrite is false.", ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Tests streaming of relatively long list of entries to verify multiple buffer flush correctness.
+        /// </summary>
+        [Test]
+        [Category(TestUtils.CategoryIntensive)]
+        public void TestStreamLongList()
+        {
+            var cache = GetClientCache<int>();
+            const int count = 50000;
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                for (var k = 0; k < count; k++)
+                {
+                    streamer.Add(k, -k);
+                }
+            }
+
+            Assert.AreEqual(count, cache.GetSize());
+            Assert.AreEqual(-2, cache[2]);
+            Assert.AreEqual(-200, cache[200]);
+        }
+
+        /// <summary>
+        /// Tests streamer usage from multiple threads.
+        /// </summary>
+        [Test]
+        [Category(TestUtils.CategoryIntensive)]
+        public void TestStreamMultithreaded()
+        {
+            var cache = GetClientCache<int>();
+            const int count = 250000;
+            int id = 0;
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                TestUtils.RunMultiThreaded(() =>
+                {
+                    while (true)
+                    {
+                        var key = Interlocked.Increment(ref id);
+
+                        if (key > count)
+                        {
+                            break;
+                        }
+
+                        // ReSharper disable once AccessToDisposedClosure
+                        streamer.Add(key, key + 2);
+                    }
+                }, 8);
+            }
+
+            Assert.AreEqual(count, cache.GetSize());
+            Assert.AreEqual(4, cache[2]);
+            Assert.AreEqual(22, cache[20]);
+        }
+
+        /// <summary>
+        /// Tests streamer usage with Parallel.For, which dynamically allocates threads to perform work.
+        /// This test verifies backpressure behavior quite well.
+        /// </summary>
+        [Test]
+        [Category(TestUtils.CategoryIntensive)]
+        public void TestStreamParallelFor()
+        {
+            var cache = GetClientCache<int>();
+            const int count = 250000;
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                // ReSharper disable once AccessToDisposedClosure
+                Parallel.For(0, count, i => streamer.Add(i, i + 2));
+
+                streamer.Flush();
+                CheckArrayPoolLeak(streamer);
+            }
+
+            Assert.AreEqual(count, cache.GetSize());
+            Assert.AreEqual(4, cache[2]);
+            Assert.AreEqual(22, cache[20]);
+        }
+
+        /// <summary>
+        /// Tests that disposing the streamer without adding any data does nothing.
+        /// </summary>
+        [Test]
+        public void TestDisposeWithNoDataAdded()
+        {
+            var cache = GetClientCache<int>();
+
+            using (Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                // No-op.
+            }
+
+            Assert.AreEqual(0, cache.GetSize());
+        }
+
+        /// <summary>
+        /// Tests that closing the streamer without adding any data does nothing.
+        /// </summary>
+        [Test]
+        public void TestCloseWithNoDataAdded([Values(true, false)] bool cancel)
+        {
+            var cache = GetClientCache<int>();
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                streamer.Close(cancel);
+            }
+
+            Assert.AreEqual(0, cache.GetSize());
+        }
+
+        /// <summary>
+        /// Tests that enabling <see cref="DataStreamerClientOptions.SkipStore"/> causes cache store to be skipped
+        /// during streaming.
+        /// </summary>
+        [Test]
+        public void TestSkipStoreDoesNotInvokeCacheStore([Values(true, false)] bool allowOverwrite)
+        {
+            var serverCache = Ignition.GetIgnite().CreateCache<int, int>(new CacheConfiguration
+            {
+                Name = TestUtils.TestName,
+                CacheStoreFactory = new BlockingCacheStore(),
+                WriteThrough = true
+            });
+
+            var options = new DataStreamerClientOptions
+            {
+                SkipStore = true,
+                AllowOverwrite = allowOverwrite
+            };
+
+            BlockingCacheStore.Block();
+
+            using (var streamer = Client.GetDataStreamer<int, int>(serverCache.Name, options))
+            {
+                foreach (var x in Enumerable.Range(1, 300))
+                {
+                    streamer.Add(x, -x);
+                }
+            }
+
+            Assert.AreEqual(300, serverCache.GetSize());
+            Assert.AreEqual(-100, serverCache[100]);
+        }
+
+        /// <summary>
+        /// Tests that add method gets blocked when the number of active flush operations for a node
+        /// exceeds <see cref="DataStreamerClientOptions.PerNodeParallelOperations"/>.
+        /// </summary>
+        [Test]
+        public void TestExceedingPerNodeParallelOperationsBlocksAddMethod()
+        {
+            var serverCache = Ignition.GetIgnite().CreateCache<int, int>(new CacheConfiguration
+            {
+                Name = TestUtils.TestName,
+                CacheStoreFactory = new BlockingCacheStore(),
+                WriteThrough = true
+            });
+
+            var options = new DataStreamerClientOptions
+            {
+                PerNodeParallelOperations = 2,
+                PerNodeBufferSize = 1,
+                AllowOverwrite = true // Required for cache store to be invoked.
+            };
+
+            // Get primary keys for one of the nodes.
+            var keys = TestUtils.GetPrimaryKeys(Ignition.GetIgnite(), serverCache.Name).Take(5).ToArray();
+
+            using (var streamer = Client.GetDataStreamer<int, int>(serverCache.Name, options))
+            {
+                // Block writes and add data.
+                BlockingCacheStore.Block();
+                streamer.Add(keys[1], 1);
+                streamer.Add(keys[2], 2);
+
+                // ReSharper disable once AccessToDisposedClosure
+                var task = Task.Factory.StartNew(() => streamer.Add(keys[3], 3));
+
+                // Task is blocked because two streamer operations are already in progress.
+                Assert.IsFalse(TestUtils.WaitForCondition(() => task.IsCompleted, 500));
+                BlockingCacheStore.Unblock();
+                TestUtils.WaitForTrueCondition(() => task.IsCompleted, 500);
+            }
+
+            Assert.AreEqual(3, serverCache.GetSize());
+        }
+
+        /// <summary>
+        /// Tests that <see cref="DataStreamerClientOptions{TK,TV}"/> have correct default values.
+        /// </summary>
+        [Test]
+        public void TestOptionsHaveCorrectDefaults()
+        {
+            using (var streamer = Client.GetDataStreamer<int, int>(CacheName))
+            {
+                var opts = streamer.Options;
+
+                Assert.AreEqual(DataStreamerClientOptions.DefaultPerNodeBufferSize, opts.PerNodeBufferSize);
+                Assert.AreEqual(DataStreamerClientOptions.DefaultPerNodeParallelOperations, opts.PerNodeParallelOperations);
+                Assert.AreEqual(Environment.ProcessorCount * 4, opts.PerNodeParallelOperations);
+                Assert.AreEqual(TimeSpan.Zero, opts.AutoFlushInterval);
+                Assert.IsNull(opts.Receiver);
+                Assert.IsFalse(opts.AllowOverwrite);
+                Assert.IsFalse(opts.SkipStore);
+                Assert.IsFalse(opts.ReceiverKeepBinary);
+            }
+        }
+
+        /// <summary>
+        /// Tests that option values are validated on set.
+        /// </summary>
+        [Test]
+        public void TestInvalidOptionValuesCauseArgumentException()
+        {
+            var opts = new DataStreamerClientOptions();
+
+            Assert.Throws<ArgumentException>(() => opts.PerNodeBufferSize = -1);
+            Assert.Throws<ArgumentException>(() => opts.PerNodeParallelOperations = -1);
+        }
+
+        /// <summary>
+        /// Tests that flush throws correct exception when cache does not exist.
+        /// </summary>
+        [Test]
+        public void TestFlushThrowsWhenCacheDoesNotExist()
+        {
+            var streamer = Client.GetDataStreamer<int, int>("bad-cache-name");
+            streamer.Add(1, 1);
+
+            var ex = Assert.Throws<AggregateException>(() => streamer.Flush());
+            StringAssert.StartsWith("Cache does not exist", ex.GetBaseException().Message);
+
+            // Streamer is closed because of the flush failure.
+            Assert.IsTrue(streamer.IsClosed);
+        }
+
+        /// <summary>
+        /// Tests that dispose throws correct exception when cache does not exist.
+        /// </summary>
+        [Test]
+        public void TestDisposeThrowsWhenCacheDoesNotExist()
+        {
+            var streamer = Client.GetDataStreamer<int, int>("bad-cache-name");
+            streamer.Add(1, 1);
+            Assert.IsFalse(streamer.IsClosed);
+
+            var ex = Assert.Throws<AggregateException>(() => streamer.Dispose());
+            StringAssert.StartsWith("Cache does not exist", ex.GetBaseException().Message);
+            Assert.IsTrue(streamer.IsClosed);
+        }
+
+        /// <summary>
+        /// Tests that flush throws when exception happens in cache store.
+        /// </summary>
+        [Test]
+        public void TestFlushThrowsOnCacheStoreException()
+        {
+            var serverCache = Ignition.GetIgnite().CreateCache<int, int>(new CacheConfiguration
+            {
+                Name = TestUtils.TestName,
+                CacheStoreFactory = new BlockingCacheStore(),
+                WriteThrough = true
+            });
+
+            var options = new DataStreamerClientOptions
+            {
+                AllowOverwrite = true // Required for cache store to be invoked.
+            };
+
+            var streamer = Client.GetDataStreamer<int, int>(serverCache.Name, options);
+            streamer.Remove(1);
+
+            var ex = Assert.Throws<AggregateException>(() => streamer.Flush());
+            StringAssert.Contains("Failed to finish operation (too many remaps)", ex.GetBaseException().Message);
+
+            // Streamer is closed because of the flush failure.
+            Assert.IsTrue(streamer.IsClosed);
+        }
+
+        /// <summary>
+        /// Tests that all add/remove operations throw <see cref="ObjectDisposedException"/> when streamer is closed.
+        /// </summary>
+        [Test]
+        public void TestAllOperationsThrowWhenStreamerIsClosed()
+        {
+            var options = new DataStreamerClientOptions
+            {
+                AllowOverwrite = true
+            };
+
+            var streamer = Client.GetDataStreamer<int, int>(CacheName, options);
+            streamer.Close(true);
+
+            Assert.Throws<ObjectDisposedException>(() => streamer.Add(1, 1));
+            Assert.Throws<ObjectDisposedException>(() => streamer.Remove(1));
+            Assert.Throws<ObjectDisposedException>(() => streamer.Flush());
+            Assert.Throws<ObjectDisposedException>(() => streamer.FlushAsync());
+        }
+
+        /// <summary>
+        /// Tests that Dispose and Close methods can be called multiple times.
+        /// </summary>
+        [Test]
+        public void TestMultipleCloseAndDisposeCallsAreAllowed()
+        {
+            using (var streamer = Client.GetDataStreamer<int, int>(CacheName))
+            {
+                streamer.Add(1, 2);
+                streamer.Close(cancel: false);
+
+                streamer.Dispose();
+                streamer.Close(true);
+                streamer.Close(false);
+                streamer.CloseAsync(true).Wait();
+                streamer.CloseAsync(false).Wait();
+            }
+
+            Assert.AreEqual(2, GetCache<int>()[1]);
+        }
+
+        /// <summary>
+        /// Tests that cancelled streamer discards buffered data.
+        /// </summary>
+        [Test]
+        public void TestCloseCancelDiscardsBufferedData()
+        {
+            using (var streamer = Client.GetDataStreamer<int, int>(CacheName))
+            {
+                streamer.Add(1, 1);
+                streamer.Add(2, 2);
+                streamer.Close(cancel: true);
+            }
+
+            Assert.AreEqual(0, GetCache<int>().GetSize());
+        }
+
+        /// <summary>
+        /// Tests that async continuation does not happen on socket receiver system thread.
+        /// </summary>
+        [Test]
+        public void TestFlushAsyncContinuationDoesNotRunOnSocketReceiverThread()
+        {
+            var cache = GetClientCache<int>();
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                streamer.Add(1, 1);
+                streamer.FlushAsync().ContinueWith(t =>
+                {
+                    var trace = new StackTrace().ToString();
+
+                    StringAssert.DoesNotContain("ClientSocket", trace);
+                }, TaskContinuationOptions.ExecuteSynchronously).Wait();
+            }
+        }
+
+        /// <summary>
+        /// Tests data streamer with a receiver.
+        /// </summary>
+        [Test]
+        public void TestStreamReceiver()
+        {
+            var cache = GetClientCache<int>();
+
+            var options = new DataStreamerClientOptions<int, int>
+            {
+                Receiver = new StreamReceiverAddOne()
+            };
+
+            using (var streamer = Client.GetDataStreamer(cache.Name, options))
+            {
+                streamer.Add(1, 1);
+            }
+
+            Assert.AreEqual(2, cache[1]);
+        }
+
+        /// <summary>
+        /// Tests stream receiver in binary mode.
+        /// </summary>
+        [Test]
+        public void TestStreamReceiverKeepBinary()
+        {
+            var cache = GetClientCache<Test>().WithKeepBinary<int, IBinaryObject>();
+
+            var options = new DataStreamerClientOptions<int, IBinaryObject>
+            {
+                Receiver = new StreamReceiverAddTwoKeepBinary(),
+                ReceiverKeepBinary = true
+            };
+
+            using (var streamer = Client.GetDataStreamer(cache.Name, options))
+            {
+                streamer.Add(1, Client.GetBinary().ToBinary<IBinaryObject>(new Test {Val = 3}));
+            }
+
+            Assert.AreEqual(5, cache[1].Deserialize<Test>().Val);
+        }
+
+        /// <summary>
+        /// Tests that flush throws when exception happens in stream receiver.
+        /// </summary>
+        [Test]
+        public void TestFlushThrowsOnExceptionInStreamReceiver()
+        {
+            var options = new DataStreamerClientOptions<int, int>
+            {
+                Receiver = new StreamReceiverThrowException()
+            };
+
+            var streamer = Client.GetDataStreamer(CacheName, options);
+            streamer.Add(1, 1);
+
+            var ex = Assert.Throws<AggregateException>(() => streamer.Flush());
+            var clientEx = (IgniteClientException) ex.GetBaseException();
+
+            StringAssert.Contains("Failed to finish operation (too many remaps)", clientEx.Message);
+        }
+
+        /// <summary>
+        /// Tests that flush throws when exception happens during stream receiver deserialization.
+        /// </summary>
+        [Test]
+        public void TestFlushThrowsOnExceptionInStreamReceiverReadBinary()
+        {
+            var options = new DataStreamerClientOptions<int, int>
+            {
+                Receiver = new StreamReceiverReadBinaryThrowException()
+            };
+
+            var streamer = Client.GetDataStreamer(CacheName, options);
+            streamer.Add(1, 1);
+
+            var ex = Assert.Throws<AggregateException>(() => streamer.Flush());
+            var clientEx = (IgniteClientException) ex.GetBaseException();
+
+            StringAssert.Contains("Failed to finish operation (too many remaps)", clientEx.Message);
+        }
+
+        /// <summary>
+        /// Tests that streamer flushes data periodically when <see cref="DataStreamerClientOptions.AutoFlushInterval"/>
+        /// is set to non-zero value.
+        /// </summary>
+        [Test]
+        public void TestAutoFlushInterval()
+        {
+            var cache = GetClientCache<int>();
+            var options = new DataStreamerClientOptions
+            {
+                AutoFlushInterval = TimeSpan.FromSeconds(0.1)
+            };
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name, options))
+            {
+                streamer.Add(1, 1);
+                TestUtils.WaitForTrueCondition(() => cache.ContainsKey(1));
+
+                streamer.Add(2, 2);
+                TestUtils.WaitForTrueCondition(() => cache.ContainsKey(2));
+            }
+        }
+
+        /// <summary>
+        /// Tests that streamer gets closed when automatic flush encounters a fatal error (cache does not exist).
+        /// </summary>
+        [Test]
+        public void TestAutoFlushClosesStreamerWhenCacheDoesNotExist()
+        {
+            var options = new DataStreamerClientOptions
+            {
+                AutoFlushInterval = TimeSpan.FromSeconds(0.2)
+            };
+
+            var streamer = Client.GetDataStreamer<int, int>("bad-cache-name", options);
+            streamer.Add(1, 1);
+
+            Assert.IsFalse(streamer.IsClosed);
+            TestUtils.WaitForTrueCondition(() => streamer.IsClosed);
+
+            var ex = Assert.Throws<IgniteClientException>(() => streamer.Flush());
+            Assert.AreEqual("Streamer is closed with error, check inner exception for details.", ex.Message);
+
+            Assert.IsNotNull(ex.InnerException);
+            var inner = ((AggregateException)ex.InnerException).GetBaseException();
+
+            StringAssert.StartsWith("Cache does not exist", inner.Message);
+        }
+
+#if NETCOREAPP
+
+        /// <summary>
+        /// Tests streaming with async/await.
+        /// </summary>
+        [Test]
+        public async Task TestStreamingAsyncAwait()
+        {
+            var cache = GetClientCache<int>();
+
+            using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                streamer.Add(1, 1);
+                await streamer.FlushAsync();
+                Assert.AreEqual(1, await cache.GetAsync(1));
+
+                streamer.Add(2, 2);
+                await streamer.FlushAsync();
+                Assert.AreEqual(2, await cache.GetAsync(2));
+
+                streamer.Add(3, 3);
+                await streamer.CloseAsync(false);
+            }
+
+            Assert.AreEqual(3, await cache.GetSizeAsync());
+            Assert.AreEqual(3, await cache.GetAsync(3));
+        }
+
+#endif
+
+        internal static void CheckArrayPoolLeak<TK, TV>(IDataStreamerClient<TK, TV> streamer)
+        {
+            var streamerImpl = (DataStreamerClient<TK, TV>) streamer;
+
+            TestUtils.WaitForCondition(() => streamerImpl.ArraysAllocated == streamerImpl.ArraysPooled, 1000);
+
+            Assert.AreEqual(streamerImpl.ArraysAllocated, streamerImpl.ArraysPooled, "Pooled arrays should not leak.");
+
+            Console.WriteLine("Array pool size: " + streamerImpl.ArraysPooled);
+        }
+
+        protected override IgniteConfiguration GetIgniteConfiguration()
+        {
+            return new IgniteConfiguration(base.GetIgniteConfiguration())
+            {
+                Logger = new TestUtils.TestContextLogger()
+            };
+        }
+
+        private class StreamReceiverAddOne : IStreamReceiver<int, int>
+        {
+            public void Receive(ICache<int, int> cache, ICollection<ICacheEntry<int, int>> entries)
+            {
+                cache.PutAll(entries.ToDictionary(x => x.Key, x => x.Value + 1));
+            }
+        }
+
+        private class StreamReceiverThrowException : IStreamReceiver<int, int>
+        {
+            public void Receive(ICache<int, int> cache, ICollection<ICacheEntry<int, int>> entries)
+            {
+                throw new ArithmeticException("Foo");
+            }
+        }
+
+        private class StreamReceiverReadBinaryThrowException : IStreamReceiver<int, int>, IBinarizable
+        {
+            public void Receive(ICache<int, int> cache, ICollection<ICacheEntry<int, int>> entries)
+            {
+                // No-op.
+            }
+
+            public void WriteBinary(IBinaryWriter writer)
+            {
+                // No-op.
+            }
+
+            public void ReadBinary(IBinaryReader reader)
+            {
+                throw new InvalidOperationException("Bar");
+            }
+        }
+
+        private class StreamReceiverAddTwoKeepBinary : IStreamReceiver<int, IBinaryObject>
+        {
+            /** <inheritdoc /> */
+            public void Receive(ICache<int, IBinaryObject> cache, ICollection<ICacheEntry<int, IBinaryObject>> entries)
+            {
+                var binary = cache.Ignite.GetBinary();
+
+                cache.PutAll(entries.ToDictionary(x => x.Key, x =>
+                    binary.ToBinary<IBinaryObject>(new Test
+                    {
+                        Val = x.Value.Deserialize<Test>().Val + 2
+                    })));
+            }
+        }
+
+        private class Test
+        {
+            public int Val { get; set; }
+        }
+
+        private class BlockingCacheStore : CacheStoreAdapter<int, int>, IFactory<ICacheStore>
+        {
+            private static readonly ManualResetEventSlim Gate = new ManualResetEventSlim();
+
+            public static void Block()
+            {
+                Gate.Reset();
+            }
+
+            public static void Unblock()
+            {
+                Gate.Set();
+            }
+
+            public override int Load(int key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override void Write(int key, int val)
+            {
+                Gate.Wait();
+            }
+
+            public override void Delete(int key)
+            {
+                throw new NotImplementedException();
+            }
+
+            public ICacheStore CreateInstance()
+            {
+                return new BlockingCacheStore();
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTestPartitionAware.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTestPartitionAware.cs
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Datastream
+{
+    using Apache.Ignite.Core.Client.Datastream;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests for <see cref="IDataStreamerClient{TK,TV}"/>.
+    /// </summary>
+    [TestFixture]
+    public class DataStreamerClientTestPartitionAware : DataStreamerClientTest
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientTest"/>.
+        /// </summary>
+        public DataStreamerClientTestPartitionAware()
+            : base(enablePartitionAwareness: true)
+        {
+            // No-op.
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTopologyChangeTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTopologyChangeTest.cs
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Datastream
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Cache;
+    using Apache.Ignite.Core.Client.Datastream;
+    using Apache.Ignite.Core.Configuration;
+    using Apache.Ignite.Core.Impl.Client;
+    using Apache.Ignite.Core.Impl.Client.Datastream;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests thin client data streamer with topology changes.
+    /// </summary>
+    [Category(TestUtils.CategoryIntensive)]
+    public class DataStreamerClientTopologyChangeTest
+    {
+        /** */
+        private readonly bool _enablePartitionAwareness;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientTopologyChangeTest"/> class.
+        /// </summary>
+        public DataStreamerClientTopologyChangeTest() : this(false)
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientTopologyChangeTest"/> class.
+        /// </summary>
+        public DataStreamerClientTopologyChangeTest(bool enablePartitionAwareness)
+        {
+            _enablePartitionAwareness = enablePartitionAwareness;
+        }
+
+        /// <summary>
+        /// Tears down the test.
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        /// <summary>
+        /// Tests that streamer does not lose per-node buffer data when node leaves the cluster.
+        /// </summary>
+        [Test]
+        public void TestStreamerDoesNotLoseDataOnFlushWhenNewNodeEntersAndOriginalNodeLeaves()
+        {
+            var server = StartServer();
+            var client = StartClient();
+
+            var cache = CreateCache(client);
+
+            using (var streamer = client.GetDataStreamer<int, int>(cache.Name))
+            {
+                // Add to the buffer for the initial server.
+                streamer.Add(1, 1);
+
+                // Start new server, stop old one.
+                StartServer();
+                server.Dispose();
+
+                streamer.Add(2, 2);
+                streamer.Flush();
+
+                Assert.AreEqual(1, cache[1]);
+                Assert.AreEqual(2, cache[2]);
+
+                streamer.Add(3, 3);
+                streamer.Flush();
+
+                Assert.AreEqual(3, cache[3]);
+            }
+        }
+
+        /// <summary>
+        /// Tests that streamer does not lose per-node buffer data when node leaves the cluster.
+        /// </summary>
+        [Test]
+        public void TestStreamerDoesNotLoseDataOnDisposeWhenNewNodeEntersAndOriginalNodeLeaves()
+        {
+            var server = StartServer();
+            var client = StartClient();
+
+            var cache = CreateCache(client);
+
+            using (var streamer = client.GetDataStreamer<int, int>(cache.Name))
+            {
+                streamer.Add(1, 1);
+
+                StartServer();
+                server.Dispose();
+
+                streamer.Add(2, 2);
+            }
+
+            Assert.AreEqual(1, cache[1]);
+            Assert.AreEqual(2, cache[2]);
+        }
+
+        /// <summary>
+        /// Tests that streamer does not lose data during random topology changes.
+        /// </summary>
+        [Test]
+        public void TestStreamerDoesNotLoseDataOnRandomTopologyChanges()
+        {
+            const int maxNodes = 4;
+            const int topologyChanges = 16;
+
+            var nodes = new Queue<IIgnite>();
+            nodes.Enqueue(StartServer());
+
+            var client = StartClient(maxPort: 10809);
+            var cache = CreateCache(client);
+
+            var options = new DataStreamerClientOptions {AllowOverwrite = true};
+            var streamer = client.GetDataStreamer<int, int>(cache.Name, options);
+
+            var id = 0;
+            var cancel = false;
+
+            var adderTask = Task.Factory.StartNew(() =>
+            {
+                // ReSharper disable once AccessToModifiedClosure
+                while (!cancel)
+                {
+                    id++;
+
+                    streamer.Add(id, id);
+
+                    if (id % 500 == 0)
+                    {
+                        // Sleep once in a while to reduce streamed data size.
+                        Thread.Sleep(100);
+                    }
+                }
+            });
+
+            for (int i = 0; i < topologyChanges; i++)
+            {
+                Thread.Sleep(100);
+
+                if (nodes.Count <= 2 || (nodes.Count < maxNodes && TestUtils.Random.Next(2) == 0))
+                {
+                    nodes.Enqueue(StartServer());
+                }
+                else
+                {
+                    nodes.Dequeue().Dispose();
+                }
+            }
+
+            cancel = true;
+            adderTask.Wait(TimeSpan.FromSeconds(15));
+            streamer.Close(cancel: false);
+
+            var streamerImpl = (DataStreamerClient<int, int>) streamer;
+
+            TestUtils.WaitForTrueCondition(
+                () => id == cache.GetSize(),
+                () => string.Format("Expected: {0}, actual: {1}, sent: {2}, alloc: {3}, pool: {4}", id,
+                    cache.GetSize(), streamerImpl.EntriesSent, streamerImpl.ArraysAllocated,
+                    streamerImpl.ArraysPooled),
+                timeout: 3000);
+
+            DataStreamerClientTest.CheckArrayPoolLeak(streamer);
+
+            Assert.Greater(id, 10000);
+
+            Assert.AreEqual(1, cache[1]);
+            Assert.AreEqual(id, cache[id]);
+        }
+
+        /// <summary>
+        /// Tests that flush fails when all servers leave the cluster.
+        /// </summary>
+        [Test]
+        public void TestFlushFailsWhenAllServersStop()
+        {
+            var server = StartServer();
+            var client = StartClient();
+
+            var cache = CreateCache(client);
+
+            var streamer = client.GetDataStreamer<int, int>(cache.Name);
+
+            streamer.Add(1, 1);
+            streamer.Flush();
+
+            server.Dispose();
+
+            streamer.Add(2, 2);
+
+            var ex = Assert.Throws<AggregateException>(() => streamer.Flush()).GetBaseException();
+            StringAssert.StartsWith("Failed to establish Ignite thin client connection", ex.Message);
+        }
+
+        /// <summary>
+        /// Tests that buffers for disconnected server nodes get flushed on explicit flush call.
+        /// </summary>
+        [Test]
+        public void TestDisconnectedBuffersGetFlushedOnExplicitFlush()
+        {
+            var server = StartServer();
+            var client = StartClient();
+
+            var cache = CreateCache(client);
+
+            var options = new DataStreamerClientOptions
+            {
+                PerNodeBufferSize = 3
+            };
+
+            using (var streamer = client.GetDataStreamer<int, int>(cache.Name, options))
+            {
+                // Fill the buffer for the initial server node.
+                streamer.Add(-1, -1);
+                streamer.Add(-2, -2);
+
+                StartServer();
+                server.Dispose();
+
+                // Perform cache operation to detect connection failure.
+                Assert.Catch(() => cache.Put(1, 3));
+
+                // Fill the buffer to force flush.
+                streamer.Add(1, 1);
+                streamer.Add(2, 2);
+                streamer.Add(3, 3);
+
+                // Automatic flush does not involve old buffer.
+                TestUtils.WaitForTrueCondition(() => cache.ContainsKey(1));
+                Assert.AreEqual(3, cache.GetSize());
+                Assert.IsTrue(cache.ContainsKeys(new[]{1, 2, 3}));
+
+                // Explicit flush includes old buffer.
+                streamer.Add(4, 4);
+                streamer.Flush();
+
+                Assert.AreEqual(6, cache.GetSize());
+                Assert.IsTrue(cache.ContainsKeys(new[]{-1, -2, 4}));
+            }
+        }
+
+        /// <summary>
+        /// Tests that buffers for disconnected server nodes get flushed on close / dispose.
+        /// </summary>
+        [Test]
+        public void TestDisconnectedBuffersGetFlushedOnClose()
+        {
+            var server = StartServer();
+            var client = StartClient();
+            var cache = CreateCache(client);
+
+            using (var streamer = client.GetDataStreamer<int, int>(cache.Name))
+            {
+                // Fill the buffer for the initial server node.
+                streamer.Add(-1, -1);
+                streamer.Add(-2, -2);
+
+                StartServer();
+                server.Dispose();
+
+                // Perform cache operation to detect connection failure.
+                Assert.Catch(() => cache.Put(1, 3));
+
+                // Fill the buffer for a new node.
+                streamer.Add(1, 1);
+                streamer.Add(2, 2);
+            }
+
+            // Close/Dispose flushes all buffers, including the buffer for the old node that was disconnected.
+            Assert.AreEqual(4, cache.GetSize());
+            Assert.IsTrue(cache.ContainsKeys(new[]{-1, -2, 1, 2}));
+        }
+
+        private static IgniteConfiguration GetServerConfiguration()
+        {
+            return new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                AutoGenerateIgniteInstanceName = true,
+                DiscoverySpi = TestUtils.GetStaticDiscovery(maxPort: 47509),
+                DataStorageConfiguration = new DataStorageConfiguration
+                {
+                    DefaultDataRegionConfiguration = new DataRegionConfiguration
+                    {
+                        Name = DataStorageConfiguration.DefaultDataRegionName,
+                        MaxSize = 500 * 1024 * 1024
+                    }
+                }
+            };
+        }
+
+        private static IIgnite StartServer()
+        {
+            return Ignition.Start(GetServerConfiguration());
+        }
+
+        private static ICacheClient<int, int> CreateCache(IIgniteClient client)
+        {
+            return client.CreateCache<int, int>(new CacheClientConfiguration
+            {
+                Name = TestUtils.TestName,
+                CacheMode = CacheMode.Replicated,
+                WriteSynchronizationMode = CacheWriteSynchronizationMode.FullSync,
+                RebalanceMode = CacheRebalanceMode.Sync
+            });
+        }
+
+        private IIgniteClient StartClient(int maxPort = 10805)
+        {
+            var cfg = new IgniteClientConfiguration("127.0.0.1:10800.." + maxPort)
+            {
+                EnablePartitionAwareness = _enablePartitionAwareness
+            };
+
+            return new IgniteClient(cfg);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTopologyChangeTestPartitionAware.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTopologyChangeTestPartitionAware.cs
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Datastream
+{
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests thin client data streamer with topology changes.
+    /// </summary>
+    [TestFixture]
+    [Category(TestUtils.CategoryIntensive)]
+    public class DataStreamerClientTopologyChangeTestPartitionAware : DataStreamerClientTopologyChangeTest
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientTopologyChangeTestPartitionAware"/> class.
+        /// </summary>
+        public DataStreamerClientTopologyChangeTestPartitionAware() : base(true)
+        {
+            // No-op.
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
@@ -149,6 +149,22 @@ namespace Apache.Ignite.Core.Tests.Dataload
         }
 
         /// <summary>
+        /// Tests removal without <see cref="IDataStreamer{TK,TV}.AllowOverwrite"/>.
+        /// </summary>
+        [Test]
+        public void TestRemoveNoOverwrite()
+        {
+            _cache.Put(1, 1);
+
+            using (var ldr = _grid.GetDataStreamer<int, int>(CacheName))
+            {
+                ldr.Remove(1);
+            }
+
+            Assert.IsTrue(_cache.ContainsKey(1));
+        }
+
+        /// <summary>
         /// Test data add/remove.
         /// </summary>
         [Test]
@@ -825,7 +841,7 @@ namespace Apache.Ignite.Core.Tests.Dataload
 
                 Assert.AreSame(batchTask, flushTask2);
                 await flushTask2;
-                
+
                 Assert.IsTrue(batchTask.IsCompleted);
                 Assert.IsFalse(await _cache.ContainsKeyAsync(1));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/PlatformTestService.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/PlatformTestService.cs
@@ -313,6 +313,7 @@ namespace Apache.Ignite.Core.Tests.Services
             if (x == null || x.Length != 1)
                 throw new Exception("Expected array of length 1");
 
+            // ReSharper disable once PossibleInvalidOperationException
             return new DateTime?[] {test((DateTime) x[0])};
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -39,6 +39,7 @@ namespace Apache.Ignite.Core.Tests
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Client;
     using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Impl.Unmanaged.Jni;
     using Apache.Ignite.Core.Log;
     using Apache.Ignite.Core.Tests.Process;
     using NUnit.Framework;
@@ -70,8 +71,8 @@ namespace Apache.Ignite.Core.Tests
             ? new List<string>
             {
                 "-XX:+HeapDumpOnOutOfMemoryError",
-                "-Xms1g",
-                "-Xmx4g",
+                "-Xms2g",
+                "-Xmx6g",
                 "-ea",
                 "-DIGNITE_QUIET=true",
                 "-Duser.timezone=UTC"
@@ -340,26 +341,30 @@ namespace Apache.Ignite.Core.Tests
         public static void WaitForTrueCondition(Func<bool> cond, Func<string> messageFunc, int timeout = 1000)
         {
             var res = WaitForCondition(cond, timeout);
-            var message = string.Format("Condition not reached within {0} ms", timeout);
 
-            if (messageFunc != null)
+            if (!res)
             {
-                message += string.Format(" ({0})", messageFunc());
-            }
+                var message = string.Format("Condition not reached within {0} ms", timeout);
 
-            Assert.IsTrue(res, message);
+                if (messageFunc != null)
+                {
+                    message += string.Format(" ({0})", messageFunc());
+                }
+
+                Assert.IsTrue(res, message);
+            }
         }
 
         /// <summary>
         /// Gets the static discovery.
         /// </summary>
-        public static TcpDiscoverySpi GetStaticDiscovery()
+        public static TcpDiscoverySpi GetStaticDiscovery(int? maxPort = null)
         {
             return new TcpDiscoverySpi
             {
                 IpFinder = new TcpDiscoveryStaticIpFinder
                 {
-                    Endpoints = new[] { "127.0.0.1:47500" }
+                    Endpoints = new[] { "127.0.0.1:47500" + (maxPort == null ? null : (".." + maxPort)) }
                 },
                 SocketTimeout = TimeSpan.FromSeconds(0.3)
             };
@@ -615,6 +620,19 @@ namespace Apache.Ignite.Core.Tests
         }
 
         /// <summary>
+        /// Creates the JVM if necessary.
+        /// </summary>
+        public static void EnsureJvmCreated()
+        {
+            if (Jvm.Get(true) == null)
+            {
+                var logger = new TestContextLogger();
+                JvmDll.Load(null, logger);
+                IgniteManager.CreateJvm(GetTestConfiguration(), logger);
+            }
+        }
+
+        /// <summary>
         /// Runs the test in new process.
         /// </summary>
         [SuppressMessage("ReSharper", "AssignNullToNotNullAttribute")]
@@ -648,17 +666,17 @@ namespace Apache.Ignite.Core.Tests
                 }
             }
         }
-        
+
         /// <summary>
         /// Deploys the Java service.
         /// </summary>
         public static string DeployJavaService(IIgnite ignite)
         {
             const string serviceName = "javaService";
-            
+
             ignite.GetCompute()
                 .ExecuteJavaTask<object>("org.apache.ignite.platform.PlatformDeployServiceTask", serviceName);
-            
+
             var services = ignite.GetServices();
 
             WaitForCondition(() => services.GetServiceDescriptors().Any(x => x.Name == serviceName), 1000);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
@@ -30,6 +30,9 @@ namespace Apache.Ignite.Core.Tests
         /** */
         private const string ClassPlatformThreadUtils = "org/apache/ignite/platform/PlatformThreadUtils";
 
+        /** */
+        private const string ClassPlatformStartIgniteUtils = "org/apache/ignite/platform/PlatformStartIgniteUtils";
+
         /// <summary>
         /// Suspend Ignite threads for the given grid.
         /// </summary>
@@ -101,6 +104,16 @@ namespace Apache.Ignite.Core.Tests
         public static string GetJavaThreadName()
         {
             return CallStringMethod(ClassPlatformThreadUtils, "getThreadName", "()Ljava/lang/String;");
+        }
+
+        public static void StartIgnite(string name)
+        {
+            CallStringMethod(ClassPlatformStartIgniteUtils, "startWithSecurity", "(Ljava/lang/String;)V", name);
+        }
+
+        public static void StopIgnite(string name)
+        {
+            CallStringMethod(ClassPlatformStartIgniteUtils, "stop", "(Ljava/lang/String;)V", name);
         }
 
         /** */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -66,6 +66,8 @@
     <Compile Include="Client\Cache\Query\Continuous\ContinuousQueryDisconnectedEventArgs.cs" />
     <Compile Include="Client\Cache\Query\Continuous\IContinuousQueryHandleClient.cs" />
     <Compile Include="Client\Compute\IComputeClient.cs" />
+    <Compile Include="Client\Datastream\DataStreamerClientOptions.cs" />
+    <Compile Include="Client\Datastream\IDataStreamerClient.cs" />
     <Compile Include="Client\IClientCluster.cs" />
     <Compile Include="Client\IClientClusterGroup.cs" />
     <Compile Include="Client\IClientClusterNode.cs" />
@@ -124,6 +126,7 @@
     <Compile Include="Impl\Client\ClientDiscoveryNode.cs" />
     <Compile Include="Impl\Client\ClientFeatures.cs" />
     <Compile Include="Impl\Client\ClientNotificationHandler.cs" />
+    <Compile Include="Impl\Client\ClientPlatformId.cs" />
     <Compile Include="Impl\Client\ClientRequestContext.cs" />
     <Compile Include="Impl\Client\ClientResponseContext.cs" />
     <Compile Include="Impl\Client\Cluster\ClientCluster.cs" />
@@ -137,6 +140,10 @@
     <Compile Include="Impl\Client\Cluster\ClientClusterNode.cs" />
     <Compile Include="Impl\Client\Compute\ComputeClient.cs" />
     <Compile Include="Impl\Client\Compute\ComputeClientFlags.cs" />
+    <Compile Include="Impl\Client\Datastream\DataStreamerClient.cs" />
+    <Compile Include="Impl\Client\Datastream\DataStreamerClientBuffer.cs" />
+    <Compile Include="Impl\Client\Datastream\DataStreamerClientEntry.cs" />
+    <Compile Include="Impl\Client\Datastream\DataStreamerClientPerNodeBuffer.cs" />
     <Compile Include="Impl\Client\Endpoint.cs" />
     <Compile Include="Impl\Client\Services\ServicesClient.cs" />
     <Compile Include="Impl\Client\SocketEndpoint.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/ClientStatusCode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/ClientStatusCode.cs
@@ -39,6 +39,11 @@ namespace Apache.Ignite.Core.Client
         InvalidOpCode = 2,
 
         /// <summary>
+        /// Invalid node state (node is stopping or not fully started).
+        /// </summary>
+        InvalidNodeState = 10,
+
+        /// <summary>
         /// Specified cache does not exist.
         /// </summary>
         CacheDoesNotExist = 1000,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/DataStreamerClientOptions.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/DataStreamerClientOptions.cs
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Client.Datastream
+{
+    using System;
+    using Apache.Ignite.Core.Datastream;
+    using Apache.Ignite.Core.Impl.Common;
+
+    /// <summary>
+    /// Thin client data streamer options.
+    /// <para />
+    /// To set a receiver, use generic class <see cref="DataStreamerClientOptions{K,V}"/>.
+    /// <para />
+    /// See also <see cref="IDataStreamerClient{TK,TV}"/>, <see cref="IIgniteClient.GetDataStreamer{TK,TV}(string)"/>.
+    /// </summary>
+    public class DataStreamerClientOptions
+    {
+        /// <summary>
+        /// The default client-side per-node buffer size (cache entries count),
+        /// see <see cref="DataStreamerClientOptions.PerNodeBufferSize"/>.
+        /// </summary>
+        public const int DefaultPerNodeBufferSize = 512;
+
+        /// <summary>
+        /// The default limit for parallel operations per server node connection,
+        /// see <see cref="DataStreamerClientOptions.PerNodeParallelOperations"/>.
+        /// <para />
+        /// Calculated as <see cref="Environment.ProcessorCount"/> times 4.
+        /// </summary>
+        public static readonly int DefaultPerNodeParallelOperations = Environment.ProcessorCount * 4;
+
+        /** */
+        private int _perNodeParallelOperations;
+
+        /** */
+        private int _perNodeBufferSize;
+
+        /** */
+        private TimeSpan _autoFlushInterval;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientOptions"/>.
+        /// </summary>
+        public DataStreamerClientOptions()
+        {
+            PerNodeBufferSize = DefaultPerNodeBufferSize;
+            PerNodeParallelOperations = DefaultPerNodeParallelOperations;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientOptions"/>.
+        /// </summary>
+        /// <param name="options">Options to copy from.</param>
+        public DataStreamerClientOptions(DataStreamerClientOptions options) : this()
+        {
+            if (options == null)
+            {
+                return;
+            }
+
+            ReceiverKeepBinary = options.ReceiverKeepBinary;
+            ReceiverInternal = options.ReceiverInternal;
+            AllowOverwrite = options.AllowOverwrite;
+            SkipStore = options.SkipStore;
+            PerNodeBufferSize = options.PerNodeBufferSize;
+            PerNodeParallelOperations = options.PerNodeParallelOperations;
+            AutoFlushInterval = options.AutoFlushInterval;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether <see cref="DataStreamerClientOptions{K,V}.Receiver"/>
+        /// should operate in binary mode.
+        /// </summary>
+        public bool ReceiverKeepBinary { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether existing values can be overwritten by the data streamer.
+        /// Performance is better when this flag is false.
+        /// <para />
+        /// NOTE: When false, cache updates won't be propagated to cache store
+        /// (even if <see cref="SkipStore"/> is false).
+        /// <para />
+        /// Default is <c>false</c>.
+        /// </summary>
+        public bool AllowOverwrite { get; set; }
+
+        /// <summary>
+        /// Gets or sets a flag indicating that write-through behavior should be disabled for data loading.
+        /// <para />
+        /// <see cref="AllowOverwrite"/> must be true for write-through to work.
+        /// <para />
+        /// Default is <c>false</c>.
+        /// </summary>
+        public bool SkipStore { get; set; }
+
+        /// <summary>
+        /// Gets or sets the size (entry count) of per node buffer.
+        /// <para />
+        /// Default is <see cref="DefaultPerNodeBufferSize"/>.
+        /// </summary>
+        public int PerNodeBufferSize
+        {
+            get { return _perNodeBufferSize; }
+            set
+            {
+                IgniteArgumentCheck.Ensure(value > 0, "value", "should be > 0");
+                _perNodeBufferSize = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the limit for parallel operations per server node.
+        /// <para />
+        /// Default is <see cref="DefaultPerNodeParallelOperations"/>.
+        /// </summary>
+        public int PerNodeParallelOperations
+        {
+            get { return _perNodeParallelOperations; }
+            set
+            {
+                IgniteArgumentCheck.Ensure(value > 0, "value", "should be > 0");
+                _perNodeParallelOperations = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the automatic flush interval. Data streamer buffers the data for performance reasons.
+        /// The buffer is flushed in the following cases:
+        /// <ul>
+        /// <li>Buffer is full.</li>
+        /// <li><see cref="IDataStreamerClient{TK,TV}.Flush"/> is called.</li>
+        /// <li>Periodically when <see cref="AutoFlushInterval"/> is set.</li >
+        /// </ul>
+        /// <para />
+        /// When set to <see cref="TimeSpan.Zero"/>, automatic flush is disabled.
+        /// <para />
+        /// Default is <see cref="TimeSpan.Zero"/> (disabled).
+        /// </summary>
+        public TimeSpan AutoFlushInterval
+        {
+            get { return _autoFlushInterval; }
+            set
+            {
+                IgniteArgumentCheck.Ensure(value >= TimeSpan.Zero, "value", "should be >= 0");
+                _autoFlushInterval = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the receiver object.
+        /// </summary>
+        internal object ReceiverInternal { get; set; }
+    }
+
+    /// <summary>
+    /// Thin client data streamer extended options.
+    /// <para />
+    /// See also <see cref="IDataStreamerClient{TK,TV}"/>, <see cref="IIgniteClient.GetDataStreamer{TK,TV}(string)"/>.
+    /// </summary>
+    public class DataStreamerClientOptions<TK, TV> : DataStreamerClientOptions
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientOptions{TK,TV}"/>.
+        /// </summary>
+        public DataStreamerClientOptions()
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientOptions{TK,TV}"/>.
+        /// </summary>
+        /// <param name="options">Options to copy from.</param>
+        public DataStreamerClientOptions(DataStreamerClientOptions options) : base(options)
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientOptions{TK,TV}"/>.
+        /// </summary>
+        /// <param name="options">Options to copy from.</param>
+        public DataStreamerClientOptions(DataStreamerClientOptions<TK, TV> options) : base(options)
+        {
+            // No-op.
+        }
+
+        /// <summary>
+        /// Gets or sets a custom stream receiver.
+        /// Stream receiver is invoked for every cache entry on the primary server node for that entry.
+        /// </summary>
+        public IStreamReceiver<TK, TV> Receiver
+        {
+            get { return (IStreamReceiver<TK, TV>) ReceiverInternal; }
+            set { ReceiverInternal = value; }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Client.Datastream
+{
+    using System;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Thin client data streamer.
+    /// <para />
+    /// Data streamer is an efficient and fault-tolerant way to load data into cache. Updates are buffered and mapped
+    /// to primary nodes to ensure minimal data movement and optimal resource utilization.
+    /// Update failures caused by cluster topology changes are retried automatically.
+    /// <para />
+    /// Note that streamer send data to remote nodes asynchronously, so cache updates can be reordered.
+    /// <para />
+    /// Instances of the implementing class are thread-safe: data can be added from multiple threads.
+    /// <para />
+    /// Closing and disposing: <see cref="IDisposable.Dispose"/> method calls <see cref="Close"/><c>(false)</c>.
+    /// This will flush any remaining data to the cache synchronously.
+    /// To avoid blocking threads when exiting <c>using()</c> block, use <see cref="CloseAsync"/>.
+    /// </summary>
+    public interface IDataStreamerClient<TK, TV> : IDisposable
+    {
+        /// <summary>
+        /// Gets the cache name.
+        /// </summary>
+        string CacheName { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether this streamer is closed.
+        /// </summary>
+        bool IsClosed { get; }
+
+        /// <summary>
+        /// Gets the options.
+        /// </summary>
+        DataStreamerClientOptions<TK, TV> Options { get; }
+
+        /// <summary>
+        /// Adds an entry to the streamer.
+        /// <para />
+        /// This method adds an entry to the buffer. When the buffer gets full, it is scheduled for
+        /// asynchronous background flush. This method will block when the number of active flush operations
+        /// exceeds <see cref="DataStreamerClientOptions.PerNodeParallelOperations"/>.
+        /// </summary>
+        /// <param name="key">Key.</param>
+        /// <param name="val">Value. When null, cache entry will be removed.</param>
+        void Add(TK key, TV val);
+
+        /// <summary>
+        /// Adds a removal entry to the streamer. Cache entry with the specified key will be removed.
+        /// <para />
+        /// Removal requires <see cref="DataStreamerClientOptions.AllowOverwrite"/> to be <c>true</c>.
+        /// <para />
+        /// This method adds an entry to the buffer. When the buffer gets full, it is scheduled for
+        /// asynchronous background flush. This method will block when the number of active flush operations
+        /// exceeds <see cref="DataStreamerClientOptions.PerNodeParallelOperations"/>.
+        /// </summary>
+        /// <param name="key"></param>
+        void Remove(TK key);
+
+        /// <summary>
+        /// Flushes all buffered entries.
+        /// </summary>
+        void Flush();
+
+        /// <summary>
+        /// Flushes all buffered entries asynchronously.
+        /// </summary>
+        Task FlushAsync();
+
+        /// <summary>
+        /// Closes this streamer, optionally loading any remaining data into the cache.
+        /// </summary>
+        /// <param name="cancel">Whether to cancel ongoing loading operations. When set to <c>true</c>,
+        /// there is no guarantee which part of remaining data will be actually loaded into the cache.</param>
+        void Close(bool cancel);
+
+        /// <summary>
+        /// Closes this streamer, optionally loading any remaining data into the cache.
+        /// </summary>
+        /// <param name="cancel">Whether to cancel ongoing loading operations. When set to <c>true</c>,
+        /// there is no guarantee which part of remaining data will be actually loaded into the cache.</param>
+        Task CloseAsync(bool cancel);
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
@@ -23,6 +23,7 @@ namespace Apache.Ignite.Core.Client
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Client.Compute;
+    using Apache.Ignite.Core.Client.Datastream;
     using Apache.Ignite.Core.Client.Services;
     using Apache.Ignite.Core.Client.Transactions;
 
@@ -155,5 +156,37 @@ namespace Apache.Ignite.Core.Client
         /// Gets the services API.
         /// </summary>
         IServicesClient GetServices();
+
+        /// <summary>
+        /// Gets a new instance of the data streamer associated with the given cache name.
+        /// <para />
+        /// Data streamer loads data efficiently into cache.
+        /// See <see cref="IDataStreamerClient{TK,TV}"/> for more information.
+        /// </summary>
+        /// <param name="cacheName">Cache name.</param>
+        /// <returns>Data streamer.</returns>
+        IDataStreamerClient<TK, TV> GetDataStreamer<TK, TV>(string cacheName);
+
+        /// <summary>
+        /// Gets a new instance of the data streamer associated with the given cache name.
+        /// <para />
+        /// Data streamer loads data efficiently into cache.
+        /// See <see cref="IDataStreamerClient{TK,TV}"/> for more information.
+        /// </summary>
+        /// <param name="cacheName">Cache name.</param>
+        /// <param name="options">Data streamer options.</param>
+        /// <returns>Data streamer.</returns>
+        IDataStreamerClient<TK, TV> GetDataStreamer<TK, TV>(string cacheName, DataStreamerClientOptions options);
+
+        /// <summary>
+        /// Gets a new instance of the data streamer associated with the given cache name.
+        /// <para />
+        /// Data streamer loads data efficiently into cache.
+        /// See <see cref="IDataStreamerClient{TK,TV}"/> for more information.
+        /// </summary>
+        /// <param name="cacheName">Cache name.</param>
+        /// <param name="options">Data streamer options.</param>
+        /// <returns>Data streamer.</returns>
+        IDataStreamerClient<TK, TV> GetDataStreamer<TK, TV>(string cacheName, DataStreamerClientOptions<TK, TV> options);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -80,12 +80,6 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             WithExpiryPolicy = 1 << 2
         }
 
-        /** Query filter platform code: Java filter. */
-        private const byte FilterPlatformJava = 1;
-
-        /** Query filter platform code: .NET filter. */
-        private const byte FilterPlatformDotnet = 2;
-
         /** Cache name. */
         private readonly string _name;
 
@@ -892,7 +886,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
 
                 writer.WriteObject(holder);
 
-                writer.WriteByte(FilterPlatformDotnet);
+                writer.WriteByte(ClientPlatformId.Dotnet);
             }
 
             writer.WriteInt(qry.PageSize);
@@ -1113,14 +1107,14 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
                 if (javaFilter != null)
                 {
                     w.WriteObject(javaFilter.GetRawProxy());
-                    w.WriteByte(FilterPlatformJava);
+                    w.WriteByte(ClientPlatformId.Java);
                 }
                 else
                 {
                     var filterHolder = new ContinuousQueryFilterHolder(continuousQuery.Filter, _keepBinary);
 
                     w.WriteObject(filterHolder);
-                    w.WriteByte(FilterPlatformDotnet);
+                    w.WriteByte(ClientPlatformId.Dotnet);
                 }
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -257,7 +257,7 @@ namespace Apache.Ignite.Core.Impl.Client
         /// <summary>
         /// Checks the disposed state.
         /// </summary>
-        private ClientSocket GetSocket()
+        internal ClientSocket GetSocket()
         {
             var tx = _transactions.Tx;
             if (tx != null)
@@ -278,7 +278,7 @@ namespace Apache.Ignite.Core.Impl.Client
             }
         }
 
-        private ClientSocket GetAffinitySocket<TKey>(int cacheId, TKey key)
+        internal ClientSocket GetAffinitySocket<TKey>(int cacheId, TKey key)
         {
             ThrowIfDisposed();
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
@@ -90,6 +90,10 @@ namespace Apache.Ignite.Core.Impl.Client
         ComputeTaskFinished = 6001,
 
         // Services.
-        ServiceInvoke = 7000
+        ServiceInvoke = 7000,
+
+        // Data Streamer.
+        DataStreamerStart = 8000,
+        DataStreamerAddData = 8001
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientPlatformId.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientPlatformId.cs
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client
+{
+    /// <summary>
+    /// Platform ids.
+    /// <para />
+    /// See <c>org.apache.ignite.internal.processors.platform.client.ClientPlatform</c> in Java.
+    /// </summary>
+    internal static class ClientPlatformId
+    {
+        /** Java platform code. */
+        public const byte Java = 1;
+
+        /** .NET platform code. */
+        public const byte Dotnet = 2;
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -225,7 +225,8 @@ namespace Apache.Ignite.Core.Impl.Client
         /// Performs a send-receive operation asynchronously.
         /// </summary>
         public Task<T> DoOutInOpAsync<T>(ClientOp opId, Action<ClientRequestContext> writeAction,
-            Func<ClientResponseContext, T> readFunc, Func<ClientStatusCode, string, T> errorFunc = null)
+            Func<ClientResponseContext, T> readFunc, Func<ClientStatusCode, string, T> errorFunc = null,
+            bool syncCallback = false)
         {
             // Encode.
             var reqMsg = WriteMessage(writeAction, opId);
@@ -234,6 +235,12 @@ namespace Apache.Ignite.Core.Impl.Client
             var task = SendRequestAsync(ref reqMsg);
 
             // Decode.
+            if (syncCallback)
+            {
+                return task.ContinueWith(responseTask => DecodeResponse(responseTask.Result, readFunc, errorFunc),
+                    TaskContinuationOptions.ExecuteSynchronously);
+            }
+
             // NOTE: ContWith explicitly uses TaskScheduler.Default,
             // which runs DecodeResponse (and any user continuations) on a thread pool thread,
             // so that WaitForMessages thread does not do anything except reading from the socket.
@@ -995,13 +1002,16 @@ namespace Apache.Ignite.Core.Impl.Client
                 {
                     return;
                 }
+                
+                // Set disposed state before ending requests so that request continuations see disconnected socket.
+                _isDisposed = true;
 
                 _exception = _exception ?? new ObjectDisposedException(typeof(ClientSocket).FullName);
                 EndRequestsWithError();
-                
+
                 // This will call Socket.Shutdown and Socket.Close.
                 _stream.Close();
-                
+
                 _listenerEvent.Set();
                 _listenerEvent.Dispose();
 
@@ -1009,9 +1019,13 @@ namespace Apache.Ignite.Core.Impl.Client
                 {
                     _timeoutCheckTimer.Dispose();
                 }
-
-                _isDisposed = true;
             }
+        }
+
+        /** <inheritDoc /> */
+        public override string ToString()
+        {
+            return string.Format("ClientSocket [RemoteEndPoint={0}]", RemoteEndPoint);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClient.cs
@@ -1,0 +1,696 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client.Datastream
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.IO;
+    using System.Net.Sockets;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Datastream;
+    using Apache.Ignite.Core.Datastream;
+    using Apache.Ignite.Core.Impl.Binary;
+    using Apache.Ignite.Core.Impl.Common;
+    using Apache.Ignite.Core.Impl.Datastream;
+    using BinaryWriter = Apache.Ignite.Core.Impl.Binary.BinaryWriter;
+
+    /// <summary>
+    /// Thin client data streamer.
+    /// </summary>
+    internal sealed class DataStreamerClient<TK, TV> : IDataStreamerClient<TK, TV>
+    {
+        /** Streamer flags. */
+        [Flags]
+        private enum Flags : byte
+        {
+            AllowOverwrite = 0x01,
+            SkipStore = 0x02,
+            KeepBinary = 0x04,
+            Flush = 0x08,
+            Close = 0x10
+        }
+
+        /** */
+        private const int ServerBufferSizeAuto = -1;
+
+        /** */
+        private const int MaxRetries = 16;
+
+        /** */
+        private readonly ClientFailoverSocket _socket;
+
+        /** */
+        private readonly int _cacheId;
+
+        /** */
+        private readonly string _cacheName;
+
+        /** */
+        private readonly DataStreamerClientOptions<TK, TV> _options;
+
+        /** */
+        private readonly ConcurrentDictionary<ClientSocket, DataStreamerClientPerNodeBuffer<TK, TV>> _buffers =
+            new ConcurrentDictionary<ClientSocket, DataStreamerClientPerNodeBuffer<TK, TV>>();
+
+        /** */
+        private readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
+
+        /** Cached flags. */
+        private readonly Flags _flags;
+
+        /** */
+        private readonly ConcurrentStack<DataStreamerClientEntry<TK, TV>[]> _arrayPool
+            = new ConcurrentStack<DataStreamerClientEntry<TK, TV>[]>();
+
+        private readonly Timer _autoFlushTimer;
+
+        /** */
+        private int _arraysAllocated;
+
+        /** */
+        private long _entriesSent;
+
+        /** Exception. When set, the streamer is closed. */
+        private volatile Exception _exception;
+
+        /** Cancelled flag. */
+        private volatile bool _cancelled;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClient{TK,TV}"/>.
+        /// </summary>
+        /// <param name="socket">Socket.</param>
+        /// <param name="cacheName">Cache name.</param>
+        /// <param name="options">Options.</param>
+        public DataStreamerClient(
+            ClientFailoverSocket socket,
+            string cacheName,
+            DataStreamerClientOptions<TK, TV> options)
+        {
+            Debug.Assert(socket != null);
+            Debug.Assert(!string.IsNullOrEmpty(cacheName));
+
+            // Copy to prevent modification.
+            _options = new DataStreamerClientOptions<TK, TV>(options);
+            _socket = socket;
+            _cacheName = cacheName;
+            _cacheId = BinaryUtils.GetCacheId(cacheName);
+            _flags = GetFlags(_options);
+
+            var interval = _options.AutoFlushInterval;
+            if (interval != TimeSpan.Zero)
+            {
+                _autoFlushTimer = new Timer(_ => AutoFlush(), null, interval, interval);
+            }
+        }
+
+        /** <inheritdoc /> */
+        public void Dispose()
+        {
+            Close(cancel: false);
+        }
+
+        /** <inheritdoc /> */
+        public string CacheName
+        {
+            get { return _cacheName; }
+        }
+
+        /** <inheritdoc /> */
+        public bool IsClosed
+        {
+            get { return _exception != null; }
+        }
+
+        /** <inheritdoc /> */
+        public DataStreamerClientOptions<TK, TV> Options
+        {
+            get
+            {
+                // Copy to prevent modification.
+                return new DataStreamerClientOptions<TK, TV>(_options);
+            }
+        }
+
+        /** <inheritdoc /> */
+        public void Add(TK key, TV val)
+        {
+            IgniteArgumentCheck.NotNull(key, "key");
+
+            Add(new DataStreamerClientEntry<TK, TV>(key, val));
+        }
+
+        /** <inheritdoc /> */
+        public void Remove(TK key)
+        {
+            IgniteArgumentCheck.NotNull(key, "key");
+
+            if (!_options.AllowOverwrite)
+            {
+                throw new IgniteClientException("DataStreamer can't remove data when AllowOverwrite is false.");
+            }
+
+            Add(new DataStreamerClientEntry<TK, TV>(key));
+        }
+
+        /** <inheritdoc /> */
+        public void Flush()
+        {
+            FlushAsync().Wait();
+        }
+
+        /** <inheritdoc /> */
+        public Task FlushAsync()
+        {
+            ThrowIfClosed();
+
+            return FlushInternalAsync();
+        }
+
+        /** <inheritdoc /> */
+        public void Close(bool cancel)
+        {
+            CloseAsync(cancel).Wait();
+        }
+
+        /** <inheritdoc /> */
+        public Task CloseAsync(bool cancel)
+        {
+            _rwLock.EnterWriteLock();
+
+            try
+            {
+                if (_exception != null)
+                {
+                    // Already closed.
+                    return TaskRunner.CompletedTask;
+                }
+
+                _exception = new ObjectDisposedException("DataStreamerClient", "Data streamer has been disposed");
+
+                if (_autoFlushTimer != null)
+                {
+                    _autoFlushTimer.Dispose();
+                }
+
+                if (cancel)
+                {
+                    // Disregard current buffers, stop all retry loops.
+                    _cancelled = true;
+
+                    return TaskRunner.CompletedTask;
+                }
+
+                return FlushInternalAsync();
+            }
+            finally
+            {
+                _rwLock.ExitWriteLock();
+            }
+        }
+
+        /** <inheritdoc /> */
+        public override string ToString()
+        {
+            return string.Format("{0} [CacheName={1}, IsClosed={2}]", GetType().Name, CacheName, IsClosed);
+        }
+
+        /// <summary>
+        /// Gets the count of sent entries.
+        /// </summary>
+        internal long EntriesSent
+        {
+            get { return Interlocked.CompareExchange(ref _entriesSent, -1, -1); }
+        }
+
+        /// <summary>
+        /// Gets the count of allocated arrays.
+        /// </summary>
+        internal int ArraysAllocated
+        {
+            get { return Interlocked.CompareExchange(ref _arraysAllocated, -1, -1); }
+        }
+
+        /// <summary>
+        /// Gets the count of pooled arrays.
+        /// </summary>
+        internal int ArraysPooled
+        {
+            get { return _arrayPool.Count; }
+        }
+
+        /// <summary>
+        /// Gets the pooled entry array.
+        /// </summary>
+        internal DataStreamerClientEntry<TK, TV>[] GetPooledArray()
+        {
+            DataStreamerClientEntry<TK,TV>[] res;
+
+            if (_arrayPool.TryPop(out res))
+            {
+                // Reset buffer and return.
+                Array.Clear(res, 0, res.Length);
+
+                return res;
+            }
+
+            Interlocked.Increment(ref _arraysAllocated);
+            res = new DataStreamerClientEntry<TK, TV>[_options.PerNodeBufferSize];
+            return res;
+        }
+
+        /// <summary>
+        /// Returns entry array to the pool.
+        /// </summary>
+        internal void ReturnPooledArray(DataStreamerClientEntry<TK, TV>[] buffer)
+        {
+            _arrayPool.Push(buffer);
+        }
+
+        /// <summary>
+        /// Adds an entry to the streamer.
+        /// </summary>
+        private void Add(DataStreamerClientEntry<TK, TV> entry)
+        {
+            if (!_rwLock.TryEnterReadLock(0))
+            {
+                throw new ObjectDisposedException("DataStreamerClient", "Data streamer has been disposed");
+            }
+
+            try
+            {
+                ThrowIfClosed();
+
+                AddNoLock(entry);
+            }
+            finally
+            {
+                _rwLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Adds an entry without RW lock.
+        /// </summary>
+        private void AddNoLock(DataStreamerClientEntry<TK, TV> entry)
+        {
+            var retries = MaxRetries;
+
+            while (!_cancelled)
+            {
+                try
+                {
+                    var socket = _socket.GetAffinitySocket(_cacheId, entry.Key) ?? _socket.GetSocket();
+                    var buffer = GetOrAddPerNodeBuffer(socket);
+
+                    if (buffer.Add(entry))
+                    {
+                        return;
+                    }
+                }
+                catch (Exception e)
+                {
+                    if (ShouldRetry(e) && retries --> 0)
+                    {
+                        continue;
+                    }
+
+                    throw;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Flushes the streamer asynchronously.
+        /// </summary>
+        private Task FlushInternalAsync()
+        {
+            if (_buffers.IsEmpty)
+            {
+                return TaskRunner.CompletedTask;
+            }
+
+            var tasks = new List<Task>(_buffers.Count);
+
+            foreach (var pair in _buffers)
+            {
+                var buffer = pair.Value;
+                var task = buffer.FlushAllAsync();
+
+                if (task != null && !task.IsCompleted)
+                {
+                    tasks.Add(task);
+                }
+            }
+
+            return TaskRunner.WhenAll(tasks.ToArray());
+        }
+
+        /// <summary>
+        /// Flushes the specified buffer asynchronously.
+        /// </summary>
+        internal Task FlushBufferAsync(
+            DataStreamerClientBuffer<TK, TV> buffer,
+            ClientSocket socket,
+            SemaphoreSlim semaphore)
+        {
+            semaphore.Wait();
+
+            var tcs = new TaskCompletionSource<object>();
+
+            FlushBufferInternalAsync(buffer, socket, tcs);
+
+            return tcs.Task.ContinueWith(t =>
+            {
+                semaphore.Release();
+
+                _exception = _exception ?? t.Exception;
+
+                return t.Result;
+            }, TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        /// Flushes the specified buffer asynchronously.
+        /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "Any exception should be propagated to TaskCompletionSource.")]
+        private void FlushBufferInternalAsync(
+            DataStreamerClientBuffer<TK, TV> buffer,
+            ClientSocket socket,
+            TaskCompletionSource<object> tcs)
+        {
+            try
+            {
+                socket.DoOutInOpAsync(
+                        ClientOp.DataStreamerStart,
+                        ctx => WriteBuffer(buffer, ctx.Writer),
+                        ctx => (object)null,
+                        syncCallback: true)
+                    .ContinueWith(
+                        t => FlushBufferCompleteOrRetry(buffer, socket, tcs, t.Exception),
+                        TaskContinuationOptions.ExecuteSynchronously);
+            }
+            catch (Exception exception)
+            {
+                FlushBufferCompleteOrRetry(buffer, socket, tcs, exception);
+            }
+        }
+
+        /// <summary>
+        /// Completes or retries the buffer flush operation.
+        /// </summary>
+        private void FlushBufferCompleteOrRetry(
+            DataStreamerClientBuffer<TK, TV> buffer,
+            ClientSocket socket,
+            TaskCompletionSource<object> tcs,
+            Exception exception)
+        {
+            if (exception == null)
+            {
+                // Successful flush.
+                Interlocked.Add(ref _entriesSent, buffer.Count);
+                ReturnPooledArray(buffer.Entries);
+                tcs.SetResult(null);
+
+                return;
+            }
+
+            if (_cancelled || (!socket.IsDisposed && !ShouldRetry(exception)))
+            {
+                // Socket is still connected: this error does not need to be retried.
+                ReturnPooledArray(buffer.Entries);
+                tcs.SetException(exception);
+
+                return;
+            }
+
+            // Release receiver thread, perform retry on a separate thread.
+            ThreadPool.QueueUserWorkItem(_ => FlushBufferRetry(buffer, socket, tcs));
+        }
+
+        /// <summary>
+        /// Retries the buffer flush operation.
+        /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "Any exception should be propagated to TaskCompletionSource.")]
+        private void FlushBufferRetry(
+            DataStreamerClientBuffer<TK, TV> buffer,
+            ClientSocket failedSocket,
+            TaskCompletionSource<object> tcs)
+        {
+            try
+            {
+                // Connection failed. Remove disconnected socket from the map.
+                DataStreamerClientPerNodeBuffer<TK, TV> removed;
+                _buffers.TryRemove(failedSocket, out removed);
+
+                // Re-add entries to other buffers.
+                ReAddEntriesAndReturnBuffer(buffer);
+
+                if (removed != null)
+                {
+                    var remaining = removed.Close();
+
+                    while (remaining != null)
+                    {
+                        if (remaining.MarkFlushed())
+                        {
+                            ReAddEntriesAndReturnBuffer(remaining);
+                        }
+
+                        remaining = remaining.Previous;
+                    }
+                }
+
+                // Note: if initial flush was caused by full buffer, not requested by the user,
+                // we don't need to force flush everything here - just re-add entries to other buffers.
+                FlushInternalAsync().ContinueWith(flushTask => flushTask.SetAsResult(tcs));
+            }
+            catch (Exception e)
+            {
+                tcs.SetException(e);
+            }
+        }
+
+        /// <summary>
+        /// Re-adds obsolete buffer entries to new buffers and returns the array to the pool.
+        /// </summary>
+        private void ReAddEntriesAndReturnBuffer(DataStreamerClientBuffer<TK, TV> buffer)
+        {
+            var count = buffer.Count;
+            var entries = buffer.Entries;
+
+            for (var i = 0; i < count; i++)
+            {
+                var entry = entries[i];
+
+                if (!entry.IsEmpty)
+                {
+                    AddNoLock(entry);
+                }
+            }
+
+            ReturnPooledArray(entries);
+        }
+
+        /// <summary>
+        /// Writes buffer data to the specified writer.
+        /// </summary>
+        private void WriteBuffer(DataStreamerClientBuffer<TK, TV> buffer, BinaryWriter w)
+        {
+            w.WriteInt(_cacheId);
+            w.WriteByte((byte) _flags);
+            w.WriteInt(ServerBufferSizeAuto); // Server per-node buffer size.
+            w.WriteInt(ServerBufferSizeAuto); // Server per-thread buffer size.
+
+            if (_options.Receiver != null)
+            {
+                var rcvHolder = new StreamReceiverHolder(_options.Receiver,
+                    (rec, grid, cache, stream, keepBinary) =>
+                        StreamReceiverHolder.InvokeReceiver((IStreamReceiver<TK, TV>) rec, grid, cache, stream,
+                            keepBinary));
+
+                w.WriteObjectDetached(rcvHolder);
+                w.WriteByte(ClientPlatformId.Dotnet);
+            }
+            else
+            {
+                w.WriteObject<object>(null);
+            }
+
+            var count = buffer.Count;
+            w.WriteInt(count);
+
+            var entries = buffer.Entries;
+
+            for (var i = 0; i < count; i++)
+            {
+                var entry = entries[i];
+
+                if (entry.IsEmpty)
+                {
+                    continue;
+                }
+
+                w.WriteObjectDetached(entry.Key);
+
+                if (entry.Remove)
+                {
+                    w.WriteObject<object>(null);
+                }
+                else
+                {
+                    w.WriteObjectDetached(entry.Val);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets or adds per-node buffer for the specified socket.
+        /// </summary>
+        private DataStreamerClientPerNodeBuffer<TK, TV> GetOrAddPerNodeBuffer(ClientSocket socket)
+        {
+            DataStreamerClientPerNodeBuffer<TK,TV> res;
+            if (_buffers.TryGetValue(socket, out res))
+            {
+                return res;
+            }
+
+            var candidate = new DataStreamerClientPerNodeBuffer<TK, TV>(this, socket);
+
+            res = _buffers.GetOrAdd(socket, candidate);
+
+            if (res != candidate)
+            {
+                // Another thread won - return array to the pool.
+                ReturnPooledArray(candidate.Close().Entries);
+            }
+
+            return res;
+        }
+
+        /// <summary>
+        /// Throws an exception if current streamer instance is closed.
+        /// </summary>
+        private void ThrowIfClosed()
+        {
+            var ex = _exception;
+
+            if (ex == null)
+            {
+                return;
+            }
+
+            if (ex is ObjectDisposedException)
+            {
+                throw new ObjectDisposedException("Streamer is closed.");
+            }
+
+            throw new IgniteClientException("Streamer is closed with error, check inner exception for details.", ex);
+        }
+
+        /// <summary>
+        /// Performs timer-based automatic flush.
+        /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "Streamer will be closed if an exception occurs during automated flush. " +
+                            "Timer thread should not throw.")]
+        private void AutoFlush()
+        {
+            if (_exception != null)
+            {
+                return;
+            }
+
+            // Prevent multiple parallel timer calls.
+            if (!Monitor.TryEnter(_autoFlushTimer))
+            {
+                return;
+            }
+
+            try
+            {
+                // Initiate flush, don't wait for completion.
+                FlushInternalAsync();
+            }
+            catch (Exception)
+            {
+                // Ignore.
+            }
+            finally
+            {
+                Monitor.Exit(_autoFlushTimer);
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether flush should be retried after the specified exception.
+        /// </summary>
+        private static bool ShouldRetry(Exception exception)
+        {
+            while (exception.InnerException != null)
+            {
+                exception = exception.InnerException;
+            }
+
+            if (exception is SocketException || exception is IOException)
+            {
+                return true;
+            }
+
+            var clientEx = exception as IgniteClientException;
+
+            if (clientEx != null && clientEx.StatusCode == ClientStatusCode.InvalidNodeState)
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Gets the flags.
+        /// </summary>
+        private static Flags GetFlags(DataStreamerClientOptions options)
+        {
+            var flags = Flags.Flush | Flags.Close;
+
+            if (options.AllowOverwrite)
+            {
+                flags |= Flags.AllowOverwrite;
+            }
+
+            if (options.SkipStore)
+            {
+                flags |= Flags.SkipStore;
+            }
+
+            if (options.ReceiverKeepBinary)
+            {
+                flags |= Flags.KeepBinary;
+            }
+
+            return flags;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClientBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClientBuffer.cs
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client.Datastream
+{
+    using System;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Apache.Ignite.Core.Impl.Common;
+
+    /// <summary>
+    /// Client data streamer buffer.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
+        Justification = "WaitHandle is not used in ReaderWriterLockSlim, no need to dispose.")]
+    internal sealed class DataStreamerClientBuffer<TK, TV>
+    {
+        /** Array vs concurrent data structures:
+         * - Can be written in parallel, since index is from Interlocked.Increment, no additional synchronization needed
+         * - Compact storage (contiguous memory block)
+         * - Less allocations
+         * - Easy pooling
+         */
+        private readonly DataStreamerClientEntry<TK, TV>[] _entries;
+
+        /** */
+        private TaskCompletionSource<object> _flushCompletionSource;
+
+        /** */
+        private readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
+
+        /** */
+        private readonly DataStreamerClientPerNodeBuffer<TK,TV> _parent;
+
+        /** Previous buffer in the chain. Buffer chain allows us to track previous flushes. */
+        private DataStreamerClientBuffer<TK,TV> _previous;
+
+        /** */
+        private long _size;
+
+        /** */
+        private volatile bool _flushing;
+
+        /** */
+        private volatile bool _flushed;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientBuffer{TK,TV}"/>.
+        /// </summary>
+        public DataStreamerClientBuffer(
+            DataStreamerClientEntry<TK,TV>[] entries,
+            DataStreamerClientPerNodeBuffer<TK, TV> parent,
+            DataStreamerClientBuffer<TK, TV> previous)
+        {
+            Debug.Assert(parent != null);
+
+            _entries = entries;
+            _parent = parent;
+            _previous = previous;
+        }
+
+        /// <summary>
+        /// Gets the entry count.
+        /// </summary>
+        public int Count
+        {
+            // Size can exceed entries length when multiple threads compete on Add.
+            get { return _size > _entries.Length ? _entries.Length : (int) _size; }
+        }
+
+        /// <summary>
+        /// Gets the flush task for this and all previous buffers.
+        /// </summary>
+        public Task GetChainFlushTask()
+        {
+            _rwLock.EnterWriteLock();
+
+            try
+            {
+                if (CheckChainFlushed())
+                {
+                    return TaskRunner.CompletedTask;
+                }
+
+                var previous = _previous;
+
+                if (_flushed)
+                {
+                    return previous == null
+                        ? TaskRunner.CompletedTask
+                        : previous.GetChainFlushTask();
+                }
+
+                if (_flushCompletionSource == null)
+                {
+                    _flushCompletionSource = new TaskCompletionSource<object>();
+                }
+
+                return previous == null
+                    ? _flushCompletionSource.Task
+                    : TaskRunner.WhenAll(new[] {previous.GetChainFlushTask(), _flushCompletionSource.Task});
+            }
+            finally
+            {
+                _rwLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Gets the entries array.
+        /// </summary>
+        public DataStreamerClientEntry<TK, TV>[] Entries
+        {
+            get { return _entries; }
+        }
+
+        /// <summary>
+        /// Gets the previous buffer in the chain.
+        /// </summary>
+        public DataStreamerClientBuffer<TK, TV> Previous
+        {
+            get { return _previous; }
+        }
+
+        /// <summary>
+        /// Adds an entry to the buffer.
+        /// </summary>
+        /// <param name="entry">Entry.</param>
+        /// <returns>True when added successfully; false otherwise (buffer is full, flushing, flushed, or closed).</returns>
+        public bool Add(DataStreamerClientEntry<TK, TV> entry)
+        {
+            if (!_rwLock.TryEnterReadLock(0))
+                return false;
+
+            long newSize;
+
+            try
+            {
+                if (_flushing || _flushed)
+                {
+                    return false;
+                }
+
+                newSize = Interlocked.Increment(ref _size);
+
+                if (newSize > _entries.Length)
+                {
+                    return false;
+                }
+
+                _entries[newSize - 1] = entry;
+            }
+            finally
+            {
+                _rwLock.ExitReadLock();
+            }
+
+            if (newSize == _entries.Length)
+            {
+                TryStartFlush();
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Initiates the flush operation.
+        /// </summary>
+        public void ScheduleFlush()
+        {
+            if (Interlocked.CompareExchange(ref _size, -1, -1) == 0)
+            {
+                // Empty buffer.
+                return;
+            }
+
+            TryStartFlush();
+        }
+
+        /// <summary>
+        /// Marks this buffer as flushed.
+        /// </summary>
+        public bool MarkFlushed()
+        {
+            _rwLock.EnterWriteLock();
+
+            try
+            {
+                if (_flushing || _flushed)
+                {
+                    return false;
+                }
+
+                _flushed = true;
+                return true;
+            }
+            finally
+            {
+                _rwLock.ExitWriteLock();
+            }
+        }
+
+        /** <inheritdoc /> */
+        public override string ToString()
+        {
+            return string.Format("{0} [Count={1}, Flushing={2}, Flushed={3}, Previous={4}]", GetType().Name, Count,
+                _flushing, _flushed, _previous);
+        }
+
+        /// <summary>
+        /// Attempts to start the flush operation.
+        /// </summary>
+        private void TryStartFlush()
+        {
+            _rwLock.EnterWriteLock();
+
+            try
+            {
+                if (_flushing || _flushed)
+                {
+                    return;
+                }
+
+                _flushing = true;
+
+                if (Count > 0)
+                {
+                    StartFlush();
+                }
+                else
+                {
+                    OnFlushed();
+                }
+            }
+            finally
+            {
+                _rwLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Starts the flush operation.
+        /// </summary>
+        private void StartFlush()
+        {
+            // NOTE: Continuation runs on socket thread - set result on thread pool.
+            _parent.FlushBufferAsync(this).ContinueWith(
+                t => ThreadPool.QueueUserWorkItem(buf =>
+                    ((DataStreamerClientBuffer<TK, TV>)buf).OnFlushed(t.Exception), this),
+                TaskContinuationOptions.ExecuteSynchronously);
+        }
+
+        /// <summary>
+        /// Called when flush operation completes.
+        /// </summary>
+        private void OnFlushed(AggregateException exception = null)
+        {
+            TaskCompletionSource<object> tcs;
+
+            _rwLock.EnterWriteLock();
+
+            try
+            {
+                _flushed = true;
+                _flushing = false;
+
+                tcs = _flushCompletionSource;
+            }
+            finally
+            {
+                _rwLock.ExitWriteLock();
+            }
+
+            CheckChainFlushed();
+
+            if (tcs != null)
+            {
+                var previous = _previous;
+
+                if (previous == null)
+                {
+                    TrySetResultOrException(tcs, exception);
+                }
+                else
+                {
+                    previous.GetChainFlushTask().ContinueWith(
+                        t => TrySetResultOrException(tcs, exception ?? t.Exception),
+                        TaskContinuationOptions.ExecuteSynchronously);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Checks if entire buffer chain is already flushed.
+        /// </summary>
+        private bool CheckChainFlushed()
+        {
+            var previous = _previous;
+
+            if (previous == null)
+            {
+                return _flushed;
+            }
+
+            if (!previous.CheckChainFlushed())
+            {
+                return false;
+            }
+
+            _previous = null;
+
+            return _flushed;
+        }
+
+        /// <summary>
+        /// Sets task completion source status.
+        /// </summary>
+        private static void TrySetResultOrException(TaskCompletionSource<object> tcs, Exception exception)
+        {
+            if (exception == null)
+            {
+                tcs.TrySetResult(null);
+            }
+            else
+            {
+                tcs.TrySetException(exception);
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClientEntry.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClientEntry.cs
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client.Datastream
+{
+    /// <summary>
+    /// Streamer entry.
+    /// </summary>
+    internal struct DataStreamerClientEntry<TK, TV>
+    {
+        /** */
+        private const byte StatusEmpty = 0;
+
+        /** */
+        private const byte StatusAdd = 1;
+
+        /** */
+        private const byte StatusRemove = 2;
+
+        /** */
+        private readonly TK _key;
+
+        /** */
+        private readonly TV _val;
+
+        /** */
+        private readonly byte _status;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientEntry{TK,TV}"/> struct.
+        /// </summary>
+        public DataStreamerClientEntry(TK key, TV val)
+        {
+            _key = key;
+            _val = val;
+            _status = StatusAdd;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientEntry{TK,TV}"/> struct.
+        /// </summary>
+        public DataStreamerClientEntry(TK key)
+        {
+            _key = key;
+            _val = default(TV);
+            _status = StatusRemove;
+        }
+
+        /// <summary>
+        /// Gets the key.
+        /// </summary>
+        public TK Key
+        {
+            get { return _key; }
+        }
+
+        /// <summary>
+        /// Gets the value.
+        /// </summary>
+        public TV Val
+        {
+            get { return _val; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this entry is marked for removal
+        /// </summary>
+        public bool Remove
+        {
+            get { return _status == StatusRemove; }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether this entry is empty.
+        /// </summary>
+        public bool IsEmpty
+        {
+            get { return _status == StatusEmpty; }
+        }
+
+        /** <inheritdoc /> */
+        public override string ToString()
+        {
+            return string.Format("DataStreamerClientEntry [Key={0}, Val={1}, Remove={2}, IsEmpty={3}]", Key, Val,
+                Remove, IsEmpty);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClientPerNodeBuffer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClientPerNodeBuffer.cs
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Impl.Client.Datastream
+{
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Manages per-node buffers and flush operations.
+    /// </summary>
+    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable",
+        Justification = "WaitHandle is not used in SemaphoreSlim and ReaderWriterLockSlim, no need to dispose.")]
+    internal sealed class DataStreamerClientPerNodeBuffer<TK, TV>
+    {
+        /** */
+        private readonly DataStreamerClient<TK, TV> _client;
+
+        /** */
+        private readonly ClientSocket _socket;
+
+        /** */
+        private readonly SemaphoreSlim _semaphore;
+
+        /** */
+        private readonly ReaderWriterLockSlim _rwLock = new ReaderWriterLockSlim();
+
+        /** */
+        private volatile DataStreamerClientBuffer<TK, TV> _buffer;
+
+        /** */
+        private volatile bool _closed;
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="DataStreamerClientPerNodeBuffer{TK,TV}"/>.
+        /// </summary>
+        /// <param name="client">Streamer.</param>
+        /// <param name="socket">Socket for the node.</param>
+        public DataStreamerClientPerNodeBuffer(DataStreamerClient<TK, TV> client, ClientSocket socket)
+        {
+            Debug.Assert(client != null);
+
+            _client = client;
+            _socket = socket;
+            _semaphore = new SemaphoreSlim(client.Options.PerNodeParallelOperations);
+
+            _buffer = new DataStreamerClientBuffer<TK, TV>(_client.GetPooledArray(), this, null);
+        }
+
+        /// <summary>
+        /// Adds an entry to the buffer.
+        /// </summary>
+        public bool Add(DataStreamerClientEntry<TK,TV> entry)
+        {
+            if (!_rwLock.TryEnterReadLock(0))
+            {
+                return false;
+            }
+
+            try
+            {
+                if (_closed)
+                {
+                    return false;
+                }
+
+                while (true)
+                {
+                    var buffer = _buffer;
+
+                    if (buffer.Add(entry))
+                    {
+                        return true;
+                    }
+
+                    var entryArray = _client.GetPooledArray();
+
+#pragma warning disable 0420 // A reference to a volatile field will not be treated as volatile (not a problem)
+                    if (Interlocked.CompareExchange(ref _buffer,
+                        new DataStreamerClientBuffer<TK, TV>(entryArray, this, buffer), buffer) != buffer)
+                    {
+                        _client.ReturnPooledArray(entryArray);
+                    }
+#pragma warning restore 0420 // A reference to a volatile field will not be treated as volatile
+                }
+            }
+            finally
+            {
+                _rwLock.ExitReadLock();
+            }
+        }
+
+        /// <summary>
+        /// Closes this instance and returns the remaining buffer, if any.
+        /// </summary>
+        public DataStreamerClientBuffer<TK, TV> Close()
+        {
+            _rwLock.EnterWriteLock();
+
+            try
+            {
+                _closed = true;
+
+                return _buffer;
+            }
+            finally
+            {
+                _rwLock.ExitWriteLock();
+            }
+        }
+
+        /// <summary>
+        /// Flushes all buffers asynchronously.
+        /// </summary>
+        public Task FlushAllAsync()
+        {
+            var buffer = _buffer;
+            buffer.ScheduleFlush();
+
+            return buffer.GetChainFlushTask();
+        }
+
+        /// <summary>
+        /// Flushes the specified buffer asynchronously.
+        /// </summary>
+        public Task FlushBufferAsync(DataStreamerClientBuffer<TK, TV> buffer)
+        {
+            return _client.FlushBufferAsync(buffer, _socket, _semaphore);
+        }
+
+        /** <inheritdoc /> */
+        public override string ToString()
+        {
+            return string.Format("{0} [Socket={1}, Closed={2}, Buffer={3}]", GetType().Name, _socket.RemoteEndPoint,
+                _closed, _buffer);
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
@@ -28,6 +28,7 @@ namespace Apache.Ignite.Core.Impl.Client
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Client.Compute;
+    using Apache.Ignite.Core.Client.Datastream;
     using Apache.Ignite.Core.Client.Services;
     using Apache.Ignite.Core.Client.Transactions;
     using Apache.Ignite.Core.Datastream;
@@ -37,6 +38,7 @@ namespace Apache.Ignite.Core.Impl.Client
     using Apache.Ignite.Core.Impl.Client.Cache;
     using Apache.Ignite.Core.Impl.Client.Cluster;
     using Apache.Ignite.Core.Impl.Client.Compute;
+    using Apache.Ignite.Core.Impl.Client.Datastream;
     using Apache.Ignite.Core.Impl.Client.Services;
     using Apache.Ignite.Core.Impl.Client.Transactions;
     using Apache.Ignite.Core.Impl.Cluster;
@@ -281,6 +283,27 @@ namespace Apache.Ignite.Core.Impl.Client
         public IServicesClient GetServices()
         {
             return _services;
+        }
+
+        /** <inheritDoc /> */
+        public IDataStreamerClient<TK, TV> GetDataStreamer<TK, TV>(string cacheName)
+        {
+            return GetDataStreamer<TK, TV>(cacheName, null);
+        }
+
+        /** <inheritDoc /> */
+        public IDataStreamerClient<TK, TV> GetDataStreamer<TK, TV>(string cacheName, DataStreamerClientOptions options)
+        {
+            return GetDataStreamer(cacheName, new DataStreamerClientOptions<TK, TV>(options));
+        }
+
+        /** <inheritDoc /> */
+        public IDataStreamerClient<TK, TV> GetDataStreamer<TK, TV>(string cacheName,
+            DataStreamerClientOptions<TK, TV> options)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
+
+            return new DataStreamerClient<TK, TV>(_socket, cacheName, options);
         }
 
         /** <inheritDoc /> */

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/TaskRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/TaskRunner.cs
@@ -127,5 +127,24 @@ namespace Apache.Ignite.Core.Impl.Common
                 }
             });
         }
+
+        /// <summary>
+        /// Sets this task as result for a <see cref="TaskCompletionSource{TResult}"/>.
+        /// </summary>
+        public static void SetAsResult<T>(this Task task, TaskCompletionSource<T> tcs)
+        {
+            if (task.IsCanceled)
+            {
+                tcs.SetCanceled();
+            }
+            else if (task.Exception != null)
+            {
+                tcs.SetException(task.Exception);
+            }
+            else
+            {
+                tcs.SetResult(default(T));
+            }
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/IgniteManager.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/IgniteManager.cs
@@ -112,7 +112,7 @@ namespace Apache.Ignite.Core.Impl
         /// Create JVM.
         /// </summary>
         /// <returns>JVM.</returns>
-        private static Jvm CreateJvm(IgniteConfiguration cfg, ILogger log)
+        internal static Jvm CreateJvm(IgniteConfiguration cfg, ILogger log)
         {
             // Do not bother with classpath when JVM exists.
             var jvm = Jvm.Get(true);

--- a/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
+++ b/modules/platforms/dotnet/Apache.Ignite.DotNetCore.sln.DotSettings
@@ -10,6 +10,7 @@
 	<s:Boolean x:Key="/Default/Environment/UnitTesting/ShadowCopy/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=binarizable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cgroup/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datastream/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=failover/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Multithreaded/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Reentrancy/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
**Server:**
* Add ClientDataStreamerStartRequest, ClientDataStreamerAddDataRequest to the thin client protocol
* Fix security permission checks in the DataStreamerImpl
* Add ClientStatus.INVALID_NODE_STATE

**.NET thin client:**
* Add `IIgniteClient.GetDataStreamer` API (thread safe)
* Implement stateless partition-aware variant (see IEP): stateful mode shows similar performance but with greatly increased complexity

Benchmark results (i7-9700K, Ubuntu 20.04, .NET 5.0.5)
```
Singlethreaded
 |            Method |     Mean |   Error |  StdDev | Ratio | RatioSD |     Gen 0 | Gen 1 | Gen 2 | Allocated |
 |------------------ |---------:|--------:|--------:|------:|--------:|----------:|------:|------:|----------:|
 |  StreamThinClient | 106.5 ms | 3.25 ms | 9.52 ms |  0.99 |    0.08 | 2000.0000 |     - |     - |  17.14 MB |
 | StreamThickClient | 109.7 ms | 2.19 ms | 4.17 ms |  1.00 |    0.00 | 2000.0000 |     - |     - |  13.61 MB |

Multithreaded
 |            Method |      Mean |    Error |   StdDev | Ratio | RatioSD |     Gen 0 |     Gen 1 | Gen 2 | Allocated |
 |------------------ |----------:|---------:|---------:|------:|--------:|----------:|----------:|------:|----------:|
 |  StreamThinClient | 107.65 ms | 2.931 ms | 8.504 ms |  1.45 |    0.14 | 2000.0000 | 1000.0000 |     - |  17.29 MB |
 | StreamThickClient |  74.69 ms | 1.829 ms | 5.278 ms |  1.00 |    0.00 | 2000.0000 | 1000.0000 |     - |  13.85 MB |
```

IEP: https://cwiki.apache.org/confluence/display/IGNITE/IEP-68%3A+Thin+Client+Data+Streamer