### PR TITLE
GG-34150 Port of IGNITE-15416 to gg-ce

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/collision/GridCollisionManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/collision/GridCollisionManager.java
@@ -18,11 +18,11 @@ package org.apache.ignite.internal.managers.collision;
 
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.SkipDaemon;
 import org.apache.ignite.internal.managers.GridManagerAdapter;
-import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.spi.collision.CollisionContext;
 import org.apache.ignite.spi.collision.CollisionExternalListener;
 import org.apache.ignite.spi.collision.CollisionJobContext;
@@ -60,7 +60,7 @@ public class GridCollisionManager extends GridManagerAdapter<CollisionSpi> {
             });
         }
         else
-            U.warn(log, "Collision resolution is disabled (all jobs will be activated upon arrival).");
+            log.info("Collision resolution is disabled (all jobs will be activated upon arrival).");
 
         if (log.isDebugEnabled())
             log.debug(startInfo());

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridCollisionManagerLoggingSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridCollisionManagerLoggingSelfTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.internal.managers.collision.GridCollisionManager;
+import org.apache.ignite.spi.collision.noop.NoopCollisionSpi;
+import org.apache.ignite.testframework.junits.GridTestKernalContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for making sure that {@link GridCollisionManager} logs about specific conditions at correct levels,
+ * messages are correct and so on.
+ */
+public class GridCollisionManagerLoggingSelfTest {
+    /** Logger used to intercept and inspect logged messages. */
+    private final IgniteLogger logger = mock(IgniteLogger.class);
+
+    /**
+     * Inits logger mock to make it behave nicely (like return a non-null logger from
+     * <tt>IgniteLogger#getLogger()</tt> method).
+     */
+    @Before
+    public void initLoggerMock() {
+        doReturn(logger).when(logger).getLogger(any());
+    }
+
+    /**
+     * Makes sure that, given collision resolution is disabled, during start up the corresponding
+     * message is logged as INFO, not as WARN.
+     *
+     * @throws Exception if something goes wrong
+     */
+    @Test
+    public void collisionResolutionDisabledMessageShouldBeLoggedAtInfoLevel() throws Exception {
+        GridCollisionManager manager = new GridCollisionManager(collisionResolutionDisabledContext());
+
+        manager.start();
+
+        verify(logger).info("Collision resolution is disabled (all jobs will be activated upon arrival).");
+    }
+
+    /**
+     * Builds context without collision resolution.
+     *
+     * @return context without collision resolution
+     */
+    private GridTestKernalContext collisionResolutionDisabledContext() {
+        GridTestKernalContext context = new GridTestKernalContext(logger);
+        context.config().setCollisionSpi(new NoopCollisionSpi());
+        return context;
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/spi/checkpoint/noop/NoopCheckpointSpiLoggingTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/checkpoint/noop/NoopCheckpointSpiLoggingTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.spi.checkpoint.noop;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.regex.Pattern;
+
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for logging concerns of {@link NoopCheckpointSpi}: how and when it logs or does not log.
+ */
+public class NoopCheckpointSpiLoggingTest {
+    /** An empty byte array. */
+    private static final byte[] EMPTY_ARRAY = new byte[0];
+
+    /** The tested SPI instance. */
+    private final NoopCheckpointSpi checkpointSpi = new NoopCheckpointSpi();
+
+    /** Logger used to intercept and inspect logged messages. */
+    private final ListeningTestLogger logger = new ListeningTestLogger();
+
+    /** Logging listener used throught the test. */
+    private LogListener listener;
+
+    /**
+     * Injects logger into SPI instance to prepare it for work.
+     *
+     * @throws Exception if something goes wrong
+     */
+    @Before
+    public void injectLogger() throws Exception {
+        for (Field field : NoopCheckpointSpi.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers()) && field.getType() == IgniteLogger.class) {
+                field.setAccessible(true);
+                field.set(checkpointSpi, logger);
+            }
+        }
+    }
+
+    /**
+     * Makes sure that 'checkpoints are disabled' is not logged at startup.
+     */
+    @Test
+    public void shouldNotLogAboutCheckpointsBeingDisabledAtStartup() {
+        LogListener listener = LogListener.matches(Pattern.compile("Checkpoints are disabled.+"))
+                .atMost(0)
+                .build();
+        logger.registerListener(listener);
+
+        checkpointSpi.spiStart("test");
+
+        assertTrue(listener.check());
+    }
+
+    /**
+     * Makes sure that 'checkpoints are disabled' is logged at a first attempt to save a checkoint.
+     */
+    @Test
+    public void shouldLogAboutCheckpointsBeingDisabledOnCheckpointSave() {
+        registerListenerExpectingExactlyOneCheckpointsDisabledMessage();
+
+        checkpointSpi.saveCheckpoint("point", EMPTY_ARRAY, 1, true);
+
+        verifyExactlyOneLogMessageSeen();
+    }
+
+    /**
+     * Makes sure that exactly one expected message is seen by the logger.
+     */
+    private void verifyExactlyOneLogMessageSeen() {
+        assertTrue(listener.check());
+    }
+
+    /**
+     * Registers a listener for 'checkpoints are disabled' message that expects exactly one such message.
+     */
+    @NotNull
+    private LogListener registerListenerExpectingExactlyOneCheckpointsDisabledMessage() {
+        listener = LogListener
+                .matches("Checkpoints are disabled (to enable configure any GridCheckpointSpi implementation)")
+                .times(1)
+                .build();
+        logger.registerListener(listener);
+        return listener;
+    }
+
+    /**
+     * Makes sure that 'checkpoints are disabled' is logged at a first attempt to load a checkoint.
+     */
+    @Test
+    public void shouldLogAboutCheckpointsBeingDisabledOnCheckpointLoad() {
+        registerListenerExpectingExactlyOneCheckpointsDisabledMessage();
+
+        checkpointSpi.loadCheckpoint("point");
+
+        verifyExactlyOneLogMessageSeen();
+    }
+
+    /**
+     * Makes sure that 'checkpoints are disabled' is logged at a first attempt to remove a checkoint.
+     */
+    @Test
+    public void shouldLogAboutCheckpointsBeingDisabledOnCheckpointRemoval() {
+        registerListenerExpectingExactlyOneCheckpointsDisabledMessage();
+
+        checkpointSpi.removeCheckpoint("point");
+
+        verifyExactlyOneLogMessageSeen();
+    }
+
+    /**
+     * Makes sure that 'checkpoints are disabled' is logged at most once.
+     */
+    @Test
+    public void shouldOnlyLogOnceAboutCheckointsBeingDisabled() {
+        registerListenerExpectingExactlyOneCheckpointsDisabledMessage();
+
+        // invoke every potentially logging method twice
+        checkpointSpi.saveCheckpoint("point", EMPTY_ARRAY, 1, true);
+        checkpointSpi.saveCheckpoint("point", EMPTY_ARRAY, 1, true);
+        checkpointSpi.loadCheckpoint("point");
+        checkpointSpi.loadCheckpoint("point");
+        checkpointSpi.removeCheckpoint("point");
+        checkpointSpi.removeCheckpoint("point");
+
+        verifyExactlyOneLogMessageSeen();
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -18,6 +18,7 @@ package org.apache.ignite.testsuites;
 
 import org.apache.ignite.ClassPathContentLoggingTest;
 import org.apache.ignite.GridSuppressedExceptionSelfTest;
+import org.apache.ignite.cache.RemoveAllDeadlockTest;
 import org.apache.ignite.events.BaselineEventsLocalTest;
 import org.apache.ignite.events.BaselineEventsRemoteTest;
 import org.apache.ignite.events.ClusterActivationStartedEventTest;
@@ -64,6 +65,7 @@ import org.apache.ignite.internal.processors.affinity.GridAffinityProcessorRende
 import org.apache.ignite.internal.processors.affinity.GridHistoryAffinityAssignmentTest;
 import org.apache.ignite.internal.processors.affinity.GridHistoryAffinityAssignmentTestNoOptimization;
 import org.apache.ignite.internal.processors.cache.CacheLocalGetSerializationTest;
+import org.apache.ignite.internal.processors.cache.CacheLockCandidatesThreadTest;
 import org.apache.ignite.internal.processors.cache.GridLocalIgniteSerializationTest;
 import org.apache.ignite.internal.processors.cache.GridProjectionForCachesOnDaemonNodeSelfTest;
 import org.apache.ignite.internal.processors.cache.IgniteDaemonNodeMarshallerCacheTest;
@@ -127,6 +129,7 @@ import org.apache.ignite.plugin.PluginConfigurationTest;
 import org.apache.ignite.plugin.PluginNodeValidationTest;
 import org.apache.ignite.plugin.security.SecurityPermissionSetBuilderTest;
 import org.apache.ignite.spi.GridSpiLocalHostInjectionTest;
+import org.apache.ignite.spi.checkpoint.noop.NoopCheckpointSpiLoggingTest;
 import org.apache.ignite.startup.properties.NotStringSystemPropertyTest;
 import org.apache.ignite.testframework.MessageOrderLogListenerTest;
 import org.apache.ignite.testframework.test.ConfigVariationsExecutionTest;
@@ -313,7 +316,11 @@ import org.junit.runners.Suite;
     BaselineEventsRemoteTest.class,
 
     IgniteThreadGroupNodeRestartTest.class,
-    BaselineEventsRemoteTest.class
+
+    // Other tests
+    CacheLockCandidatesThreadTest.class,
+    RemoveAllDeadlockTest.class,
+    NoopCheckpointSpiLoggingTest.class
 })
 public class IgniteBasicTestSuite {
 }

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteComputeGridTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteComputeGridTestSuite.java
@@ -25,6 +25,7 @@ import org.apache.ignite.internal.GridCancelOnGridStopSelfTest;
 import org.apache.ignite.internal.GridCancelUnusedJobSelfTest;
 import org.apache.ignite.internal.GridCancelledJobsMetricsSelfTest;
 import org.apache.ignite.internal.GridCollisionJobsContextSelfTest;
