### PR TITLE
GG-33219 [IGNITE-14856] Fix "Failed to resolve class name" on server when cache with indexed types is defined on client

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformProcessorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformProcessorImpl.java
@@ -302,6 +302,9 @@ public class PlatformProcessorImpl extends GridProcessorAdapter implements Platf
 
         // Add Interop node attributes.
         ctx.addNodeAttribute(PlatformUtils.ATTR_PLATFORM, interopCfg.platform());
+
+        // Register query entity meta.
+        ctx.query().registerMetadataForRegisteredCaches(true);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -312,6 +312,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
         }, QRY_DETAIL_METRICS_EVICTION_FREQ, QRY_DETAIL_METRICS_EVICTION_FREQ);
 
         idxRebuildStateStorage.start();
+
+        registerMetadataForRegisteredCaches(false);
     }
 
     /** {@inheritDoc} */
@@ -363,8 +365,6 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      * @throws IgniteCheckedException If failed.
      */
     public void onCacheKernalStart() throws IgniteCheckedException {
-        registerMetadataForRegisteredCaches();
-
         synchronized (stateMux) {
             exchangeReady = true;
 
@@ -1168,10 +1168,12 @@ public class GridQueryProcessor extends GridProcessorAdapter {
 
     /**
      * Register metadata locally for already registered caches.
+     *
+     * @param platformOnly Whether to register non-Java platformOnly types only.
      */
-    private void registerMetadataForRegisteredCaches() {
+    public void registerMetadataForRegisteredCaches(boolean platformOnly) {
         for (DynamicCacheDescriptor cacheDescriptor : ctx.cache().cacheDescriptors().values())
-            registerBinaryMetadata(cacheDescriptor.cacheConfiguration(), cacheDescriptor.schema());
+            registerBinaryMetadata(cacheDescriptor.cacheConfiguration(), cacheDescriptor.schema(), platformOnly);
     }
 
     /**
@@ -1185,7 +1187,7 @@ public class GridQueryProcessor extends GridProcessorAdapter {
                 continue;
 
             try {
-                registerBinaryMetadata(req.startCacheConfiguration(), req.schema());
+                registerBinaryMetadata(req.startCacheConfiguration(), req.schema(), false);
             }
             catch (BinaryObjectException e) {
                 ctx.cache().completeCacheStartFuture(req, false, e);
@@ -1198,9 +1200,10 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      *
      * @param ccfg Cache configuration.
      * @param schema Schema for which register metadata is required.
+     * @param platformOnly Whether to register non-Java platformOnly types only.
      * @throws BinaryObjectException if register was failed.
      */
-    private void registerBinaryMetadata(CacheConfiguration ccfg, QuerySchema schema) throws BinaryObjectException {
+    private void registerBinaryMetadata(CacheConfiguration ccfg, QuerySchema schema, boolean platformOnly) throws BinaryObjectException {
         if (schema != null) {
             Collection<QueryEntity> qryEntities = schema.entities();
 
@@ -1209,8 +1212,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
 
                 if (binaryEnabled) {
                     for (QueryEntity qryEntity : qryEntities) {
-                        registerTypeLocally(qryEntity.findKeyType());
-                        registerTypeLocally(qryEntity.findValueType());
+                        registerTypeLocally(qryEntity.findKeyType(), platformOnly);
+                        registerTypeLocally(qryEntity.findValueType(), platformOnly);
                     }
                 }
             }
@@ -1298,9 +1301,10 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      * Register class metadata locally if it didn't do it earlier.
      *
      * @param clsName Class name for which the metadata should be registered.
+     * @param platformOnly Whether to only register non-Java platform types only.
      * @throws BinaryObjectException if register was failed.
      */
-    private void registerTypeLocally(String clsName) throws BinaryObjectException {
+    private void registerTypeLocally(String clsName, boolean platformOnly) throws BinaryObjectException {
         if (clsName == null)
             return;
 
@@ -1311,8 +1315,10 @@ public class GridQueryProcessor extends GridProcessorAdapter {
 
             Class<?> cls = U.box(U.classForName(clsName, null, true));
 
-            if (cls != null)
-                binProc.binaryContext().registerClass(cls, true, false, true);
+            if (cls != null) {
+                if (!platformOnly)
+                    binProc.binaryContext().registerClass(cls, true, false, true);
+            }
             else
                 registerPlatformTypeLocally(clsName, binProc);
         }
@@ -1327,9 +1333,7 @@ public class GridQueryProcessor extends GridProcessorAdapter {
     private void registerPlatformTypeLocally(String clsName, CacheObjectBinaryProcessorImpl binProc) {
         PlatformProcessor platformProc = ctx.platform();
 
-        assert platformProc != null : "Platform processor must be initialized";
-
-        if (!platformProc.hasContext())
+        if (platformProc == null || !platformProc.hasContext())
             return;
 
         PlatformContext platformCtx = platformProc.context();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteMarshallerCacheSeparateDirectoryTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/IgniteMarshallerCacheSeparateDirectoryTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+import java.io.File;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.Ignition;
+import org.apache.ignite.cache.query.annotations.QuerySqlField;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteCallable;
+import org.apache.ignite.lang.IgniteRunnable;
+import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Tests cache metadata exchange when marshaller directory is not shared between server and client.
+ */
+public class IgniteMarshallerCacheSeparateDirectoryTest extends GridCommonAbstractTest {
+    /** */
+    public static final String KEY = "key";
+
+    /** */
+    public static final String SERVER = "server";
+
+    /** */
+    public static final String CLIENT = "client";
+
+    /** */
+    private boolean ccfgOnClient;
+
+    /** */
+    private boolean ccfgOnServer;
+
+    /** */
+    private boolean indexedTypes;
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setPeerClassLoadingEnabled(false);
+
+        ((TcpCommunicationSpi)cfg.getCommunicationSpi()).setSharedMemoryPort(-1);
+
+        cfg.setWorkDirectory(workDir(igniteInstanceName).getAbsolutePath());
+
+        if (igniteInstanceName.equals(SERVER) && ccfgOnServer ||
+                igniteInstanceName.equals(CLIENT) && ccfgOnClient) {
+            CacheConfiguration ccfg = new CacheConfiguration(DEFAULT_CACHE_NAME);
+
+            ccfg.setBackups(1);
+
+            if (indexedTypes)
+                ccfg.setIndexedTypes(String.class, TestClass.class);
+
+            cfg.setCacheConfiguration(ccfg);
+        }
+
+        if (igniteInstanceName.equals(CLIENT))
+            cfg.setClientMode(true);
+
+        return cfg;
+    }
+
+    /** */
+    private File workDir(String igniteInstanceName) {
+        return new File(U.getIgniteHome() + File.separator + igniteInstanceName + "-work");
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+
+        U.delete(workDir(SERVER));
+        U.delete(workDir(CLIENT));
+
+        super.afterTest();
+    }
+
+    /** */
+    @Test
+    public void testRegular() throws Exception {
+        run(true, true, false, AccessMode.SERVER, AccessMode.CLIENT);
+    }
+
+    /** */
+    @Test
+    public void testIndexed() throws Exception {
+        run(true, true, true, AccessMode.CLIENT, AccessMode.SERVER);
+    }
+
+    /** */
+    @Test
+    public void testIndexedClosure() throws Exception {
+        run(true, true, true, AccessMode.CLOSURE, AccessMode.CLOSURE);
+    }
+
+    /** */
+    @Test
+    public void testClientCcfgIndexedGetClosure() throws Exception {
+        run(true, false, true, AccessMode.CLIENT, AccessMode.CLOSURE);
+    }
+
+    /** */
+    @Test
+    public void testClientCcfgGetClosure() throws Exception {
+        run(true, false, false, AccessMode.CLIENT, AccessMode.CLOSURE);
+    }
+
+    /** */
+    @Test
+    public void testServerCcfgIndexedGetClosure() throws Exception {
+        run(false, true, true, AccessMode.CLIENT, AccessMode.CLOSURE);
+    }
+
+    /** */
+    @Test
+    public void testServerCcfgIndexed() throws Exception {
+        run(false, true, true, AccessMode.SERVER, AccessMode.CLIENT);
+    }
+
+    /** */
+    @Test
+    public void testClientCcfgIndexedClosure() throws Exception {
+        run(true, false, true, AccessMode.CLOSURE, AccessMode.CLOSURE);
+    }
+
+    /** */
+    @Test
+    public void testClientCcfgIndexed() throws Exception {
+        run(true, false, false, AccessMode.CLIENT, AccessMode.SERVER);
+    }
+
+    /** */
+    @Test
+    public void testClientCcfgIndexedPutClosure() throws Exception {
+        run(false, true, true, AccessMode.CLOSURE, AccessMode.CLIENT);
+    }
+
+    /** */
+    @Test
+    public void testServerCcfgPutClosure() throws Exception {
+        run(true, false, false, AccessMode.CLOSURE, AccessMode.SERVER);
+    }
+
+    /** */
+    private void run(boolean ccfgOnClient, boolean ccfgOnServer, boolean indexedTypes,
+                     AccessMode putMode, AccessMode getMode) throws Exception {
+        this.ccfgOnClient = ccfgOnClient;
+        this.ccfgOnServer = ccfgOnServer;
+        this.indexedTypes = indexedTypes;
+
+        Ignite server = startGrid(SERVER);
+
+        Ignite client = startGrid(CLIENT);
+
+        if (putMode == AccessMode.CLOSURE) {
+            client.compute().run(new IgniteRunnable() {
+                @Override public void run() {
+                    Ignition.ignite(SERVER).cache(DEFAULT_CACHE_NAME).put(KEY, new TestClass());
+                }
+            });
+        }
+        else
+            (putMode == AccessMode.SERVER ? server : client).cache(DEFAULT_CACHE_NAME).put(KEY, new TestClass());
+
+        Object val;
+
+        if (getMode == AccessMode.CLOSURE) {
+            val = client.compute().call(new IgniteCallable<Object>() {
+                @Override public Object call() throws Exception {
+                    return Ignition.ignite(SERVER).cache(DEFAULT_CACHE_NAME).get(KEY);
+                }
+            });
+        }
+        else
+            val = (putMode == AccessMode.SERVER ? server : client).cache(DEFAULT_CACHE_NAME).get(KEY);
+
+        assertNotNull(val);
+        assertTrue(val.toString().contains("TestClass"));
+    }
+
+    /** */
+    private enum AccessMode {
+        SERVER,
+        CLIENT,
+        CLOSURE;
+    }
+
+    /** */
+    static class TestClass {
+        @QuerySqlField
+        private int f = 42;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -71,6 +71,7 @@ import org.apache.ignite.internal.processors.cache.IgniteMarshallerCacheClassNam
 import org.apache.ignite.internal.processors.cache.IgniteMarshallerCacheClientRequestsMappingOnMissTest;
 import org.apache.ignite.internal.processors.cache.IgniteMarshallerCacheConcurrentReadWriteTest;
 import org.apache.ignite.internal.processors.cache.IgniteMarshallerCacheFSRestoreTest;
+import org.apache.ignite.internal.processors.cache.IgniteMarshallerCacheSeparateDirectoryTest;
 import org.apache.ignite.internal.processors.cache.RebalanceWithDifferentThreadPoolSizeTest;
 import org.apache.ignite.internal.processors.cache.SetTxTimeoutOnPartitionMapExchangeTest;
 import org.apache.ignite.internal.processors.cache.distributed.IgniteRejectConnectOnNodeStopTest;
@@ -243,6 +244,7 @@ import org.junit.runners.Suite;
     IgniteMarshallerCacheFSRestoreTest.class,
     IgniteMarshallerCacheClassNameConflictTest.class,
     IgniteMarshallerCacheClientRequestsMappingOnMissTest.class,
+    IgniteMarshallerCacheSeparateDirectoryTest.class,
 
     IgniteDiagnosticMessagesTest.class,
     IgniteDiagnosticMessagesMultipleConnectionsTest.class,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/QueryEntityMetadataRegistrationTest.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
 {
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Client;
@@ -57,6 +58,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query
                 {
                     SpringConfigUrl = springConfig,
                     IgniteInstanceName = i.ToString(),
+                    WorkDirectory = Path.Combine(
+                        Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), 
+                        "ignite_work_" + GetType().Name + "_" + i),
 
                     // Cache configs will be merged with Spring cache configs.
                     CacheConfiguration = new[]


### PR DESCRIPTION
* Restore `registerMetadataForRegisteredCaches` call in `GridQueryProcessor#start` - this fixes Java-side behavior, but breaks registration for platform types, because `PlatformProcessor` is not available at this point
* Call `registerMetadataForRegisteredCaches` second time from `PlatformProcessorImpl.start` only for platform types