### PR TITLE
GG-33226 Fix build for maven 3.8.x

### DIFF
--- a/modules/extdata/uri/pom.xml
+++ b/modules/extdata/uri/pom.xml
@@ -63,7 +63,27 @@
         <module>modules/uri-dependency</module>
     </modules>
 
+    <properties>
+
+        <uri.fn>uri</uri.fn>
+        <uri.jar>${uri.fn}.jar</uri.jar>
+
+        <plain.fn>deployfile</plain.fn>
+        <plain.clr>plain</plain.clr>
+        <plain.jar>${plain.fn}-${plain.clr}.jar</plain.jar>
+
+        <well-signed.fn>deployfile</well-signed.fn>
+        <well-signed.clr>well-signed</well-signed.clr>
+        <well-signed.jar>${well-signed.fn}-${well-signed.clr}.jar</well-signed.jar>
+
+        <bad-signed.fn>deployfile</bad-signed.fn>
+        <bad-signed.clr>bad-signed</bad-signed.clr>
+        <bad-signed.jar>${bad-signed.fn}-${bad-signed.clr}.jar</bad-signed.jar>
+
+    </properties>
+
     <build>
+
         <resources>
             <resource>
                 <directory>src/main/java</directory>
@@ -114,13 +134,29 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>jar-uri</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <finalName>${uri.fn}</finalName>
+                            <outputDirectory>${basedir}/target/deploy</outputDirectory>
+                            <includes>
+                                <include>**/GridUriDeploymentTestTask8.class</include>
+                                <include>**/GridUriDeploymentTestWithNameTask8.class</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
                         <id>jar-file</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <finalName>deployfile</finalName>
+                            <finalName>${plain.fn}</finalName>
+                            <classifier>${plain.clr}</classifier>
                             <outputDirectory>${basedir}/target/file</outputDirectory>
                             <includes>
                                 <include>**/GridUriDeploymentTestTask8.class</include>
@@ -133,28 +169,14 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>jar-uri</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <finalName>uri</finalName>
-                            <outputDirectory>${basedir}/target/deploy</outputDirectory>
-                            <includes>
-                                <include>**/GridUriDeploymentTestTask8.class</include>
-                                <include>**/GridUriDeploymentTestWithNameTask8.class</include>
-                            </includes>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>jar-well-signed</id>
                         <phase>compile</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <finalName>well-signed-deployfile</finalName>
+                            <finalName>${well-signed.fn}</finalName>
+                            <classifier>${well-signed.clr}</classifier>
                             <outputDirectory>${basedir}/target/file</outputDirectory>
                             <includes>
                                 <include>**/GridUriDeploymentTestTask10.class</include>
@@ -169,7 +191,8 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-                            <finalName>bad-signed-deployfile</finalName>
+                            <finalName>${bad-signed.fn}</finalName>
+                            <classifier>${bad-signed.clr}</classifier>
                             <outputDirectory>${basedir}/target/file</outputDirectory>
                             <includes>
                                 <include>**/GridUriDeploymentTestTask11.class</include>
@@ -183,6 +206,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jarsigner-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>sign-well</id>
@@ -191,7 +215,7 @@
                             <goal>sign</goal>
                         </goals>
                         <configuration>
-                            <archive>${basedir}/target/file/well-signed-deployfile.jar</archive>
+                            <archive>${basedir}/target/file/${well-signed.jar}</archive>
                             <keystore>${basedir}/config/signeddeploy/keystore</keystore>
                             <alias>business</alias>
                             <storepass>abc123</storepass>
@@ -211,7 +235,6 @@
                         <artifactId>ignite-tools</artifactId>
                         <version>${project.version}</version>
                     </dependency>
-
                     <dependency>
                         <groupId>com.sun.mail</groupId>
                         <artifactId>javax.mail</artifactId>
@@ -232,15 +255,15 @@
                                 <copy file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestTask11.class" todir="${basedir}/target/file_tmp/classes/org/apache/ignite/spi/deployment/uri/tasks/" />
                                 <copy file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestTask11.class" tofile="${basedir}/target/file_tmp/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" />
 
-                                <jar destfile="${basedir}/target/file/bad-signed-deployfile.jar" basedir="${basedir}/target/file_tmp/classes" />
+                                <jar destfile="${basedir}/target/file/${bad-signed.jar}" basedir="${basedir}/target/file_tmp/classes" />
 