+import org.apache.ignite.internal.GridCollisionManagerLoggingSelfTest;
 import org.apache.ignite.internal.GridDeploymentMultiThreadedSelfTest;
 import org.apache.ignite.internal.GridDeploymentSelfTest;
 import org.apache.ignite.internal.GridEventStorageCheckAllEventsSelfTest;
@@ -166,6 +167,7 @@ import org.junit.runners.Suite;
     PublicThreadpoolStarvationTest.class,
     StripedExecutorTest.class,
     GridJobServicesAddNodeTest.class,
+    GridCollisionManagerLoggingSelfTest.class,
 
     IgniteComputeCustomExecutorConfigurationSelfTest.class,
     IgniteComputeCustomExecutorSelfTest.class,


### PR DESCRIPTION
IGNITE-15416 False warnings from default Checkpoint and Collision SPIs

- The following warning was written to log when starting with the default CheckpointSpi (NoOpCheckpointSpi):
WARNING: Checkpoints are disabled (to enable configure any GridCheckpointSpi implementation)
This happens even if the user does not use checkpointing at all. In such a case, we should not log this message, but instead it was logged as a WARNING which was confusing.
The change is that now we log it only on the first attempt to actually save/load/remove a checkpoint, not at startup time.

- The following was written to log when starting without collision resolution configuration:
WARNING: Collision resolution is disabled (all jobs will be activated upon arrival).
This is the normal mode, and it should not be a warning.
The change is to log it at INFO level.