### PR TITLE
GG-33310 [IGNITE-14826] .NET: Support string and array keys in thin client with partition awareness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheTest.cs
@@ -93,6 +93,24 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         }
 
         /// <summary>
+        /// Tests put/get with array keys.
+        /// </summary>
+        [Test]
+        public void TestPutGetArrayKey()
+        {
+            var cache = GetClientCache<object, object>();
+
+            var key1 = new[] {1, 2};
+            var key2 = new byte[] {3, 4};
+
+            cache.Put(key1, 1);
+            cache.Put(key2, 1);
+
+            Assert.AreEqual(1, cache.Get(key1));
+            Assert.AreEqual(1, cache.Get(key2));
+        }
+
+        /// <summary>
         /// Tests the cache put / get with user data types.
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -368,23 +368,25 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             }
         }
 
+        // ReSharper disable RedundantExplicitArrayCreation
         [Test]
         [TestCase(1, 1)]
         [TestCase(2, 0)]
         [TestCase((uint) 1, 1)]
-        [TestCase((uint) 2, 0)]
+        [TestCase(uint.MaxValue, 0)]
         [TestCase((byte) 1, 1)]
         [TestCase((byte) 2, 0)]
+        [TestCase((byte) 131, 1)]
         [TestCase((sbyte) 1, 1)]
-        [TestCase((sbyte) 2, 0)]
+        [TestCase((sbyte) -2, 1)]
         [TestCase((short) 1, 1)]
         [TestCase((short) 2, 0)]
         [TestCase((ushort) 1, 1)]
-        [TestCase((ushort) 2, 0)]
+        [TestCase(ushort.MaxValue, 0)]
         [TestCase((long) 1, 1)]
         [TestCase((long) 2, 0)]
         [TestCase((ulong) 1, 1)]
-        [TestCase((ulong) 2, 0)]
+        [TestCase(ulong.MaxValue, 0)]
         [TestCase((float) 1.3, 0)]
         [TestCase((float) 1.4, 2)]
         [TestCase((double) 51.3, 1)]
@@ -393,15 +395,34 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase((double) 255.5, 1)]
         [TestCase('1', 2)]
         [TestCase('2', 1)]
+        [TestCase("1", 2)]
+        [TestCase("2", 1)]
+        [TestCase("Hello World", 0)]
+        [TestCase("Тест1", 1)]
+        [TestCase("🙂🔥😎", 2)]
         [TestCase(true, 1)]
         [TestCase(false, 1)]
+        [TestCase(new[]{true, false}, 1)]
+        [TestCase(new byte[]{1, 2}, 2)]
+        [TestCase(new sbyte[]{1, -2}, 0)]
+        [TestCase(new short[]{1, 3}, 2)]
+        [TestCase(new ushort[]{1, 4}, 2)]
+        [TestCase(new int[]{1, 5}, 2)]
+        [TestCase(new uint[]{1, 6}, 1)]
+        [TestCase(new long[]{1, 7}, 0)]
+        [TestCase(new ulong[]{1, 8}, 0)]
+        [TestCase(new float[]{1.1f, 9.9f}, 1)]
+        [TestCase(new double[]{1.2f, 19.19f}, 1)]
+        [TestCase(new char[]{'x', 'y'}, 1)]
+        [TestCase(new string[]{"Hello", "World"}, 2)]
+        // ReSharper restore RedundantExplicitArrayCreation
         public void CachePut_AllPrimitiveTypes_RequestIsRoutedToPrimaryNode(object key, int gridIdx)
         {
             var cache = Client.GetCache<object, object>(_cache.Name);
             TestOperation(() => cache.Put(key, key), gridIdx, "Put");
 
             // Verify against real Affinity.
-            Assert.AreEqual(gridIdx, GetPrimaryNodeIdx(key));
+            Assert.AreEqual(gridIdx, GetPrimaryNodeIdx(key), "Actual primary node is different");
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ProjectFilesTest.cs
@@ -241,7 +241,8 @@ namespace Apache.Ignite.Core.Tests
                 "BinaryStringTest.cs",
                 "BinarySelfTest.cs",
                 "CacheDmlQueriesTest.cs",
-                "CacheTest.cs"
+                "CacheTest.cs",
+                "PartitionAwarenessTest.cs"
             };
 
             var srcFiles = TestUtils.GetDotNetSourceDir()

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -44,11 +44,29 @@ namespace Apache.Ignite.Core.Impl.Binary
             if (type == typeof(long))
                 return GetLongHashCode(TypeCaster<long>.Cast(val));
 
+            if (type == typeof(string))
+                return BinaryUtils.GetStringHashCode((string) (object) val);
+
+            if (type == typeof(Guid))
+                return GetGuidHashCode(TypeCaster<Guid>.Cast(val));
+
+            if (type == typeof(uint))
+            {
+                var val0 = TypeCaster<uint>.Cast(val);
+                return *(int*) &val0;
+            }
+
+            if (type == typeof(ulong))
+            {
+                var val0 = TypeCaster<ulong>.Cast(val);
+                return GetLongHashCode(*(long*) &val0);
+            }
+
             if (type == typeof(bool))
                 return TypeCaster<bool>.Cast(val) ? 1231 : 1237;
 
             if (type == typeof(byte))