-                                <signjar jar="${basedir}/target/file/bad-signed-deployfile.jar" keystore="${basedir}/config/signeddeploy/keystore" storepass="abc123" keypass="abc123" alias="business" />
+                                <signjar jar="${basedir}/target/file/${bad-signed.jar}" keystore="${basedir}/config/signeddeploy/keystore" storepass="abc123" keypass="abc123" alias="business" />
 
                                 <sleep seconds="2" />
 
                                 <touch file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" />
 
-                                <zip destfile="${basedir}/target/file/bad-signed-deployfile.jar" basedir="${basedir}/target/classes/" includes="org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" update="yes" />
+                                <zip destfile="${basedir}/target/file/${bad-signed.jar}" basedir="${basedir}/target/classes/" includes="org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" update="yes" />
 
                                 <delete dir="${basedir}/target/file_tmp/"/>
                             </target>
@@ -257,7 +280,7 @@
                             <target>
                                 <taskdef name="gar" classname="org.apache.ignite.util.antgar.IgniteDeploymentGarAntTask" />
 
-                                <!-- copying resources to classes -->
+                                <!-- Copying resources to classes -->
                                 <copy todir="${basedir}/target/classes">
                                     <fileset dir="${basedir}/src/main/java">
                                         <include name="**/*.xml" />
@@ -270,7 +293,7 @@
                                 <!--uri-classes.gar-->
                                 <gar destfile="${basedir}/target/deploy2/uri-classes.gar" basedir="${basedir}/target/classes" />
 
-                                <!--Copy libs.-->
+                                <!-- Copy libs -->
                                 <zip destfile="${basedir}/target/classes/lib/depend.jar" encoding="UTF-8">
                                     <zipfileset dir="modules/uri-dependency/target/classes" />
                                 </zip>

