### PR TITLE
GG-34190 [IGNITE-15820] .NET: Fix thin client streamer not creating SQL table entries

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerReader.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/streamer/ClientDataStreamerReader.java
@@ -65,6 +65,9 @@ class ClientDataStreamerReader {
         if (obj == null)
             return null;
 
+        if (obj instanceof CacheObject)
+            return (T) obj;
+
         int pos1 = in.position();
 
         in.position(pos0);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTest.cs
@@ -25,8 +25,10 @@ namespace Apache.Ignite.Core.Tests.Client.Datastream
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Cache.Store;
     using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Client.Datastream;
     using Apache.Ignite.Core.Common;
     using Apache.Ignite.Core.Datastream;
@@ -681,6 +683,76 @@ namespace Apache.Ignite.Core.Tests.Client.Datastream
             var inner = ((AggregateException)ex.InnerException).GetBaseException();
 
             StringAssert.StartsWith("Cache does not exist", inner.Message);
+        }
+
+        /// <summary>
+        /// Tests that streaming binary objects with a thin client results in those objects being
+        /// available through SQL in the cache's table.
+        /// </summary>
+        [Test]
+        public void TestBinaryStreamerCreatesSqlRecord()
+        {
+            var cacheCfg = new CacheClientConfiguration
+            {
+                Name = "TestBinaryStreamerCreatesSqlRecord",
+                SqlSchema = "persons",
+                QueryEntities = new[]
+                {
+                    new QueryEntity
+                    {
+                        KeyTypeName = "PersonKey",
+                        ValueTypeName = "Person",
+                        Fields = new List<QueryField>
+                        {
+                            new QueryField
+                            {
+                                Name = "Id",
+                                FieldType = typeof(int),
+                                IsKeyField = true
+                            },
+                            new QueryField
+                            {
+                                Name = "Name",
+                                FieldType = typeof(string),
+                            },
+                            new QueryField
+                            {
+                                Name = "Age",
+                                FieldType = typeof(int)
+                            }
+                        }
+                    }
+                }
+            };
+
+            var cacheClientBinary = Client.GetOrCreateCache<int, IBinaryObject>(cacheCfg)
+                .WithKeepBinary<int, IBinaryObject>();
+
+            // Prepare a binary object.
+            var personKey = Client.GetBinary().GetBuilder("PersonKey")
+                .SetIntField("Id", 111)
+                .Build();
+
+            var person = Client.GetBinary().GetBuilder("Person")
+                .SetStringField("Name", "Jane")
+                .SetIntField("Age", 43)
+                .Build();
+
+            // Stream the binary object to the server.
+            using (var streamer = Client.GetDataStreamer<IBinaryObject, IBinaryObject>(cacheCfg.Name))
+            {
+                streamer.Add(personKey, person);
+                streamer.Flush();
+            }
+
+            // Check that SQL works.
+            var query = new SqlFieldsQuery("SELECT Id, Name, Age FROM \"PERSONS\".PERSON");
+            var fullResultAfterClientStreamer = cacheClientBinary.Query(query).GetAll();
+            Assert.IsNotNull(fullResultAfterClientStreamer);
+            Assert.AreEqual(1, fullResultAfterClientStreamer.Count);
+            Assert.AreEqual(111, fullResultAfterClientStreamer[0][0]);
+            Assert.AreEqual("Jane", fullResultAfterClientStreamer[0][1]);
+            Assert.AreEqual(43, fullResultAfterClientStreamer[0][2]);
         }
 
 #if NETCOREAPP

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
@@ -24,6 +24,8 @@ namespace Apache.Ignite.Core.Tests.Dataload
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Datastream;
     using NUnit.Framework;
 
@@ -806,6 +808,66 @@ namespace Apache.Ignite.Core.Tests.Dataload
 #pragma warning restore 618 // Type or member is obsolete
         }
 
+
+        /// <summary>
+        /// Tests that streaming binary objects with a thin client results in those objects being
+        /// available through SQL in the cache's table.
+        /// </summary>
+        [Test]
+        public void TestBinaryStreamerCreatesSqlRecord()
+        {
+            var cacheCfg = new CacheConfiguration
+            {
+                Name = "TestBinaryStreamerCreatesSqlRecord",
+                SqlSchema = "persons",
+                QueryEntities = new[]
+                {
+                    new QueryEntity
+                    {
+                        ValueTypeName = "Person",
+                        Fields = new List<QueryField>
+                        {
+                            new QueryField
+                            {
+                                Name = "Name",
+                                FieldType = typeof(string),
+                            },
+                            new QueryField
+                            {
+                                Name = "Age",
+                                FieldType = typeof(int)
+                            }
+                        }
+                    }
+                }
+            };
+
+            var cacheClientBinary = _grid.GetOrCreateCache<int, IBinaryObject>(cacheCfg)
+                .WithKeepBinary<int, IBinaryObject>();
+
+            // Prepare a binary object.
+            var jane = _grid.GetBinary().GetBuilder("Person")
+                .SetStringField("Name", "Jane")
+                .SetIntField("Age", 43)
+                .Build();
+
+            const int key = 1;
+
+            // Stream the binary object to the server.
+            using (var streamer = _grid.GetDataStreamer<int, IBinaryObject>(cacheCfg.Name))
+            {
+                streamer.Add(key, jane);
+                streamer.Flush();
+            }
+
+            // Check that SQL works.
+            var query = new SqlFieldsQuery("SELECT Name, Age FROM \"PERSONS\".PERSON");
+            var fullResultAfterClientStreamer = cacheClientBinary.Query(query).GetAll();
+            Assert.IsNotNull(fullResultAfterClientStreamer);
+            Assert.AreEqual(1, fullResultAfterClientStreamer.Count);
+            Assert.AreEqual("Jane", fullResultAfterClientStreamer[0][0]);
+            Assert.AreEqual(43, fullResultAfterClientStreamer[0][1]);
+        }
 
 #if NETCOREAPP
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -112,6 +112,11 @@ namespace Apache.Ignite.Core.Impl.Binary
                 return GetArrayHashCode(val, marsh, affinityKeyFieldIds);
             }
 
+            if (type == typeof(BinaryObject))
+            {
+                return val.GetHashCode();
+            }
+
             // DateTime, when used as key, is always written as BinaryObject.
             return GetComplexTypeHashCode(val, marsh, affinityKeyFieldIds);
         }


### PR DESCRIPTION
* Fix BinaryObject handling in ClientDataStreamerReader.
* Fix BinaryObject hash code calculation in .NET thin client.