### PR TITLE
GG-32736 [IGNITE-15830] Fix performance suggestion when Ignite is run…

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/suggestions/JvmConfigurationSuggestions.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/suggestions/JvmConfigurationSuggestions.java
@@ -57,8 +57,8 @@ public class JvmConfigurationSuggestions {
         if (!U.jvmName().toLowerCase().contains("server"))
             suggestions.add("Enable server mode for JVM (add '" + SERVER + "' to JVM options)");
 
-        if (!U.jdkVersion().equals("1.8"))
-            suggestions.add("Switch to the most recent 1.8 JVM version");
+        if (!"11".equals(U.jdkVersion()))
+            suggestions.add("Switch to the most recent 11 JVM version");
 
         if (U.jdkVersion().equals("1.8") && !args.contains(USE_G1_GC))
             suggestions.add("Enable G1 Garbage Collector (add '" + USE_G1_GC + "' to JVM options)");

--- a/modules/core/src/test/java/org/apache/ignite/internal/suggestions/JvmConfigurationSuggestionsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/suggestions/JvmConfigurationSuggestionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
  *
  * Licensed under the GridGain Community Edition License (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/test/java/org/apache/ignite/internal/suggestions/JvmConfigurationSuggestionsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/suggestions/JvmConfigurationSuggestionsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.suggestions;
+
+import java.util.List;
+
+import org.apache.ignite.internal.util.IgniteUtils;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Tests for {@link JvmConfigurationSuggestions}.
+ */
+public class JvmConfigurationSuggestionsTest {
+    /***/
+    @Test
+    public void shouldSuggestJava11WhenNotRunOnJava11() {
+        try (JdkVersionForger ignored = withJdkVersion("1.8")) {
+            List<String> suggestions = JvmConfigurationSuggestions.getSuggestions();
+
+            assertThat(suggestions, hasItem("Switch to the most recent 11 JVM version"));
+        }
+    }
+
+    /***/
+    @Test
+    public void shouldNotSuggestJava11WhenRunOnJava11() {
+        try (JdkVersionForger ignored = withJdkVersion("11")) {
+            List<String> suggestions = JvmConfigurationSuggestions.getSuggestions();
+
+            assertThat(suggestions, not(hasItem(matchesPattern("Switch to the most recent .+"))));
+        }
+    }
+
+    /***/
+    @NotNull
+    private JdkVersionForger withJdkVersion(String jdkVersion) {
+        return new JdkVersionForger(jdkVersion);
+    }
+
+    /**
+     * Forges JDK version stored as {@code IgniteUtils#jdkVer}. Normally, we would just use
+     * {@code @WithSystemProperty} and be happy, but {@link IgniteUtils} caches values read from system properties
+     * on startup, so we have to resort to this dirty trick.
+     */
+    private static class JdkVersionForger implements AutoCloseable {
+        /** The JDK version we saw in the field when constructing, used to restore the original value. */
+        private final String oldVersion = IgniteUtils.jdkVersion();
+
+        /***/
+        private JdkVersionForger(String newVersion) {
+            setJdkVersion(newVersion);
+        }
+
+        /***/
+        private void setJdkVersion(String newVersion) {
+            GridTestUtils.setFieldValue(null, IgniteUtils.class, "jdkVer", newVersion);
+        }
+
+        /** {@inheritDoc} */
+        @Override public void close() {
+            setJdkVersion(oldVersion);
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -113,6 +113,7 @@ import org.apache.ignite.internal.processors.odbc.OdbcEscapeSequenceSelfTest;
 import org.apache.ignite.internal.processors.odbc.SqlListenerUtilsTest;
 import org.apache.ignite.internal.product.FeaturesIsNotAvailableTest;
 import org.apache.ignite.internal.product.GridProductVersionSelfTest;
+import org.apache.ignite.internal.suggestions.JvmConfigurationSuggestionsTest;
 import org.apache.ignite.internal.util.GridCleanerTest;
 import org.apache.ignite.internal.util.collection.BitSetIntSetTest;
 import org.apache.ignite.internal.util.collection.ImmutableIntSetTest;
@@ -320,7 +321,8 @@ import org.junit.runners.Suite;
     // Other tests
     CacheLockCandidatesThreadTest.class,
     RemoveAllDeadlockTest.class,
-    NoopCheckpointSpiLoggingTest.class
+    NoopCheckpointSpiLoggingTest.class,
+    JvmConfigurationSuggestionsTest.class
 })
 public class IgniteBasicTestSuite {
 }


### PR DESCRIPTION
… with a jdk other than 8x

When started on Java 11, current Ignite suggests to switch to the latest Java 8 JVM which seems weird as Ignite is officially tested on Java 8 and 11 ( https://ignite.apache.org/docs/latest/quick-start/java ), and the recommended version for running Ignite is 11.

This commit changes the behavior to 'Suggest Java 11 when run on any Java version other than 11'.