--- a/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-4.2/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -35,6 +35,7 @@ import org.hibernate.service.jta.platform.internal.AbstractJtaPlatform;
 import org.hibernate.service.jta.platform.spi.JtaPlatform;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 /**
  *
@@ -74,7 +75,7 @@ public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfT
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-5.1/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -35,6 +35,7 @@ import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 /**
  *
@@ -74,7 +75,7 @@ public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfT
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
+++ b/modules/hibernate-5.3/src/test/java/org/apache/ignite/cache/hibernate/HibernateL2CacheTransactionalSelfTest.java
@@ -35,6 +35,7 @@ import org.hibernate.engine.transaction.jta.platform.spi.JtaPlatform;
 import org.hibernate.resource.transaction.backend.jta.internal.JtaTransactionCoordinatorBuilderImpl;
 import org.jetbrains.annotations.Nullable;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 /**
  *
@@ -74,7 +75,7 @@ public class HibernateL2CacheTransactionalSelfTest extends HibernateL2CacheSelfT
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -47,6 +47,12 @@
         </dependency>
 
         <dependency>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.ow2.jotm</groupId>
             <artifactId>jotm-core</artifactId>
             <version>${jotm.version}</version>

--- a/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/GridJtaTransactionManagerSelfTest.java
+++ b/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/GridJtaTransactionManagerSelfTest.java
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.objectweb.jotm.Current;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 
 import static org.apache.ignite.cache.CacheMode.PARTITIONED;
 import static org.apache.ignite.transactions.TransactionConcurrency.OPTIMISTIC;
@@ -75,7 +76,7 @@ public class GridJtaTransactionManagerSelfTest extends GridCommonAbstractTest {
     @Override protected void beforeTestsStarted() throws Exception {
         super.beforeTestsStarted();
 
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         Current.setAppServer(false);
 

--- a/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/jta/AbstractCacheJtaSelfTest.java
+++ b/modules/jta/src/test/java/org/apache/ignite/internal/processors/cache/jta/AbstractCacheJtaSelfTest.java
@@ -28,6 +28,7 @@ import org.apache.ignite.testframework.GridTestSafeThreadFactory;
 import org.apache.ignite.transactions.Transaction;
 import org.junit.Test;
 import org.objectweb.jotm.Jotm;
+import org.objectweb.jotm.rmi.RmiLocalConfiguration;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CountDownLatch;
 
@@ -48,7 +49,7 @@ public abstract class AbstractCacheJtaSelfTest extends GridCacheAbstractSelfTest
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        jotm = new Jotm(true, false);
+        jotm = new Jotm(true, false, new RmiLocalConfiguration());
 
         super.beforeTestsStarted();
     }

--- a/modules/kubernetes/pom.xml
+++ b/modules/kubernetes/pom.xml
@@ -108,13 +108,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>5.11.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>

--- a/modules/spark/pom.xml
+++ b/modules/spark/pom.xml
@@ -71,6 +71,12 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_2.11</artifactId>
             <version>${spark.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.java.dev.jets3t</groupId>
+                    <artifactId>jets3t</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -89,6 +95,12 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_2.11</artifactId>
             <version>${spark.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.spark</groupId>
+                    <artifactId>spark-core_2.11</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.apache</groupId>
         <artifactId>apache</artifactId>
-        <version>16</version>
+        <version>23</version>
         <relativePath/>
     </parent>
 
@@ -55,15 +55,16 @@
         <aspectj.version>1.8.13</aspectj.version>
         <aws.sdk.bundle.version>1.10.12_1</aws.sdk.bundle.version>
         <aws.sdk.version>1.11.851</aws.sdk.version>
-        <camel.version>2.22.3</camel.version>
         <aws.encryption.sdk.version>1.3.2</aws.encryption.sdk.version>
         <bouncycastle.version>1.68</bouncycastle.version>
+        <camel.version>2.22.3</camel.version>
         <commons.beanutils.bundle.version>1.9.2_1</commons.beanutils.bundle.version>
         <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.codec.version>1.13</commons.codec.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compress.version>1.20</commons.compress.version>
         <commons.lang.version>2.6</commons.lang.version>
+        <commons.lang3.version>3.9</commons.lang3.version>
         <commons.io.version>2.6</commons.io.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <cron4j.version>2.2.5</cron4j.version>
@@ -95,7 +96,7 @@
         <jms.spec.version>1.1.1</jms.spec.version>
         <jna.version>4.5.2</jna.version>
         <jnr.posix.version>3.0.50</jnr.posix.version>
-        <jotm.version>2.2.3</jotm.version>
+        <jotm.version>2.3.1-M1</jotm.version>
         <jsch.bundle.version>0.1.54_1</jsch.bundle.version>
         <jsch.version>0.1.54</jsch.version>
         <jsonlib.bundle.version>2.4_1</jsonlib.bundle.version>
@@ -107,8 +108,6 @@
         <lucene.bundle.version>7.4.0_1</lucene.bundle.version>
         <lucene.version>7.4.0</lucene.version>
         <lz4.version>1.8.0</lz4.version>
-        <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
-        <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
         <checkstyle.puppycrawl.version>8.29</checkstyle.puppycrawl.version>
         <mockito.version>3.4.6</mockito.version>
         <mysql.connector.version>8.0.13</mysql.connector.version>
@@ -154,10 +153,10 @@
         <tyrus.standalon.client.version>1.15</tyrus.standalon.client.version>
         <reflections.version>0.11.7</reflections.version>
         <org.testcontainers.testcontainers>1.12.3</org.testcontainers.testcontainers>
-        <commons.lang3.version>3.9</commons.lang3.version>
-
 
         <!-- Maven plugins versions -->
+        <maven.bundle.plugin.version>3.5.0</maven.bundle.plugin.version>
+        <maven.checkstyle.plugin.version>3.1.1</maven.checkstyle.plugin.version>
         <maven.javadoc.plugin.version>2.10.4</maven.javadoc.plugin.version>
 
         <!-- OSGI Manifest generation default property values -->
@@ -339,7 +338,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.3.2</version>
+                    <version>3.3.3</version>
                     <configuration>
                         <jvmArgs>
                             <jvmArg>-Xms512m</jvmArg>
@@ -368,9 +367,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <configuration>
-                        <useDefaultManifestFile>true</useDefaultManifestFile>
-                    </configuration>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
1. Use 'https' schema in repository links
    
2. Update versions:
- apache parent (to migrate to 'https' in default repositories links)
- jotm (fixes issue with jotm third-party dependency repo link)
    
3. Fix broken configuration for jar plugin (due to versions upgrade in apache parent):
- Remove 'useDefaultManifestFile' option from ignite parent pom
- Add classifiers for artifacts in modules/extdata/uri due to some new constraints in jar-plugin configuration
    
4. Remove duplicated dependencies declarations in several modules along with other minor cleaning to reduce maven warnings
    
5. Excluded net.java.dev.jets3t:jets3t from ignite-spark as transitive dependency of spark-core to get rid of annoying warnings like:
[WARNING] The POM for commons-codec:commons-codec:jar:1.15-SNAPSHOT is missing, no dependency information available