### PR TITLE
GG-34250 [IGNITE-15360] .NET: Fix verify-nuget.ps1 failure when .NET 5 is installed

### DIFF
--- a/modules/platforms/dotnet/release/_global.json
+++ b/modules/platforms/dotnet/release/_global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "2.1.300",
+    "rollForward": "major"
+  }
+}

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -35,6 +35,19 @@ param (
     [string]$packageDir="..\nupkg"
 )
 
+echo ".NET SDKs:"
+dotnet --list-sdks
+
+$newSdks = dotnet --list-sdks | where {$_ -match "\d+\.\d+"} | where {[int]($_.Split(".")[0]) -gt 2}
+
+if ($newSdks.Length -gt 0) {
+    # Enable global.json only when .NET SDK 3+ is present.
+    # We don't need it otherwise, and "rollForward" is not supported on lower versions.
+    echo "Enabling global.json..."
+
+    Set-Location $PSScriptRoot
+    Copy-Item _global.json global.json
+}
 
 # Find NuGet packages (*.nupkg)
 $dir = If ([System.IO.Path]::IsPathRooted($packageDir)) { $packageDir } Else { Join-Path $PSScriptRoot $packageDir }


### PR DESCRIPTION
Add global.json to use .NET Core 2.x SDK for NuGet verification: .NET 5 changes restore behavior and breaks the script.