### PR TITLE
GG-31007 Server node fails on remote filter with static initializer deployment if client disconnects

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/GridEventConsumeHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/GridEventConsumeHandler.java
@@ -428,6 +428,11 @@ class GridEventConsumeHandler implements GridContinuousHandler {
 
                 throw e;
             }
+            catch (ExceptionInInitializerError e) {
+                ((GridFutureAdapter)p2pUnmarshalFut).onDone(e);
+
+                throw new IgniteCheckedException("Failed to unmarshal deployable object.", e);
+            }
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/GridMessageListenHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/GridMessageListenHandler.java
@@ -198,6 +198,11 @@ public class GridMessageListenHandler implements GridContinuousHandler {
 
             throw e;
         }
+        catch (ExceptionInInitializerError e) {
+            ((GridFutureAdapter)p2pUnmarshalFut).onDone(e);
+
+            throw new IgniteCheckedException("Failed to unmarshal deployable object.", e);
+        }
 
         ((GridFutureAdapter)p2pUnmarshalFut).onDone();
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryHandler.java
@@ -348,9 +348,14 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
                     fut.get();
 
                     initRemoteFilter(getEventFilter0(), ctx);
+
+                    IgniteClosure trans = getTransformer0();
+
+                    if (trans != null)
+                        ctx.resource().injectGeneric(trans);
                 }
-                catch (IgniteCheckedException e) {
-                    throw new IgniteException("Failed to initialize a remote filter.", e);
+                catch (IgniteCheckedException | ExceptionInInitializerError e) {
+                    throw new IgniteException("Failed to initialize a continuous query.", e);
                 }
 
                 return null;
@@ -547,14 +552,24 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
                         if (asyncCb) {
                             ctx.asyncCallbackPool().execute(new Runnable() {
                                 @Override public void run() {
-                                    notifyLocalListener(evts, getTransformer());
+                                    try {
+                                        notifyLocalListener(evts, getTransformer());
+                                    } catch (IgniteCheckedException ex) {
+                                        U.error(ctx.log(CU.CONTINUOUS_QRY_LOG_CATEGORY),
+                                            "Failed to notify local listener.", ex);
+                                    }
                                 }
                             }, part);
                         }
                         else
                             skipCtx.addProcessClosure(new Runnable() {
                                 @Override public void run() {
-                                    notifyLocalListener(evts, getTransformer());
+                                    try {
+                                        notifyLocalListener(evts, getTransformer());
+                                    } catch (IgniteCheckedException ex) {
+                                        U.error(ctx.log(CU.CONTINUOUS_QRY_LOG_CATEGORY),
+                                            "Failed to notify local listener.", ex);
+                                    }
                                 }
                             });
                     }
@@ -763,7 +778,16 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
     /**
      * @return Cache entry event transformer.
      */
-    @Nullable protected IgniteClosure<CacheEntryEvent<? extends K, ? extends V>, ?> getTransformer() {
+    @Nullable protected IgniteClosure<CacheEntryEvent<? extends K, ? extends V>, ?> getTransformer() throws IgniteCheckedException {
+        initFut.get();
+
+        return getTransformer0();
+    }
+
+    /**
+     * @return Cache entry event transformer.
+     */
+    @Nullable protected IgniteClosure<CacheEntryEvent<? extends K, ? extends V>, ?> getTransformer0() {
         return null;
     }
 
@@ -1319,6 +1343,13 @@ public class CacheContinuousQueryHandler<K, V> implements GridContinuousHandler 
                 ((GridFutureAdapter)p2pUnmarshalFut).onDone(e);
 
                 throw e;
+            }
+            catch (ExceptionInInitializerError e) {
+                IgniteCheckedException err = new IgniteCheckedException("Failed to unmarshal deployable object.", e);
+
+                ((GridFutureAdapter)p2pUnmarshalFut).onDone(err);
+
+                throw err;
             }
         }
         else

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryHandlerV3.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryHandlerV3.java
@@ -101,7 +101,7 @@ public class CacheContinuousQueryHandlerV3<K, V> extends CacheContinuousQueryHan
     }
 
     /** {@inheritDoc} */