-                return TypeCaster<byte>.Cast(val);
+                return unchecked((sbyte) TypeCaster<byte>.Cast(val));
 
             if (type == typeof(short))
                 return TypeCaster<short>.Cast(val);
@@ -69,27 +87,12 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
 
             if (type == typeof(sbyte))
-            {
-                var val0 = TypeCaster<sbyte>.Cast(val);
-                return *(byte*) &val0;
-            }
+                return TypeCaster<sbyte>.Cast(val);
 
             if (type == typeof(ushort))
             {
                 var val0 = TypeCaster<ushort>.Cast(val);
                 return *(short*) &val0;
-            }
-
-            if (type == typeof(uint))
-            {
-                var val0 = TypeCaster<uint>.Cast(val);
-                return *(int*) &val0;
-            }
-
-            if (type == typeof(ulong))
-            {
-                var val0 = TypeCaster<ulong>.Cast(val);
-                return GetLongHashCode(*(long*) &val0);
             }
 
             if (type == typeof(IntPtr))
@@ -104,13 +107,101 @@ namespace Apache.Ignite.Core.Impl.Binary
                 return GetLongHashCode(*(long*) &val0);
             }
 
-            if (type == typeof(Guid))
+            if (type.IsArray)
             {
-                return GetGuidHashCode(TypeCaster<Guid>.Cast(val));
+                return GetArrayHashCode(val, marsh, affinityKeyFieldIds);
             }
 
             // DateTime, when used as key, is always written as BinaryObject.
             return GetComplexTypeHashCode(val, marsh, affinityKeyFieldIds);
+        }
+
+        /// <summary>
+        /// Gets the Ignite-specific hash code for an array.
+        /// </summary>
+        private static int GetArrayHashCode<T>(T val, Marshaller marsh, IDictionary<int, int> affinityKeyFieldIds)
+        {
+            var res = 1;
+
+            var bytes = val as sbyte[];  // Matches byte[] too.
+
+            if (bytes != null)
+            {
+                foreach (var x in bytes)
+                    res = 31 * res + x;
+
+                return res;
+            }
+
+            var ints = val as int[]; // Matches uint[] too.
+
+            if (ints != null)
+            {
+                foreach (var x in ints)
+                    res = 31 * res + x;
+
+                return res;
+            }
+
+            var longs = val as long[]; // Matches ulong[] too.
+
+            if (longs != null)
+            {
+                foreach (var x in longs)
+                    res = 31 * res + GetLongHashCode(x);
+
+                return res;
+            }
+
+            var guids = val as Guid[];
+
+            if (guids != null)
+            {
+                foreach (var x in guids)
+                    res = 31 * res + GetGuidHashCode(x);
+
+                return res;
+            }
+
+            var shorts = val as short[]; // Matches ushort[] too.
+
+            if (shorts != null)
+            {
+                foreach (var x in shorts)
+                    res = 31 * res + x;
+
+                return res;
+            }
+
+            var chars = val as char[];
+
+            if (chars != null)
+            {
+                foreach (var x in chars)
+                    res = 31 * res + x;
+
+                return res;
+            }
+
+            // This covers all other arrays.
+            // We don't have special handling for unlikely use cases such as float[] and double[].
+            var arr = val as Array;
+
+            Debug.Assert(arr != null);
+
+            if (arr.Rank != 1)
+            {
+                throw new IgniteException(
+                    string.Format("Failed to compute hash code for object '{0}' of type '{1}': " +
+                                  "multidimensional arrays are not supported", val, val.GetType()));
+            }
+
+            foreach (var element in arr)
+            {
+                res = 31 * res + (element == null ? 0 : GetHashCode(element, marsh, affinityKeyFieldIds));
+            }
+
+            return res;
         }
 
         // ReSharper disable once ParameterOnlyUsedForPreconditionCheck.Local
@@ -144,7 +235,8 @@ namespace Apache.Ignite.Core.Impl.Binary
                     return hashCode.Value;
                 }
 
-                throw new IgniteException(string.Format("Failed to compute hash code for object '{0}'", val));
+                throw new IgniteException(
+                    string.Format("Failed to compute hash code for object '{0}' of type '{1}'", val, val.GetType()));
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryUtils.cs
@@ -1451,7 +1451,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// <summary>
         /// Gets the string hash code using Java algorithm.
         /// </summary>
-        private static int GetStringHashCode(string val)
+        public static int GetStringHashCode(string val)
         {
             if (val == null)
                 return 0;


### PR DESCRIPTION
* Add missing support for strings and arrays in `BinaryHashCodeUtils`
* Fix `byte` and `sbyte` hash codes: Java `byte` is signed, so the logic should be reversed