### PR TITLE
GG-34169 .NET: Allow null SslStreamFactory.CertificatePath

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -110,6 +110,9 @@
     <None Update="Examples\ExpectedOutput\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\Client\server-with-ssl-no-client-auth.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -488,6 +488,7 @@
     <Content Include="Config\Client\IgniteClientConfiguration.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Config\Client\server-with-ssl-no-client-auth.xml" />
     <Content Include="Config\Client\server-with-ssl.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -488,7 +488,9 @@
     <Content Include="Config\Client\IgniteClientConfiguration.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="Config\Client\server-with-ssl-no-client-auth.xml" />
+    <Content Include="Config\Client\server-with-ssl-no-client-auth.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="Config\Client\server-with-ssl.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Core.Tests.Client
     using System.Linq;
     using System.Net;
     using System.Net.Sockets;
+    using System.Security.Authentication;
     using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
@@ -651,6 +652,66 @@ namespace Apache.Ignite.Core.Tests.Client
 
             TestUtils.WaitForTrueCondition(() => logger.Entries.Any(
                 e => e.Message == string.Format("Receiver thread #{0} stopped.", threadId)));
+        }
+
+        /// <summary>
+        /// Tests SSL connection with client-side SSL certificate.
+        /// </summary>
+        [Test]
+        public void TestSslConnectionWithClientAuth()
+        {
+            Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl.xml")
+            });
+
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new[] { "127.0.0.1:11110" },
+                SslStreamFactory = new SslStreamFactory
+                {
+                    CertificatePath = Path.Combine("Config", "Client", "thin-client-cert.pfx"),
+                    CertificatePassword = "123456",
+                    SkipServerCertificateValidation = true,
+                    CheckCertificateRevocation = true,
+#if !NETCOREAPP
+                    SslProtocols = SslProtocols.Tls
+#else
+                    SslProtocols = SslProtocols.Tls12
+#endif
+                }
+            };
+
+            using (var client = Ignition.StartClient(cfg))
+            {
+                Assert.AreEqual(1, client.GetCluster().GetNodes().Count);
+            }
+        }
+
+        /// <summary>
+        /// Tests SSL connection without client-side SSL certificate.
+        /// </summary>
+        [Test]
+        public void TestSslConnectionWithoutClientAuth()
+        {
+            Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl-no-client-auth.xml"),
+            });
+
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new[] { "127.0.0.1:11120" },
+                SslStreamFactory = new SslStreamFactory
+                {
+                    SkipServerCertificateValidation = true
+                }
+            };
+
+            using (var client = Ignition.StartClient(cfg))
+            {
+                Assert.AreEqual(1, client.GetCluster().GetNodes().Count);
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -689,7 +689,7 @@ namespace Apache.Ignite.Core.Tests.Client
 
             // Does not connect without client certificate.
             cfg.SslStreamFactory = new SslStreamFactory { SkipServerCertificateValidation = true };
-            Assert.Throws<IgniteClientException>(() => Ignition.StartClient(cfg));
+            Assert.Catch<Exception>(() => Ignition.StartClient(cfg));
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -686,6 +686,10 @@ namespace Apache.Ignite.Core.Tests.Client
             {
                 Assert.AreEqual(1, client.GetCluster().GetNodes().Count);
             }
+
+            // Does not connect without client certificate.
+            cfg.SslStreamFactory = new SslStreamFactory { SkipServerCertificateValidation = true };
+            Assert.Throws<IgniteClientException>(() => Ignition.StartClient(cfg));
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/RawSecureSocketTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/RawSecureSocketTest.cs
@@ -30,39 +30,55 @@ namespace Apache.Ignite.Core.Tests.Client
     /// </summary>
     public class RawSecureSocketTest
     {
-        /// <summary>
-        /// Tests that we can do handshake over SSL without using Ignite.NET APIs.
-        /// </summary>
-        [Test]
-        public void TestHandshake()
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
         {
             var igniteConfiguration = new IgniteConfiguration(TestUtils.GetTestConfiguration())
             {
                 SpringConfigUrl = Path.Combine("Config", "Client", "server-with-ssl.xml")
             };
 
-            using (Ignition.Start(igniteConfiguration))
-            {
-                const string host = "127.0.0.1";
-                const int port = 11110;
+            Ignition.Start(igniteConfiguration);
+        }
 
-                using (var client = new TcpClient(host, port))
-                using (var sslStream = new SslStream(client.GetStream(), false, ValidateServerCertificate, null))
-                {
-                    var certsCollection = new X509CertificateCollection(new X509Certificate[] {LoadCertificateFile()});
+        [TestFixtureTearDown]
+        public void FixtureTearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        /// <summary>
+        /// Tests that we can do handshake over SSL without using Ignite.NET APIs.
+        /// </summary>
+        [Test]
+        public void TestHandshake([Values(true, false)] bool clientCert)
+        {
+            const string host = "127.0.0.1";
+            const int port = 11110;
+
+            using (var client = new TcpClient(host, port))
+            using (var sslStream = new SslStream(client.GetStream(), false, ValidateServerCertificate, null))
+            {
+                var certsCollection = new X509CertificateCollection(new X509Certificate[] { LoadCertificateFile() });
 
 #if !NETCOREAPP
-                    sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls, false);
+                sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls, false);
 #else
+                if (clientCert)
+                {
                     sslStream.AuthenticateAsClient(host, certsCollection, SslProtocols.Tls12, false);
+                }
+                else
+                {
+                    sslStream.AuthenticateAsClient(host);
+                }
 #endif
 
-                    Assert.IsTrue(sslStream.IsAuthenticated);
-                    Assert.IsTrue(sslStream.IsMutuallyAuthenticated);
-                    Assert.IsTrue(sslStream.IsEncrypted);
+                Assert.IsTrue(sslStream.IsAuthenticated);
+                Assert.AreEqual(clientCert, sslStream.IsMutuallyAuthenticated);
+                Assert.IsTrue(sslStream.IsEncrypted);
 
-                    DoHandshake(sslStream);
-                }
+                DoHandshake(sslStream);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/server-with-ssl-no-client-auth.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/server-with-ssl-no-client-auth.xml
@@ -30,11 +30,11 @@
         <property name="clientConnectorConfiguration">
             <bean class="org.apache.ignite.configuration.ClientConnectorConfiguration">
                 <property name="host" value="127.0.0.1"/>
-                <property name="port" value="11110"/>
+                <property name="port" value="11120"/>
                 <property name="portRange" value="10"/>
                 <property name="sslEnabled" value="true"/>
                 <property name="useIgniteSslContextFactory" value="false"/>
-                <property name="sslClientAuth" value="true"/>
+                <property name="sslClientAuth" value="false"/>
 
                 <property name="sslContextFactory">
                     <bean class="org.apache.ignite.ssl.SslContextFactory">

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/SslStreamFactory.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/SslStreamFactory.cs
@@ -55,8 +55,13 @@ namespace Apache.Ignite.Core.Client
 
             var sslStream = new SslStream(stream, false, ValidateServerCertificate, null);
 
-            var cert = new X509Certificate2(CertificatePath, CertificatePassword);
-            var certs = new X509CertificateCollection(new X509Certificate[] { cert });
+            var cert = string.IsNullOrEmpty(CertificatePath)
+                ? null
+                : new X509Certificate2(CertificatePath, CertificatePassword);
+
+            var certs = cert == null
+                ? null
+                : new X509CertificateCollection(new X509Certificate[] { cert });
 
             sslStream.AuthenticateAsClient(targetHost, certs, SslProtocols, CheckCertificateRevocation);
 


### PR DESCRIPTION
Allow thin client to establish SSL connection without client-side certificate when `ClientConnectorConfiguration.sslClientAuth` is `false` on server.