### PR TITLE
GG-34256 [IGNITE-15845] .NET: Fix TypeNameParser to ignore escaped characters in compiler-generated type names

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/TypeNameParserTest.cs
@@ -86,7 +86,7 @@ namespace Apache.Ignite.Core.Tests.Binary
 #else
             const string coreAsmNamePrefix = "mscorlib,";
 #endif
-            
+
             // Simple name.
             var res = TypeNameParser.Parse("List`1[[Int]]");
             Assert.AreEqual("List`1", res.GetName());
@@ -192,9 +192,9 @@ namespace Apache.Ignite.Core.Tests.Binary
             Assert.AreEqual("System.Int32", gen.GetNameWithNamespace());
 
             res = TypeNameParser.Parse(typeof(NestedGeneric<int>.NestedGeneric2<string>).AssemblyQualifiedName);
-            
+
             Assert.AreEqual("NestedGeneric2`1", res.GetName());
-            Assert.AreEqual("Apache.Ignite.Core.Tests.Binary.TypeNameParserTest+NestedGeneric`1+NestedGeneric2`1", 
+            Assert.AreEqual("Apache.Ignite.Core.Tests.Binary.TypeNameParserTest+NestedGeneric`1+NestedGeneric2`1",
                 res.GetNameWithNamespace());
 
             Assert.AreEqual(2, res.Generics.Count);
@@ -236,6 +236,20 @@ namespace Apache.Ignite.Core.Tests.Binary
             CheckType(typeof(List<int>[]));
             CheckType(typeof(List<int>[,]));
             CheckType(typeof(List<int>[][]));
+        }
+
+        [Test]
+        public void TestCompilerGeneratedTypes()
+        {
+            var res = TypeNameParser.Parse(
+                @"Foo.Bar+<Abc-Def<System-String\,System-Byte\[\]>-Convert>d__0");
+
+            Assert.AreEqual(@"<Abc-Def<System-String\,System-Byte\[\]>-Convert>d__0", res.GetName());
+
+            var res2 = TypeNameParser.Parse(
+                @"Foo.Bar+<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1");
+
+            Assert.AreEqual(@"<Foo-Bar<Abc-Def<System-Byte\[\]>\,Abc-Def<System-String>>-Convert>d__4`1", res2.GetName());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
@@ -418,7 +418,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                 {
                     // Ignore escaped characters in compiler-generated type names.
                     // Return any non-separator character to continue parsing.
-                    return default;
+                    return default(char);
                 }
 
                 return _typeName[_pos];

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/TypeNameParser.cs
@@ -410,7 +410,19 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// </summary>
         private char Char
         {
-            get { return _typeName[_pos]; }
+            get
+            {
+                const char escape = '\\';
+
+                if (_pos > 0 && _typeName[_pos - 1] == escape)
+                {
+                    // Ignore escaped characters in compiler-generated type names.
+                    // Return any non-separator character to continue parsing.
+                    return default;
+                }
+
+                return _typeName[_pos];
+            }
         }
 
         /** <inheritdoc /> */


### PR DESCRIPTION
Compiler-generated type names use `\` to escape characters such as `[` and `,`, example: `MassTransit.Initializers.PropertyConverters.MessageDataPropertyConverter+<MassTransit-Initializers-IPropertyConverter<MassTransit-MessageData<System-Byte\[\]>\,MassTransit-MessageData<System-String>>-Convert>d__4`.

`TypeNameParser` was trying to parse those escaped characters as arrays, while it is just a part of the type name.