### PR TITLE
GG-33390 [IGNITE-14978] .NET: Fix build failures on 2.x SDKs

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/BenchmarkBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/BenchmarkBase.cs
@@ -114,7 +114,7 @@ namespace Apache.Ignite.Benchmarks
 
             ValidateArguments();
 
-            if (ResultWriter.ToLower().Equals(ResultWriterConsole))
+            if (ResultWriter.Equals(ResultWriterConsole, StringComparison.OrdinalIgnoreCase))
                 _writer = new BenchmarkConsoleResultWriter();
             else
                 _writer = new BenchmarkFileResultWriter();
@@ -434,11 +434,11 @@ namespace Apache.Ignite.Benchmarks
                 if (MaxErrors < 0)
                     throw new Exception("MaxErrors cannot be negative: " + MaxErrors);
 
-                if (ResultWriter == null || !ResultWriter.ToLower().Equals(ResultWriterConsole)
-                    && !ResultWriter.ToLower().Equals(ResultWriterFile))
+                if (ResultWriter == null || !ResultWriter.Equals(ResultWriterConsole, StringComparison.OrdinalIgnoreCase)
+                    && !ResultWriter.Equals(ResultWriterFile, StringComparison.OrdinalIgnoreCase))
                     throw new Exception("Invalid ResultWriter: " + ResultWriter);
 
-                if (ResultWriter.ToLower().Equals(ResultWriterFile) && ResultFolder == null)
+                if (ResultWriter.Equals(ResultWriterFile, StringComparison.OrdinalIgnoreCase) && ResultFolder == null)
                     throw new Exception("ResultFolder must be set for file result writer.");
 
                 if (ResultBucketCount <= 0)

