### PR TITLE
GG-34377 [IGNITE-13804] Java thin: avoid buffer copy on send

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/streams/BinaryHeapOutputStream.java
@@ -27,6 +27,9 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
     /** Allocator. */
     private final BinaryMemoryAllocatorChunk chunk;
 
+    /** Disable auto close flag. */
+    private final boolean disableAutoClose;
+
     /** Data. */
     private byte[] data;
 
@@ -46,13 +49,34 @@ public final class BinaryHeapOutputStream extends BinaryAbstractOutputStream {
      * @param chunk Chunk.
      */
     public BinaryHeapOutputStream(int cap, BinaryMemoryAllocatorChunk chunk) {
+        this(cap, chunk, false);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param cap Capacity.
+     * @param chunk Chunk.
+     * @param disableAutoClose Whether to disable resource release in {@link BinaryHeapOutputStream#close()} method
+     *                         so that an explicit {@link BinaryHeapOutputStream#release()} call is required.
+     */
+    public BinaryHeapOutputStream(int cap, BinaryMemoryAllocatorChunk chunk, boolean disableAutoClose) {
         this.chunk = chunk;
+        this.disableAutoClose = disableAutoClose;
 
         data = chunk.allocate(cap);
     }
 
     /** {@inheritDoc} */
     @Override public void close() {
+        if (!disableAutoClose)
+            release();
+    }
+
+    /**
+     * Releases pooled memory.
+     */
+    public void release() {
         chunk.release(data, pos);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/PayloadOutputChannel.java
@@ -16,7 +16,9 @@
 
 package org.apache.ignite.internal.client.thin;
 
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.ignite.internal.binary.streams.BinaryHeapOutputStream;
+import org.apache.ignite.internal.binary.streams.BinaryMemoryAllocator;
 import org.apache.ignite.internal.binary.streams.BinaryOutputStream;
 
 /**
@@ -30,13 +32,17 @@ class PayloadOutputChannel implements AutoCloseable {
     private final ClientChannel ch;
 
     /** Output stream. */
-    private final BinaryOutputStream out;
+    private final BinaryHeapOutputStream out;
+
+    /** Close guard. */
+    private final AtomicBoolean closed = new AtomicBoolean();
 
     /**
      * Constructor.
      */
     PayloadOutputChannel(ClientChannel ch) {
-        out = new BinaryHeapOutputStream(INITIAL_BUFFER_CAPACITY);
+        // Disable AutoCloseable on the stream so that out callers don't release the pooled buffer before it is written to the socket.
+        out = new BinaryHeapOutputStream(INITIAL_BUFFER_CAPACITY, BinaryMemoryAllocator.POOLED.chunk(), true);
         this.ch = ch;
     }
 
@@ -56,6 +62,9 @@ class PayloadOutputChannel implements AutoCloseable {
 
     /** {@inheritDoc} */
     @Override public void close() {
-        out.close();
+        // Pooled buffer is reusable and should be released once and only once.
+        // Releasing more than once potentially "steals" it from another request.
+        if (closed.compareAndSet(false, true))
+            out.release();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -247,7 +247,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         throws ClientException {
         long id = reqId.getAndIncrement();
 
-        try (PayloadOutputChannel payloadCh = new PayloadOutputChannel(this)) {
+        PayloadOutputChannel payloadCh = new PayloadOutputChannel(this);
+
+        try {
             if (closed())
                 throw new ClientConnectionException("Channel is closed");
 
@@ -266,13 +268,15 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             req.writeInt(0, req.position() - 4); // Actual size.
 
-            // arrayCopy is required, because buffer is pooled, and write is async.
-            write(req.arrayCopy(), req.position());
+            write(req.array(), req.position(), payloadCh::close);
 
             return fut;
         }
         catch (Throwable t) {
             pendingReqs.remove(id);
+
+            // Potential double-close is handled in PayloadOutputChannel.
+            payloadCh.close();
 
             throw t;
         }
@@ -605,7 +609,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             writer.out().writeInt(0, writer.out().position() - 4);// actual size
 
-            write(writer.out().arrayCopy(), writer.out().position());
+            write(writer.out().arrayCopy(), writer.out().position(), null);
         }
     }
 
@@ -675,11 +679,11 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     }
 
     /** Write bytes to the output stream. */
-    private void write(byte[] bytes, int len) throws ClientConnectionException {
+    private void write(byte[] bytes, int len, @Nullable Runnable onDone) throws ClientConnectionException {
         ByteBuffer buf = ByteBuffer.wrap(bytes, 0, len);
 
         try {
-            sock.send(buf);
+            sock.send(buf, onDone);
         }
         catch (IgniteCheckedException e) {
             throw new ClientConnectionException(e.getMessage(), e);

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/ClientConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/ClientConnection.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.client.thin.io;
 import java.nio.ByteBuffer;
 
 import org.apache.ignite.IgniteCheckedException;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Client connection: abstracts away sending and receiving messages.
@@ -28,8 +29,9 @@ public interface ClientConnection extends AutoCloseable {
      * Sends a message.
      *
      * @param msg Message buffer.
+     * @param onDone Callback to be invoked when asynchronous send operation completes.
      */
-    void send(ByteBuffer msg) throws IgniteCheckedException;
+    void send(ByteBuffer msg, @Nullable Runnable onDone) throws IgniteCheckedException;
 
     /**
      * Closes the connection.

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnection.java
@@ -24,6 +24,7 @@ import org.apache.ignite.internal.client.thin.io.ClientConnectionStateHandler;
 import org.apache.ignite.internal.client.thin.io.ClientMessageHandler;
 import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.apache.ignite.internal.util.nio.GridNioSessionMetaKey;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Client connection.
@@ -61,8 +62,11 @@ class GridNioClientConnection implements ClientConnection {
     }
 
     /** {@inheritDoc} */
-    @Override public void send(ByteBuffer msg) throws IgniteCheckedException {
-        ses.sendNoFuture(msg, null);
+    @Override public void send(ByteBuffer msg, @Nullable Runnable onDone) throws IgniteCheckedException {
+        if (onDone != null)
+            ses.send(msg).listen(f -> onDone.run());
+        else
+            ses.sendNoFuture(msg, null);
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
* Release pooled buffer in NIO future listener to avoid an extra copy.
* Use `BinaryMemoryAllocator.POOLED` instead of `THREAD_LOCAL` because we release the buffer asynchronously.
* Fix use-after-free caused by `PayloadOutputChannel.out()` callers which wrap it into a writer inside try-with-resources.
* Checked `JmhThinClientCacheBenchmark` - no observable difference.