### PR TITLE
GG-34257 [IGNITE-15921] Thin client: drop connection on invalid handshake without allocating buffer

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioMessageParser.java
@@ -24,7 +24,6 @@ import org.apache.ignite.internal.util.nio.GridNioParser;
 import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.apache.ignite.internal.util.nio.GridNioSessionMetaKey;
 import org.apache.ignite.internal.util.typedef.internal.U;
-import org.apache.ignite.plugin.extensions.communication.Message;
 
 /**
  * This class implements stream parser based on {@link ClientListenerNioServerBuffer}.
@@ -41,8 +40,8 @@ public class ClientListenerNioMessageParser implements GridNioParser {
     /** Message metadata key. */
     static final int MSG_META_KEY = GridNioSessionMetaKey.nextUniqueKey();
 
-    /** Reader metadata key. */
-    static final int READER_META_KEY = GridNioSessionMetaKey.nextUniqueKey();
+    /** First message key. */
+    static final int FIRST_MESSAGE_RECEIVED_KEY = GridNioSessionMetaKey.nextUniqueKey();
 
     /** */
     private final IgniteLogger log;
@@ -54,19 +53,22 @@ public class ClientListenerNioMessageParser implements GridNioParser {
 
     /** {@inheritDoc} */
     @Override public Object decode(GridNioSession ses, ByteBuffer buf) throws IOException, IgniteCheckedException {
-        Message msg = ses.removeMeta(MSG_META_KEY);
+        ClientMessage msg = ses.removeMeta(MSG_META_KEY);
 
         try {
             if (msg == null)
-                msg = new ClientMessage();
+                msg = new ClientMessage(ses.meta(FIRST_MESSAGE_RECEIVED_KEY) == null);
 
             boolean finished = false;
 
             if (buf.hasRemaining())
-                finished = msg.readFrom(buf, null);
+                finished = msg.readFrom(buf);
 
-            if (finished)
+            if (finished) {
+                ses.addMeta(FIRST_MESSAGE_RECEIVED_KEY, true);
+
                 return msg;
+            }
             else {
                 ses.addMeta(MSG_META_KEY, msg);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientMessage.java
@@ -33,6 +33,18 @@ public class ClientMessage implements Message, Externalizable {
     /** */
     private static final long serialVersionUID = -4609408156037304495L;
 
+    /** Limit handshake size to 64 MiB. */
+    private static final int MAX_HANDSHAKE_SIZE = 64 * 1024 * 1024;
+
+    /** First 3 bytes in handshake are either 1 1 0 (handshake = 1, major version = 1)... */
+    private static final int HANDSHAKE_HEADER = 1 + (1 << 8);
+
+    /** ...or 1 2 0 (handshake = 1, major version = 2). */
+    private static final int HANDSHAKE_HEADER2 = 1 + (2 << 8);
+
+    /** */
+    private final boolean isFirstMessage;
+
     /** */
     private byte[] data;
 
@@ -46,16 +58,29 @@ public class ClientMessage implements Message, Externalizable {
     private int msgSize;
 
     /** */
-    public ClientMessage() {}
+    private int firstMessageHeader;
+
+    /** */
+    public ClientMessage() {
+        isFirstMessage = false;
+    }
+
+    /** */
+    public ClientMessage(boolean isFirstMessage) {
+        this.isFirstMessage = isFirstMessage;
+    }
 
     /** */
     public ClientMessage(byte[] data) {
+        //noinspection AssignmentOrReturnOfFieldWithMutableType
         this.data = data;
+        isFirstMessage = false;
     }
 
     /** */
     public ClientMessage(BinaryHeapOutputStream stream) {
         this.stream = stream;
+        isFirstMessage = false;
     }
 
     /** {@inheritDoc} */
@@ -107,6 +132,16 @@ public class ClientMessage implements Message, Externalizable {
 
     /** {@inheritDoc} */
     @Override public boolean readFrom(ByteBuffer buf, MessageReader reader) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Reads this message from provided byte buffer.
+     *
+     * @param buf Byte buffer.
+     * @return Whether message was fully read.
+     */
+    public boolean readFrom(ByteBuffer buf) throws IOException {
         if (cnt < 0) {
             for (; cnt < 0 && buf.hasRemaining(); cnt++)
                 msgSize |= (buf.get() & 0xFF) << (8 * (4 + cnt));
@@ -114,10 +149,13 @@ public class ClientMessage implements Message, Externalizable {
             if (cnt < 0)
                 return false;
 
-            data = new byte[msgSize];
+            if (msgSize <= 0)
+                throw new IOException("Message size must be greater than 0: " + msgSize);
+
+            if (isFirstMessage && msgSize > MAX_HANDSHAKE_SIZE)
+                throw new IOException("Client handshake size limit exceeded: " + msgSize + " > " + MAX_HANDSHAKE_SIZE);
         }
 
-        assert data != null;
         assert cnt >= 0;
         assert msgSize > 0;
 
@@ -128,6 +166,31 @@ public class ClientMessage implements Message, Externalizable {
 
             if (missing > 0) {
                 int len = Math.min(missing, remaining);
+
+                if (isFirstMessage) {
+                    // Sanity check: first 3 bytes in handshake are always 1 1 0 (handshake = 1, major version = 1).
+                    // Do not allocate the buffer before validating the header to protect us from garbage data sent by unrelated application
+                    // connecting on our port by accident.
+                    while (len > 0 && cnt < 3) {
+                        firstMessageHeader |= (buf.get() & 0xFF) << (8 * cnt);
+                        cnt++;
+                        len--;
+                    }
+
+                    if (cnt < 3)
+                        return false;
+
+                    if (firstMessageHeader != HANDSHAKE_HEADER && firstMessageHeader != HANDSHAKE_HEADER2)
+                        throw new IOException("Handshake header check failed: " + firstMessageHeader);
+
+                    // Header is valid, create buffer and set first bytes.
+                    data = new byte[msgSize];
+                    data[0] = 1;
+                    data[1] = (byte)(firstMessageHeader >> 8);
+                }
+
+                if (data == null)
+                    data = new byte[msgSize];
 
                 buf.get(data, cnt, len);
 
@@ -170,6 +233,7 @@ public class ClientMessage implements Message, Externalizable {
             stream = null;
         }
 
+        //noinspection AssignmentOrReturnOfFieldWithMutableType
         return data;
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -16,10 +16,14 @@
 
 package org.apache.ignite.client;
 
+import java.io.OutputStream;
+import java.net.Socket;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.ClientConfiguration;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 /**
  * Checks if it can connect to a valid address from the node address list.
@@ -82,6 +86,51 @@ public class ConnectionTest {
         String userName = new String(data);
 
         testConnectionWithUsername(userName, Config.SERVER);
+    }
+
+    /** */
+    @Test
+    public void testHandshakeTooLargeServerDropsConnection() throws Exception {
+        try (LocalIgniteCluster ignored = LocalIgniteCluster.start(1, IPv4_HOST)) {
+            Socket clientSocket = new Socket(IPv4_HOST, 10800);
+            OutputStream stream = clientSocket.getOutputStream();
+
+            stream.write(new byte[]{1, 1, 1, 1});
+            stream.flush();
+
+            // Read returns -1 when end of stream has been reached, blocks otherwise.
+            assertEquals(-1, clientSocket.getInputStream().read());
+        }
+    }
+
+    /** */
+    @Test
+    public void testNegativeMessageSizeDropsConnection() throws Exception {
+        try (LocalIgniteCluster ignored = LocalIgniteCluster.start(1, IPv4_HOST)) {
+            Socket clientSocket = new Socket(IPv4_HOST, 10800);
+            OutputStream stream = clientSocket.getOutputStream();
+
+            byte b = (byte)255;
+            stream.write(new byte[]{b, b, b, b});
+            stream.flush();
+
+            // Read returns -1 when end of stream has been reached, blocks otherwise.
+            assertEquals(-1, clientSocket.getInputStream().read());
+        }
+    }
+
+    /** */
+    @Test
+    public void testInvalidHandshakeHeaderDropsConnection() throws Exception {
+        try (LocalIgniteCluster ignored = LocalIgniteCluster.start(1, IPv4_HOST)) {
+            Socket clientSocket = new Socket(IPv4_HOST, 10800);
+            OutputStream stream = clientSocket.getOutputStream();
+
+            stream.write(new byte[]{10, 0, 0, 0, 42, 42, 42});
+            stream.flush();
+
+            assertEquals(-1, clientSocket.getInputStream().read());
+        }
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -80,7 +80,6 @@ public class ConnectionTest {
 
     /** */
     @Test(expected = org.apache.ignite.client.ClientConnectionException.class)
-    @Ignore("https://ggsystems.atlassian.net/browse/GG-23022")
     public void testInvalidBigHandshakeMessage() throws Exception {
         char[] data = new char[1024 * 1024 * 128];
         String userName = new String(data);


### PR DESCRIPTION
* Check first 3 bytes of the handshake message without allocating the buffer, drop connection in case of garbage data.
* Add 64 MiB handshake size limit.