--- a/modules/platforms/dotnet/Apache.Ignite.Benchmarks/BenchmarkRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Benchmarks/BenchmarkRunner.cs
@@ -83,7 +83,7 @@ namespace Apache.Ignite.Benchmarks
             {
                 var arg = args[i];
 
-                if (arg.StartsWith("-"))
+                if (arg.StartsWith("-", StringComparison.Ordinal))
                     arg = arg.Substring(1);
                 else
                     continue;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.DotNetCore.csproj
@@ -19,8 +19,9 @@
     <!--
     NOTE: Microsoft.CodeAnalysis.NetAnalyzers is the new replacement for FxCopAnalyzers,
     but it has some issues on older SDKs (https://github.com/dotnet/roslyn-analyzers/issues/4776).
+    NOTE: Don't upgrade to 3.x - it does not work on some older 2.x SDKs
     -->
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.12"/>
   </ItemGroup>
   <ItemGroup>
     <None Update="IgniteConfigurationSection.xsd">

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -28,7 +28,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <RunCodeAnalysis>false</RunCodeAnalysis>
-    <CodeAnalysisRuleSet>Apache.Ignite.Core.ruleset</CodeAnalysisRuleSet>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
@@ -37,7 +36,6 @@
     <DocumentationFile>bin\Release\Apache.Ignite.Core.xml</DocumentationFile>
     <Optimize>true</Optimize>
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <CodeAnalysisRuleSet>Apache.Ignite.Core.ruleset</CodeAnalysisRuleSet>
     <DebugType>none</DebugType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunCodeAnalysis>false</RunCodeAnalysis>
@@ -626,7 +624,6 @@
     <Compile Include="Transactions\TransactionTimeoutException.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Apache.Ignite.Core.ruleset" />
     <None Include="Apache.Ignite.Core.nuspec" />
     <None Include="Apache.Ignite.Core.Schema.nuspec" />
     <None Include="IgniteClientConfigurationSection.xsd">

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Affinity/AffinityKeyMappedAttribute.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Affinity/AffinityKeyMappedAttribute.cs
@@ -17,10 +17,10 @@
 namespace Apache.Ignite.Core.Cache.Affinity
 {
     using System;
-    using System.Diagnostics;
     using System.Linq;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Impl.Binary;
+    using Apache.Ignite.Core.Impl.Common;
 
     /// <summary>
     /// Specifies cache key field to be used to determine a node on which given cache key will be stored.
@@ -48,7 +48,7 @@ namespace Apache.Ignite.Core.Cache.Affinity
         /// </summary>
         public static string GetFieldNameFromAttribute(Type type)
         {
-            Debug.Assert(type != null);
+            IgniteArgumentCheck.NotNull(type, "type");
 
             var res = ReflectionUtils.GetFieldsAndProperties(type)
                 .Select(x => x.Key)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/MemoryConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/MemoryConfiguration.cs
@@ -25,6 +25,7 @@ namespace Apache.Ignite.Core.Cache.Configuration
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Configuration;
+    using Apache.Ignite.Core.Impl.Common;
 
     /// <summary>
     /// A page memory configuration for an Apache Ignite node. The page memory is a manageable off-heap based
@@ -84,9 +85,9 @@ namespace Apache.Ignite.Core.Cache.Configuration
         /// Initializes a new instance of the <see cref="MemoryConfiguration"/> class.
         /// </summary>
         /// <param name="reader">The reader.</param>
-        public MemoryConfiguration(IBinaryRawReader reader)
+        public MemoryConfiguration(IBinaryRawReader reader) // Should be internal.
         {
-            Debug.Assert(reader != null);
+            IgniteArgumentCheck.NotNull(reader, "reader");
 
             SystemCacheInitialSize = reader.ReadLong();
             SystemCacheMaxSize = reader.ReadLong();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Common/IgniteProductVersion.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Common/IgniteProductVersion.cs
@@ -149,12 +149,14 @@ namespace Apache.Ignite.Core.Common
 
         /** <inheritDoc /> */
         [SuppressMessage("Microsoft.Globalization", "CA1308:NormalizeStringsToUppercase")]
+        [SuppressMessage("Microsoft.Globalization", "CA1307:SpecifyStringComparison", Justification = "Not available on .NET FW")]
         public override string ToString()
         {
             string hash = null;
             if (RevisionHash != null)
             {
-                hash = BitConverter.ToString(RevisionHash).Replace("-", "")
+                hash = BitConverter.ToString(RevisionHash)
+                    .Replace("-", "")
                     .ToLowerInvariant()
                     .Substring(0, Math.Min(RevisionHash.Length, 8));
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Ignition.cs
@@ -923,6 +923,7 @@ namespace Apache.Ignite.Core
             }
 
             /** <inheritdoc /> */
+            [SuppressMessage("Microsoft.Globalization", "CA1307:SpecifyStringComparison", Justification = "Not available on .NET FW")]
             public override int GetHashCode()
             {
                 return _name == null ? 0 : _name.GetHashCode();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureEntry.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureEntry.cs
@@ -16,6 +16,7 @@
 
 namespace Apache.Ignite.Core.Impl.Binary.Structure
 {
+    using System;
     using System.Diagnostics;
     using Apache.Ignite.Core.Binary;
 
@@ -70,7 +71,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         public bool IsExpected(string name, byte type)
         {
             // Perform reference equality check first because field name is a literal in most cases.
-            if (!ReferenceEquals(_name, name) && !name.Equals(_name))
+            if (!ReferenceEquals(_name, name) && !name.Equals(_name, StringComparison.Ordinal))
                 return false;
 
             ValidateType(type);

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureJumpTable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureJumpTable.cs
@@ -77,7 +77,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             // Fallback to slow-path with normal string comparison.
             for (var i = 0; i < _names.Length; i++)
             {
-                if (fieldName.Equals(_names[i]))
+                if (fieldName.Equals(_names[i], StringComparison.Ordinal))
                     return _pathIdxs[i];
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Os.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Os.cs
@@ -38,7 +38,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
                         || platform == PlatformID.Win32S
                         || platform == PlatformID.Win32Windows;
 
-            IsMacOs = IsLinux && Shell.ExecuteSafe("uname", string.Empty).Contains("Darwin");
+            IsMacOs = IsLinux && 
+                      Shell.ExecuteSafe("uname", string.Empty).IndexOf("Darwin", StringComparison.Ordinal) >= 0;
+            
             IsMono = Type.GetType("Mono.Runtime") != null;
             IsNetCore = !IsMono;
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.DotNetCore.csproj
@@ -22,8 +22,9 @@
     <!--
     NOTE: Microsoft.CodeAnalysis.NetAnalyzers is the new replacement for FxCopAnalyzers,
     but it has some issues on older SDKs (https://github.com/dotnet/roslyn-analyzers/issues/4776).
+    NOTE: Don't upgrade to 3.x - it does not work on some older 2.x SDKs
     -->
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.12"/>
   </ItemGroup>
 
 </Project>

--- a/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Linq/Apache.Ignite.Linq.csproj
@@ -19,7 +19,6 @@
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisRuleSet>..\Apache.Ignite.Core\Apache.Ignite.Core.ruleset</CodeAnalysisRuleSet>
     <RunCodeAnalysis>false</RunCodeAnalysis>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Tests.ruleset
+++ b/modules/platforms/dotnet/Apache.Ignite.Tests.ruleset
@@ -62,8 +62,14 @@
     <!-- StartsWith locale. -->
     <Rule Id="CA1310" Action="None" />
 
+    <!-- string.Compare locale. -->
+    <Rule Id="CA1307" Action="None" />
+
     <!-- Underscores in names. -->
     <Rule Id="CA1707" Action="None" />
+
+    <!-- Reserved suffixes. -->
+    <Rule Id="CA1710" Action="None" />
 
     <!-- Call Dispose. -->
     <Rule Id="CA2000" Action="None" />

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
@@ -18,6 +18,15 @@
   <ItemGroup>
     <ProjectReference Include="..\Apache.Ignite.Core\Apache.Ignite.Core.DotNetCore.csproj" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <!--
+    NOTE: Microsoft.CodeAnalysis.NetAnalyzers is the new replacement for FxCopAnalyzers,
+    but it has some issues on older SDKs (https://github.com/dotnet/roslyn-analyzers/issues/4776).
+    NOTE: Don't upgrade to 3.x - it does not work on some older 2.x SDKs
+    -->
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.12"/>
+  </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Service\IgniteService.cs" />

--- a/modules/platforms/dotnet/Apache.Ignite/IgniteRunner.cs
+++ b/modules/platforms/dotnet/Apache.Ignite/IgniteRunner.cs
@@ -68,20 +68,20 @@ namespace Apache.Ignite
                         return;
                     }
 
-                    if (Svc.Equals(first))
+                    if (Svc.Equals(first, StringComparison.Ordinal))
                     {
                         args = RemoveFirstArg(args);
 
                         svc = true;
                     }
 
-                    else if (SvcInstall.Equals(first))
+                    else if (SvcInstall.Equals(first, StringComparison.Ordinal))
                     {
                         args = RemoveFirstArg(args);
 
                         install = true;
                     }
-                    else if (SvcUninstall.Equals(first))
+                    else if (SvcUninstall.Equals(first, StringComparison.Ordinal))
                     {
                         IgniteService.Uninstall();
 


### PR DESCRIPTION
* Downgrade FxCopAnalyzers to 2.x: 3.x is not supported on older SDKs
* Remove ruleset leftovers
* Fix some new warnings