-    @Override protected IgniteClosure<CacheEntryEvent<? extends K, ? extends V>, ?> getTransformer() {
+    @Override protected IgniteClosure<CacheEntryEvent<? extends K, ? extends V>, ?> getTransformer0() {
         if (rmtTrans == null && rmtTransFactory != null)
             rmtTrans = rmtTransFactory.create();
 
@@ -124,11 +124,6 @@ public class CacheContinuousQueryHandlerV3<K, V> extends CacheContinuousQueryHan
     /** {@inheritDoc} */
     @Override public RegisterStatus register(UUID nodeId, UUID routineId,
         GridKernalContext ctx) throws IgniteCheckedException {
-        final IgniteClosure trans = getTransformer();
-
-        if (trans != null)
-            ctx.resource().injectGeneric(trans);
-
         if (locTransLsnr != null) {
             ctx.resource().injectGeneric(locTransLsnr);
 

--- a/modules/core/src/test/java/org/apache/ignite/p2p/GridP2PContinuousDeploymentClientDisconnectTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/p2p/GridP2PContinuousDeploymentClientDisconnectTest.java
@@ -1,0 +1,340 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.p2p;
+
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.cache.CacheException;
+import javax.cache.configuration.Factory;
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryEventFilter;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cache.CacheEntryEventSerializableFilter;
+import org.apache.ignite.cache.query.AbstractContinuousQuery;
+import org.apache.ignite.cache.query.ContinuousQuery;
+import org.apache.ignite.cache.query.ContinuousQueryWithTransformer;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.events.Event;
+import org.apache.ignite.events.EventType;
+import org.apache.ignite.failure.AbstractFailureHandler;
+import org.apache.ignite.failure.FailureContext;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.managers.communication.GridMessageListener;
+import org.apache.ignite.internal.managers.deployment.GridDeploymentManager;
+import org.apache.ignite.internal.managers.deployment.GridDeploymentRequest;
+import org.apache.ignite.lang.IgniteBiPredicate;
+import org.apache.ignite.lang.IgniteClosure;
+import org.apache.ignite.lang.IgnitePredicate;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static org.apache.ignite.internal.GridTopic.TOPIC_CLASSLOAD;
+import static org.apache.ignite.testframework.GridTestUtils.assertThrowsWithCause;
+
+/**
+ * Tests for client disconnection during continuous query deployment.
+ */
+public class GridP2PContinuousDeploymentClientDisconnectTest extends GridCommonAbstractTest {
+    /** */
+    private ListeningTestLogger testLog;
+
+    /** The resource name which is used in static initializer block. */
+    private static final String P2P_TEST_OBJ_RSRC_NAME = "org/apache/ignite/tests/p2p/GridP2PTestObjectWithStaticInitializer$GridP2PTestObject.class";
+
+    /** */
+    private static final String REMOTE_FILTER_CLS_NAME = "org.apache.ignite.tests.p2p.GridP2PSerializableRemoteFilterWithStaticInitializer";
+
+    /** */
+    private static final String REMOTE_FILTER_FACTORY_CLS_NAME = "org.apache.ignite.tests.p2p.GridP2PRemoteFilterWithStaticInitializerFactory";
+
+    /** */
+    private static final String REMOTE_TRANSFORMER_FACTORY_CLS_NAME = "org.apache.ignite.tests.p2p.GridP2PRemoteTransformerWithStaticInitializerFactory";
+
+    /** */
+    private static final String EVT_REMOTE_FILTER_CLS_NAME = "org.apache.ignite.tests.p2p.GridP2PEventRemoteFilterWithStaticInitializer";
+
+    /** */
+    private static final String MSG_REMOTE_LSNR_CLS_NAME = "org.apache.ignite.tests.p2p.GridP2PMessageRemoteListenerWithStaticInitializer";
+
+    /** Flag that is raised in case the failure handler was called. */
+    private final AtomicBoolean failure = new AtomicBoolean(false);
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setCacheConfiguration(defaultCacheConfiguration());
+
+        cfg.setGridLogger(testLog);
+
+        cfg.setFailureHandler(new AbstractFailureHandler() {
+            /** {@inheritDoc} */
+            @Override protected boolean handle(Ignite ignite, FailureContext failureCtx) {
+                failure.set(true);
+
+                return false;
+            }
+        });
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        testLog = new ListeningTestLogger(true, log);
+
+        startGrid(0);
+
+        startClientGrid(1);
+
+        blockClassLoadingRequest(grid(1));
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        testLog.clearListeners();
+
+        stopAllGrids();
+    }
+
+    /**
+     * Test starts 1 server node and 1 client node. Class-loading request for the {@link #P2P_TEST_OBJ_RSRC_NAME}
+     * resource blocks on the client node. The client node tries to deploy CQ with remote filter for
+     * the cache {@link #DEFAULT_CACHE_NAME}.
+     * Expected that exception with 'Failed to unmarshal deployable object.' error message will be thrown and
+     * the server node wouldn't be failed.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testContinuousQueryRemoteFilter() throws Exception {
+        final Class<CacheEntryEventSerializableFilter<Integer, Integer>> rmtFilterCls =
+            (Class<CacheEntryEventSerializableFilter<Integer, Integer>>)getExternalClassLoader().
+                loadClass(REMOTE_FILTER_CLS_NAME);
+
+        ContinuousQuery<Integer, Integer> qry = new ContinuousQuery<Integer, Integer>()
+            .setLocalListener(evts -> {
+                // No-op.
+            })
+            .setRemoteFilter(rmtFilterCls.newInstance());
+
+        IgniteEx client = grid(1);
+
+        LogListener lsnr = LogListener.matches(
+            "Failed to unmarshal deployable object."
+        ).build();
+
+        testLog.registerListener(lsnr);
+
+        IgniteCache<Integer, Integer> cache = client.cache(DEFAULT_CACHE_NAME);
+
+        assertThrowsWithCause(() -> cache.query(qry), CacheException.class);
+
+        assertTrue(lsnr.check());
+
+        // Check that the failure handler was not called.
+        assertFalse(failure.get());
+    }
+
+    /**
+     * Test starts 1 server node and 1 client node. Class-loading request for the {@link #P2P_TEST_OBJ_RSRC_NAME}
+     * resource blocks on the client node. The client node tries to deploy CQ with remote filter factory for
+     * the cache {@link #DEFAULT_CACHE_NAME}.
+     * Expected that exception with 'Failed to initialize a continuous query.' error message will be thrown and
+     * the server node wouldn't be failed.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testContinuousQueryRemoteFilterFactory() throws Exception {
+        final Class<Factory<? extends CacheEntryEventFilter<Integer, Integer>>> rmtFilterFactoryCls =
+            (Class<Factory<? extends CacheEntryEventFilter<Integer, Integer>>>)getExternalClassLoader().
+                loadClass(REMOTE_FILTER_FACTORY_CLS_NAME);
+
+        AbstractContinuousQuery<Integer, Integer> qry = new ContinuousQuery<Integer, Integer>()
+            .setLocalListener(evts -> {
+                // No-op.
+            })
+            .setRemoteFilterFactory(rmtFilterFactoryCls.newInstance());
+
+        IgniteEx client = grid(1);
+
+        LogListener lsnr = LogListener.matches(
+            "Failed to initialize a continuous query."
+        ).build();
+
+        testLog.registerListener(lsnr);
+
+        IgniteCache<Integer, Integer> cache = client.cache(DEFAULT_CACHE_NAME);
+
+        cache.query(qry);
+
+        assertTrue(lsnr.check());
+
+        // Check that the failure handler was not called.
+        assertFalse(failure.get());
+    }
+
+    /**
+     * Test starts 1 server node and 1 client node. Class-loading request for the {@link #P2P_TEST_OBJ_RSRC_NAME}
+     * resource blocks on the client node. The client node tries to deploy CQ with remote transformer for
+     * the cache {@link #DEFAULT_CACHE_NAME}.
+     * Expected that exception with 'Failed to unmarshal deployable object.' error message will be thrown and
+     * the server node wouldn't be failed.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testContinuousQueryRemoteTransformer() throws Exception {
+        Class<Factory<IgniteClosure<CacheEntryEvent<? extends Integer, ? extends Integer>, String>>> rmtTransformerFactoryCls =
+            (Class<Factory<IgniteClosure<CacheEntryEvent<? extends Integer, ? extends Integer>, String>>>) getExternalClassLoader()
+                .loadClass(REMOTE_TRANSFORMER_FACTORY_CLS_NAME);
+
+        ContinuousQueryWithTransformer<Integer, Integer, String> qry = new ContinuousQueryWithTransformer<Integer, Integer, String>()
+            .setLocalListener(evts -> {
+                // No-op.
+            })
+            .setRemoteTransformerFactory(rmtTransformerFactoryCls.newInstance());
+
+        LogListener lsnr = LogListener.matches(
+            "Failed to initialize a continuous query."
+        ).build();
+
+        testLog.registerListener(lsnr);
+
+        IgniteCache<Integer, Integer> cache = grid(1).cache(DEFAULT_CACHE_NAME);
+
+        cache.query(qry);
+
+        assertTrue(lsnr.check());
+
+        // Check that the failure handler was not called.
+        assertFalse(failure.get());
+    }
+
+    /**
+     * Test starts 1 server node and 1 client node. Class-loading request for the {@link #P2P_TEST_OBJ_RSRC_NAME}
+     * resource blocks on the client node. The client node tries to deploy remote event listener for
+     * the cache {@link #DEFAULT_CACHE_NAME}.
+     * Expected that exception with 'Failed to unmarshal deployable object.' error message will be thrown and
+     * the server node wouldn't be failed.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testEventRemoteFilter() throws Exception {
+        final Class<IgnitePredicate<Event>> evtFilterCls =
+            (Class<IgnitePredicate<Event>>) getExternalClassLoader().loadClass(EVT_REMOTE_FILTER_CLS_NAME);
+
+        LogListener lsnr = LogListener.matches(
+            "Failed to unmarshal deployable object."
+        ).build();
+
+        testLog.registerListener(lsnr);
+
+        assertThrowsWithCause(
+            () -> grid(1)
+                .events()
+                .remoteListen(
+                    (uuid, event) -> true,
+                    evtFilterCls.newInstance(),
+                    EventType.EVT_NODE_JOINED
+                ),
+            IgniteException.class
+        );
+
+        assertTrue(lsnr.check());
+
+        // Check that the failure handler was not called.
+        assertFalse(failure.get());
+    }
+
+    /**
+     * Test starts 1 server node and 1 client node. Class-loading request for the {@link #P2P_TEST_OBJ_RSRC_NAME}
+     * resource blocks on the client node. The client node tries to deploy remote message listener for
+     * the cache {@link #DEFAULT_CACHE_NAME}.
+     * Expected that exception with 'Failed to unmarshal deployable object.' error message will be thrown and
+     * the server node wouldn't be failed.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testMessageRemoteListen() throws Exception {
+        Class<IgniteBiPredicate<UUID, String>> rmtLsnrCls =
+            (Class<IgniteBiPredicate<UUID, String>>) getExternalClassLoader().loadClass(MSG_REMOTE_LSNR_CLS_NAME);
+
+        LogListener lsnr = LogListener.matches(
+            "Failed to unmarshal deployable object."
+        ).build();
+
+        testLog.registerListener(lsnr);
+
+        assertThrowsWithCause(
+            () -> grid(1)
+                .message()
+                .remoteListen("test", rmtLsnrCls.newInstance()),
+            IgniteException.class
+        );
+
+        assertTrue(lsnr.check());
+
+        // Check that the failure handler was not called.
+        assertFalse(failure.get());
+    }
+
+    /**
+     * Blocks peer-class loading for {@link #P2P_TEST_OBJ_RSRC_NAME} resource.
+     *
+     * @param node The node where peer-class loading should be blocked.
+     */
+    private void blockClassLoadingRequest(IgniteEx node) {
+        GridKernalContext ctx = node.context();
+
+        GridDeploymentManager deploymentMgr = ctx.deploy();
+
+        Object comm = GridTestUtils.getFieldValue(deploymentMgr, "comm");
+
+        GridMessageListener peerLsnr = GridTestUtils.getFieldValue(comm, "peerLsnr");
+
+        ctx.io().removeMessageListener(TOPIC_CLASSLOAD, peerLsnr);
+
+        GridMessageListener newPeerLsnr = new GridMessageListener() {
+            @Override public void onMessage(UUID nodeId, Object msg, byte plc) {
+                GridDeploymentRequest req = (GridDeploymentRequest)msg;
+
+                String rsrcName = GridTestUtils.getFieldValue(req, "rsrcName");
+
+                if (rsrcName.equals(P2P_TEST_OBJ_RSRC_NAME))
+                    return;
+
+                peerLsnr.onMessage(nodeId, msg, plc);
+            }
+        };
+
+        ctx.io().addMessageListener(TOPIC_CLASSLOAD, newPeerLsnr);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteP2PSelfTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteP2PSelfTestSuite.java
@@ -22,6 +22,7 @@ import org.apache.ignite.internal.managers.deployment.P2PCacheOperationIntoCompu
 import org.apache.ignite.p2p.DeploymentClassLoaderCallableTest;
 import org.apache.ignite.p2p.GridP2PClassLoadingSelfTest;
 import org.apache.ignite.p2p.GridP2PComputeWithNestedEntryProcessorTest;
+import org.apache.ignite.p2p.GridP2PContinuousDeploymentClientDisconnectTest;
 import org.apache.ignite.p2p.GridP2PContinuousDeploymentSelfTest;
 import org.apache.ignite.p2p.GridP2PCountTiesLoadClassDirectlyFromClassLoaderTest;
 import org.apache.ignite.p2p.GridP2PDifferentClassLoaderSelfTest;
@@ -73,6 +74,7 @@ import org.junit.runners.Suite;
     GridP2PScanQueryWithTransformerTest.class,
     P2PCacheOperationIntoComputeTest.class,
     GridDifferentLocalDeploymentSelfTest.class,
+    GridP2PContinuousDeploymentClientDisconnectTest.class
 })
 public class IgniteP2PSelfTestSuite {
 }

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PEventRemoteFilterWithStaticInitializer.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PEventRemoteFilterWithStaticInitializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import org.apache.ignite.events.Event;
+import org.apache.ignite.lang.IgnitePredicate;
+
+/**
+ * Event remote filter with static initializer.
+ */
+public class GridP2PEventRemoteFilterWithStaticInitializer implements IgnitePredicate<Event> {
+    /** */
+    private final GridP2PTestObjectWithStaticInitializer testObj = new GridP2PTestObjectWithStaticInitializer();
+
+    /** {@inheritDoc} */
+    @Override public boolean apply(Event event) {
+        return false;
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PMessageRemoteListenerWithStaticInitializer.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PMessageRemoteListenerWithStaticInitializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import java.util.UUID;
+import org.apache.ignite.lang.IgniteBiPredicate;
+
+/**
+ * Message remote listener with static initializer.
+ */
+public class GridP2PMessageRemoteListenerWithStaticInitializer implements IgniteBiPredicate<UUID, String> {
+    /** */
+    private final GridP2PTestObjectWithStaticInitializer testObj = new GridP2PTestObjectWithStaticInitializer();
+
+    /** {@inheritDoc} */
+    @Override public boolean apply(UUID nodeId, String msg) {
+        return true;
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteFilterWithStaticInitializer.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteFilterWithStaticInitializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryEventFilter;
+import javax.cache.event.CacheEntryListenerException;
+
+/**
+ * Event filter with static initalizer.
+ */
+public class GridP2PRemoteFilterWithStaticInitializer implements CacheEntryEventFilter<Integer, Integer> {
+    /** */
+    private final GridP2PTestObjectWithStaticInitializer testObj = new GridP2PTestObjectWithStaticInitializer();
+
+    /** {@inheritDoc} */
+    @Override public boolean evaluate(CacheEntryEvent<? extends Integer, ? extends Integer> evt)
+        throws CacheEntryListenerException {
+        return evt.getValue() == null || evt.getValue() % 2 != 0;
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteFilterWithStaticInitializerFactory.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteFilterWithStaticInitializerFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import javax.cache.configuration.Factory;
+import javax.cache.event.CacheEntryEventFilter;
+
+/**
+ * Event filter factory for deployment.
+ */
+public class GridP2PRemoteFilterWithStaticInitializerFactory implements Factory<CacheEntryEventFilter<Integer, Integer>> {
+    /** {@inheritDoc} */
+    @Override public CacheEntryEventFilter<Integer, Integer> create() {
+        return new GridP2PRemoteFilterWithStaticInitializer();
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteTransformerWithStaticInitializer.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteTransformerWithStaticInitializer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import javax.cache.event.CacheEntryEvent;
+import org.apache.ignite.lang.IgniteClosure;
+
+/**
+ * Remote transformer with static initializer.
+ */
+public class GridP2PRemoteTransformerWithStaticInitializer implements IgniteClosure<CacheEntryEvent<Integer, Integer>, String> {
+    /** */
+    private final GridP2PTestObjectWithStaticInitializer testObj = new GridP2PTestObjectWithStaticInitializer();
+
+    /** {@inheritDoc} */
+    @Override public String apply(CacheEntryEvent<Integer, Integer> event) {
+        return Integer.toString(event.getValue());
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteTransformerWithStaticInitializerFactory.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PRemoteTransformerWithStaticInitializerFactory.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import javax.cache.configuration.Factory;
+import javax.cache.event.CacheEntryEvent;
+import org.apache.ignite.lang.IgniteClosure;
+
+/**
+ * Remote transformer with static initializer factory.
+ */
+public class GridP2PRemoteTransformerWithStaticInitializerFactory implements Factory<IgniteClosure<CacheEntryEvent<Integer, Integer>, String>> {
+    /** {@inheritDoc} */
+    @Override public IgniteClosure<CacheEntryEvent<Integer, Integer>, String> create() {
+        return new GridP2PRemoteTransformerWithStaticInitializer();
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PSerializableRemoteFilterWithStaticInitializer.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PSerializableRemoteFilterWithStaticInitializer.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+import javax.cache.event.CacheEntryEvent;
+import javax.cache.event.CacheEntryListenerException;
+import org.apache.ignite.cache.CacheEntryEventSerializableFilter;
+
+/**
+ * Serializable remote filter with static initializer.
+ */
+public class GridP2PSerializableRemoteFilterWithStaticInitializer implements CacheEntryEventSerializableFilter {
+    /** */
+    private final GridP2PTestObjectWithStaticInitializer testObj = new GridP2PTestObjectWithStaticInitializer();
+
+    /** {@inheritDoc} */
+    @Override public boolean evaluate(CacheEntryEvent event) throws CacheEntryListenerException {
+        return true;
+    }
+}

--- a/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PTestObjectWithStaticInitializer.java
+++ b/modules/extdata/p2p/src/main/java/org/apache/ignite/tests/p2p/GridP2PTestObjectWithStaticInitializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.tests.p2p;
+
+/**
+ * Test object with static initializer.
+ */
+public class GridP2PTestObjectWithStaticInitializer {
+    /**
+     * Static initializer.
+     */
+    static {
+        new GridP2PTestObject();
+    }
+
+    /**
+     * Test Object.
+     */
+    public static class GridP2PTestObject {
+    }
+}


### PR DESCRIPTION
GG-31007 Server node fails on remote filter with static initializer deployment if client disconnects

* GG-31007 exception handling implemented for errors in static initializer during remote filter deployment in CQ

* GG-31007 exception handling improved

* GG-31007 CQ remote transformer initialization changed

* GG-30311 CQ handler registration changed. Javadoc added for the tests.

* GG-31007 logging added

* Revert "GG-31007 logging added"