### PR TITLE
GG-34397 Snapshot doesn't work for caches with TDE in case these caches have a lot of values (#2233)

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/mvcc/txlog/TxLogInnerIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/mvcc/txlog/TxLogInnerIO.java
@@ -36,6 +36,8 @@ public class TxLogInnerIO extends BPlusInnerIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void storeByOffset(long pageAddr, int off, TxKey row) {
+        assertPageType(pageAddr);
+
         TxRow row0 = (TxRow)row;
 
         setMajor(pageAddr, off, row0.major());
@@ -45,6 +47,8 @@ public class TxLogInnerIO extends BPlusInnerIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void store(long dstPageAddr, int dstIdx, BPlusIO<TxKey> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         TxLogIO srcIo0 = (TxLogIO)srcIo;
 
         int srcOff = srcIo.offset(srcIdx);
@@ -79,6 +83,8 @@ public class TxLogInnerIO extends BPlusInnerIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void setMajor(long pageAddr, int off, long major) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, off, major);
     }
 
@@ -89,6 +95,8 @@ public class TxLogInnerIO extends BPlusInnerIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void setMinor(long pageAddr, int off, long minor) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, off + 8, minor);
     }
 
@@ -99,6 +107,8 @@ public class TxLogInnerIO extends BPlusInnerIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void setState(long pageAddr, int off, byte state) {
+        assertPageType(pageAddr);
+
         PageUtils.putByte(pageAddr, off + 16, state);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/mvcc/txlog/TxLogLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/mvcc/txlog/TxLogLeafIO.java
@@ -36,6 +36,8 @@ public class TxLogLeafIO extends BPlusLeafIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void storeByOffset(long pageAddr, int off, TxKey row) {
+        assertPageType(pageAddr);
+
         TxRow row0 = (TxRow)row;
 
         setMajor(pageAddr, off, row0.major());
@@ -45,6 +47,8 @@ public class TxLogLeafIO extends BPlusLeafIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void store(long dstPageAddr, int dstIdx, BPlusIO<TxKey> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         TxLogIO srcIo0 = (TxLogIO)srcIo;
 
         int srcOff = srcIo.offset(srcIdx);
@@ -79,6 +83,8 @@ public class TxLogLeafIO extends BPlusLeafIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void setMajor(long pageAddr, int off, long major) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, off, major);
     }
 
@@ -89,6 +95,8 @@ public class TxLogLeafIO extends BPlusLeafIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void setMinor(long pageAddr, int off, long minor) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, off + 8, minor);
     }
 
@@ -99,6 +107,8 @@ public class TxLogLeafIO extends BPlusLeafIO<TxKey> implements TxLogIO {
 
     /** {@inheritDoc} */
     @Override public void setState(long pageAddr, int off, byte state) {
+        assertPageType(pageAddr);
+
         PageUtils.putByte(pageAddr, off + 16, state);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IndexStorageImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IndexStorageImpl.java
@@ -543,6 +543,8 @@ public class IndexStorageImpl implements IndexStorage {
 
         /** {@inheritDoc} */
         @Override public void storeByOffset(long buf, int off, IndexItem row) throws IgniteCheckedException {
+            assertPageType(buf);
+
             storeRow(buf, off, row);
         }
 
@@ -552,6 +554,8 @@ public class IndexStorageImpl implements IndexStorage {
             final BPlusIO<IndexItem> srcIo,
             final long srcPageAddr,
             final int srcIdx) throws IgniteCheckedException {
+            assertPageType(dstPageAddr);
+
             storeRow(dstPageAddr, offset(dstIdx), srcPageAddr, ((IndexIO)srcIo).getOffset(srcPageAddr, srcIdx));
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListMetaIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListMetaIO.java
@@ -76,6 +76,7 @@ public class PagesListMetaIO extends PageIO {
      */
     private void setCount(long pageAddr, int cnt) {
         assert cnt >= 0 && cnt <= Short.MAX_VALUE : cnt;
+        assertPageType(pageAddr);
 
         PageUtils.putShort(pageAddr, CNT_OFF, (short)cnt);
     }
@@ -93,6 +94,8 @@ public class PagesListMetaIO extends PageIO {
      * @param metaPageId Next meta page ID.
      */
     public void setNextMetaPageId(long pageAddr, long metaPageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, NEXT_META_PAGE_OFF, metaPageId);
     }
 
@@ -113,6 +116,7 @@ public class PagesListMetaIO extends PageIO {
      */
     public int addTails(int pageSize, long pageAddr, int bucket, PagesList.Stripe[] tails, int tailsOff) {
         assert bucket >= 0 && bucket <= Short.MAX_VALUE : bucket;
+        assertPageType(pageAddr);
 
         int cnt = getCount(pageAddr);
         int cap = getCapacity(pageSize, pageAddr);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListNodeIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/freelist/io/PagesListNodeIO.java
@@ -86,6 +86,8 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      * @param nextId Next page ID.
      */
     public void setNextId(long pageAddr, long nextId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, NEXT_PAGE_ID_OFF, nextId);
     }
 
@@ -102,6 +104,8 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      * @param prevId Previous  page ID.
      */
     public void setPreviousId(long pageAddr, long prevId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, PREV_PAGE_ID_OFF, prevId);
     }
 
@@ -123,6 +127,7 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      */
     private void setCount(long pageAddr, int cnt) {
         assert cnt >= 0 && cnt <= Short.MAX_VALUE : cnt;
+        assertPageType(pageAddr);
 
         PageUtils.putShort(pageAddr, CNT_OFF, (short)cnt);
     }
@@ -160,6 +165,8 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      * @param pageId Item value to write.
      */
     private void setAt(long pageAddr, int idx, long pageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset(idx), pageId);
     }
 
@@ -172,6 +179,8 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      * @return Total number of items in this page.
      */
     public int addPage(long pageAddr, long pageId, int pageSize) {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         if (cnt == getCapacity(pageSize))
@@ -190,6 +199,8 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      * @return Removed page ID.
      */
     public long takeAnyPage(long pageAddr) {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         if (cnt == 0)
@@ -209,6 +220,7 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
      */
     public boolean removePage(long pageAddr, long dataPageId) {
         assert dataPageId != 0;
+        assertPageType(pageAddr);
 
         int cnt = getCount(pageAddr);
 
@@ -236,6 +248,8 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
 
     /** {@inheritDoc} */
     @Override public void compactPage(ByteBuffer page, ByteBuffer out, int pageSize) {
+        assertPageType(page);
+
         copyPage(page, out, pageSize);
 
         long pageAddr = GridUnsafe.bufferAddress(out);
@@ -249,6 +263,7 @@ public class PagesListNodeIO extends PageIO implements CompactablePageIO {
         assert compactPage.isDirect();
         assert compactPage.position() == 0;
         assert compactPage.limit() <= pageSize;
+        assertPageType(compactPage);
 
         compactPage.limit(pageSize); // Just add garbage to the end.
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/metastorage/MetastorageInnerIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/metastorage/MetastorageInnerIO.java
@@ -38,6 +38,8 @@ public class MetastorageInnerIO extends BPlusInnerIO<MetastorageRow> implements 
         int off,
         MetastorageRow row
     ) {
+        assertPageType(pageAddr);
+
         // All update operations should use new IO version.
         setVersion(pageAddr, 2);
 
@@ -46,6 +48,8 @@ public class MetastorageInnerIO extends BPlusInnerIO<MetastorageRow> implements 
 
     /** {@inheritDoc} */
     @Override public void store(long dstPageAddr, int dstIdx, BPlusIO<MetastorageRow> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         // All update operations should use new IO version.
         setVersion(dstPageAddr, 2);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/metastorage/MetastorageLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/metastorage/MetastorageLeafIO.java
@@ -38,6 +38,8 @@ public class MetastorageLeafIO extends BPlusLeafIO<MetastorageRow> implements Me
         int off,
         MetastorageRow row
     ) {
+        assertPageType(pageAddr);
+
         setVersion(pageAddr, 2);
 
         MetastoragePageIOUtils.storeByOffset(this, pageAddr, off, row);
@@ -45,6 +47,8 @@ public class MetastorageLeafIO extends BPlusLeafIO<MetastorageRow> implements Me
 
     /** {@inheritDoc} */
     @Override public void store(long dstPageAddr, int dstIdx, BPlusIO<MetastorageRow> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         setVersion(dstPageAddr, 2);
 
         MetastoragePageIOUtils.store(this, dstPageAddr, dstIdx, srcIo, srcPageAddr, srcIdx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/AbstractDataPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/AbstractDataPageIO.java
@@ -236,6 +236,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
      * @param freeListPageId Free list page ID.
      */
     public void setFreeListPageId(long pageAddr, long freeListPageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, FREE_LIST_PAGE_ID_OFF, freeListPageId);
     }
 
@@ -293,6 +295,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
      */
     private void setFirstEntryOffset(long pageAddr, int dataOff, int pageSize) {
         assert dataOff >= ITEMS_OFF + ITEM_SIZE && dataOff <= pageSize : dataOff;
+        assertPageType(pageAddr);
 
         PageUtils.putShort(pageAddr, FIRST_ENTRY_OFF, (short)dataOff);
     }
@@ -312,6 +315,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
      */
     private void setRealFreeSpace(long pageAddr, int freeSpace, int pageSize) {
         assert freeSpace == actualFreeSpace(pageAddr, pageSize) : freeSpace + " != " + actualFreeSpace(pageAddr, pageSize);
+        assertPageType(pageAddr);
 
         PageUtils.putShort(pageAddr, FREE_SPACE_OFF, (short)freeSpace);
     }
@@ -362,6 +366,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
      */
     private void setDirectCount(long pageAddr, int cnt) {
         assert checkCount(cnt) : cnt;
+        assertPageType(pageAddr);
 
         PageUtils.putByte(pageAddr, DIRECT_CNT_OFF, (byte)cnt);
     }
@@ -385,16 +390,18 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
     /**
      * @param pageAddr Page address.
      * @param c Closure.
-     * @param <T> Closure return type.
+     * @param <U> Closure return type.
      * @return Collection of closure results for all items in page.
      * @throws IgniteCheckedException In case of error in closure body.
      */
-    public <T> List<T> forAllItems(long pageAddr, CC<T> c) throws IgniteCheckedException {
+    public <U> List<U> forAllItems(long pageAddr, CC<U> c) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         long pageId = getPageId(pageAddr);
 
         int cnt = getDirectCount(pageAddr);
 
-        List<T> res = new ArrayList<>(cnt);
+        List<U> res = new ArrayList<>(cnt);
 
         for (int i = 0; i < cnt; i++) {
             long link = PageIdUtils.link(pageId, i);
@@ -664,6 +671,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
      * @param item Item.
      */
     private void setItem(long pageAddr, int idx, short item) {
+        assertPageType(pageAddr);
+
         PageUtils.putShort(pageAddr, itemOffset(idx), item);
     }
 
@@ -795,6 +804,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         final int rowSize) throws IgniteCheckedException {
         assert checkIndex(itemId) : itemId;
         assert row != null ^ payload != null;
+        assertPageType(pageAddr);
 
         final int dataOff = getDataOffset(pageAddr, itemId, pageSize);
 
@@ -818,6 +828,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
      */
     public long removeRow(long pageAddr, int itemId, int pageSize) throws IgniteCheckedException {
         assert checkIndex(itemId) : itemId;
+        assertPageType(pageAddr);
 
         final int dataOff = getDataOffset(pageAddr, itemId, pageSize);
         final long nextLink = isFragmented(pageAddr, dataOff) ? getNextFragmentLink(pageAddr, dataOff) : 0;
@@ -932,6 +943,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         final int pageSize
     ) throws IgniteCheckedException {
         assert rowSize <= getFreeSpace(pageAddr) : "can't call addRow if not enough space for the whole row";
+        assertPageType(pageAddr);
 
         int fullEntrySize = getPageEntrySize(rowSize, SHOW_PAYLOAD_LEN | SHOW_ITEM);
 
@@ -962,6 +974,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         int pageSize
     ) throws IgniteCheckedException {
         assert payload.length <= getFreeSpace(pageAddr) : "can't call addRow if not enough space for the whole row";
+        assertPageType(pageAddr);
 
         int fullEntrySize = getPageEntrySize(payload.length, SHOW_PAYLOAD_LEN | SHOW_ITEM);
 
@@ -992,6 +1005,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         int dataOff,
         int pageSize
     ) {
+        assertPageType(pageAddr);
+
         if (!isEnoughSpace(entryFullSize, dataOff, directCnt, indirectCnt)) {
             dataOff = compactDataEntries(pageAddr, directCnt, pageSize);
 
@@ -1075,6 +1090,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         int rowSize,
         int pageSize
     ) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         return addRowFragment(pageMem, pageId, pageAddr, written, rowSize, row.link(), row, null, pageSize);
     }
 
@@ -1095,6 +1112,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         long lastLink,
         int pageSize
     ) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         addRowFragment(null, pageId, pageAddr, 0, 0, lastLink, null, payload, pageSize);
     }
 
@@ -1240,6 +1259,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
 
     /** {@inheritDoc} */
     @Override public void compactPage(ByteBuffer page, ByteBuffer out, int pageSize) {
+        assertPageType(page);
+
         // TODO May we compactDataEntries in-place and then copy compacted data to out?
         copyPage(page, out, pageSize);
 
@@ -1272,6 +1293,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         assert page.isDirect();
         assert page.position() == 0;
         assert page.limit() <= pageSize;
+        assertPageType(page);
 
         long pageAddr = bufferAddress(page);
 
@@ -1446,6 +1468,8 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         int dataOff,
         byte[] payload
     ) {
+        assertPageType(pageAddr);
+
         PageUtils.putShort(pageAddr, dataOff, (short)payload.length);
         dataOff += 2;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusIO.java
@@ -95,6 +95,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      * @param pageId Forward page ID.
      */
     public final void setForward(long pageAddr, long pageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, FORWARD_OFF, pageId);
 
         assert getForward(pageAddr) == pageId;
@@ -113,6 +115,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      * @param rmvId Remove ID.
      */
     public final void setRemoveId(long pageAddr, long rmvId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, REMOVE_ID_OFF, rmvId);
 
         assert getRemoveId(pageAddr) == rmvId;
@@ -135,6 +139,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      * @param cnt Count.
      */
     public final void setCount(long pageAddr, int cnt) {
+        assertPageType(pageAddr);
+
         assert cnt >= 0 : cnt;
 
         PageUtils.putShort(pageAddr, CNT_OFF, (short)cnt);
@@ -178,6 +184,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      */
     public final byte[] store(long pageAddr, int idx, L row, byte[] rowBytes, boolean needRowBytes)
         throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         int off = offset(idx);
 
         if (rowBytes == null) {
@@ -261,6 +269,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      */
     public byte[] insert(long pageAddr, int idx, L row, byte[] rowBytes, long rightId, boolean needRowBytes)
         throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         // Move right all the greater elements to make a free slot for a new row link.
@@ -288,6 +298,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
         int cnt,
         int pageSize
     ) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         initNewPage(fwdPageAddr, fwdId, pageSize);
 
         cnt -= mid;
@@ -308,6 +320,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      * @param fwdId New forward page ID.
      */
     public void splitExistingPage(long pageAddr, int mid, long fwdId) {
+        assertPageType(pageAddr);
+
         setCount(pageAddr, mid);
         setForward(pageAddr, fwdId);
     }
@@ -319,6 +333,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
      * @throws IgniteCheckedException If failed.
      */
     public void remove(long pageAddr, int idx, int cnt) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         cnt--;
 
         copyItems(pageAddr, pageAddr, idx + 1, idx, cnt - idx, false);
@@ -345,6 +361,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
         boolean emptyBranch,
         int pageSize
     ) throws IgniteCheckedException {
+        assertPageType(leftPageAddr);
+
         int prntCnt = prntIo.getCount(prntPageAddr);
         int leftCnt = getCount(leftPageAddr);
         int rightCnt = getCount(rightPageAddr);
@@ -425,6 +443,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
 
     /** {@inheritDoc} */
     @Override public void compactPage(ByteBuffer page, ByteBuffer out, int pageSize) {
+        assertPageType(page);
+
         copyPage(page, out, pageSize);
 
         long pageAddr = GridUnsafe.bufferAddress(out);
@@ -435,6 +455,8 @@ public abstract class BPlusIO<L> extends PageIO implements CompactablePageIO {
 
     /** {@inheritDoc} */
     @Override public void restorePage(ByteBuffer compactPage, int pageSize) {
+        assertPageType(compactPage);
+
         assert compactPage.isDirect();
         assert compactPage.position() == 0;
         assert compactPage.limit() <= pageSize;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusInnerIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusInnerIO.java
@@ -66,6 +66,8 @@ public abstract class BPlusInnerIO<L> extends BPlusIO<L> {
      * @param pageId Page ID.
      */
     public final void setLeft(long pageAddr, int idx, long pageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset0(idx, SHIFT_LEFT), pageId);
 
         assert pageId == getLeft(pageAddr, idx);
@@ -86,6 +88,8 @@ public abstract class BPlusInnerIO<L> extends BPlusIO<L> {
      * @param pageId Page ID.
      */
     private void setRight(long pageAddr, int idx, long pageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset0(idx, SHIFT_RIGHT), pageId);
 
         assert pageId == getRight(pageAddr, idx);
@@ -94,6 +98,8 @@ public abstract class BPlusInnerIO<L> extends BPlusIO<L> {
     /** {@inheritDoc} */
     @Override public final void copyItems(long srcPageAddr, long dstPageAddr, int srcIdx, int dstIdx, int cnt,
         boolean cpLeft) throws IgniteCheckedException {
+        assertPageType(dstPageAddr);
+
         assert srcIdx != dstIdx || srcPageAddr != dstPageAddr;
 
         cnt *= getItemSize() + 8; // From items to bytes.
@@ -137,6 +143,8 @@ public abstract class BPlusInnerIO<L> extends BPlusIO<L> {
         long rightId,
         boolean needRowBytes
     ) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         rowBytes = super.insert(pageAddr, idx, row, rowBytes, rightId, needRowBytes);
 
         // Setup reference to the right page on split.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusLeafIO.java
@@ -41,6 +41,7 @@ public abstract class BPlusLeafIO<L> extends BPlusIO<L> {
     @Override public final void copyItems(long srcPageAddr, long dstPageAddr, int srcIdx, int dstIdx, int cnt,
         boolean cpLeft) throws IgniteCheckedException {
         assert srcIdx != dstIdx || srcPageAddr != dstPageAddr;
+        assertPageType(dstPageAddr);
 
         PageHandler.copyMemory(srcPageAddr, offset(srcIdx), dstPageAddr, offset(dstIdx),
             cnt * getItemSize());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusMetaIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/BPlusMetaIO.java
@@ -102,6 +102,8 @@ public class BPlusMetaIO extends PageIO {
      * @param pageSize Page size.
      */
     public void initRoot(long pageAdrr, long rootId, int pageSize) {
+        assertPageType(pageAdrr);
+
         setLevelsCount(pageAdrr, 1, pageSize);
         setFirstPageId(pageAdrr, 0, rootId);
     }
@@ -184,6 +186,8 @@ public class BPlusMetaIO extends PageIO {
      * @param pageSize Page size.
      */
     public void addRoot(long pageAddr, long rootPageId, int pageSize) {
+        assertPageType(pageAddr);
+
         int lvl = getLevelsCount(pageAddr);
 
         setLevelsCount(pageAddr, lvl + 1, pageSize);
@@ -195,6 +199,8 @@ public class BPlusMetaIO extends PageIO {
      * @param pageSize Page size.
      */
     public void cutRoot(long pageAddr, int pageSize) {
+        assertPageType(pageAddr);
+
         int lvl = getRootLevel(pageAddr);
 
         setLevelsCount(pageAddr, lvl, pageSize); // Decrease tree height.
@@ -205,6 +211,8 @@ public class BPlusMetaIO extends PageIO {
      * @param size Offset size.
      */
     public void setInlineSize(long pageAddr, int size) {
+        assertPageType(pageAddr);
+
         if (getVersion() > 1)
             PageUtils.putShort(pageAddr, INLINE_SIZE_OFFSET, (short)size);
     }
@@ -269,6 +277,8 @@ public class BPlusMetaIO extends PageIO {
      * @param createdVer The version of the product that creates the page (b+tree).
      */
     public void initFlagsAndVersion(long pageAddr, long flags, IgniteProductVersion createdVer) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, FLAGS_OFFSET, flags);
 
         setCreatedVersion(pageAddr, createdVer);
@@ -280,6 +290,7 @@ public class BPlusMetaIO extends PageIO {
      */
     public void setCreatedVersion(long pageAddr, IgniteProductVersion curVer) {
         assert curVer != null;
+        assertPageType(pageAddr);
 
         PageUtils.putByte(pageAddr, CREATED_VER_OFFSET, curVer.major());
         PageUtils.putByte(pageAddr, CREATED_VER_OFFSET + 1, curVer.minor());
@@ -321,6 +332,7 @@ public class BPlusMetaIO extends PageIO {
      */
     public void setFlags(long pageAddr, boolean unwrappedPk, boolean inlineObjSupported) {
         assert supportFlags();
+        assertPageType(pageAddr);
 
         long flags = unwrappedPk ? FLAG_UNWRAPPED_PK : 0;
         flags |= inlineObjSupported ? FLAG_INLINE_OBJECT_SUPPORTED : 0;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/DataPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/DataPageIO.java
@@ -43,7 +43,7 @@ import static org.apache.ignite.internal.processors.cache.persistence.tree.io.Da
 public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
     /** */
     public static final int MVCC_INFO_SIZE = 40;
-    
+
     /** */
     public static final IOVersions<DataPageIO> VERSIONS = new IOVersions<>(
         new DataPageIO(1)
@@ -59,6 +59,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
     /** {@inheritDoc} */
     @Override protected void writeRowData(long pageAddr, int dataOff, int payloadSize, CacheDataRow row,
         boolean newRow) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         long addr = pageAddr + dataOff;
 
         int cacheIdSize = row.cacheId() != 0 ? 4 : 0;
@@ -114,6 +116,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
     /** {@inheritDoc} */
     @Override protected void writeFragmentData(CacheDataRow row, ByteBuffer buf, int rowOff,
         int payloadSize) throws IgniteCheckedException {
+        assertPageType(buf);
+
         final int keySize = row.key().valueBytesLength(null);
 
         final int valSize = row.value().valueBytesLength(null);
@@ -250,6 +254,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
      * @param txState Tx state hint.
      */
     public void updateNewVersion(long pageAddr, int dataOff, long mvccCrd, long mvccCntr, int mvccOpCntr, byte txState) {
+        assertPageType(pageAddr);
+
         long addr = pageAddr + dataOff;
 
         updateNewVersion(addr, mvccCrd, mvccCntr,
@@ -265,6 +271,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
      * @param mvccOpCntr Operation counter.
      */
     public void updateNewVersion(long pageAddr, int itemId, int pageSize, long mvccCrd, long mvccCntr, int mvccOpCntr) {
+        assertPageType(pageAddr);
+
         int dataOff = getDataOffset(pageAddr, itemId, pageSize);
 
         long addr = pageAddr + dataOff + (isFragmented(pageAddr, dataOff) ? 10 : 2);
@@ -279,6 +287,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
      * @param txState Tx state hint.
      */
     public void updateTxState(long pageAddr, int itemId, int pageSize, byte txState) {
+        assertPageType(pageAddr);
+
         int dataOff = getDataOffset(pageAddr, itemId, pageSize);
 
         long addr = pageAddr + dataOff + (isFragmented(pageAddr, dataOff) ? 10 : 2);
@@ -295,6 +305,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
      * @param txState Tx state hint.
      */
     public void updateNewTxState(long pageAddr, int itemId, int pageSize, byte txState) {
+        assertPageType(pageAddr);
+
         int dataOff = getDataOffset(pageAddr, itemId, pageSize);
 
         long addr = pageAddr + dataOff + (isFragmented(pageAddr, dataOff) ? 10 : 2);
@@ -367,6 +379,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
      * @param opCntr MVCC counter value.
      */
     public void rawMvccOperationCounter(long pageAddr, int dataOff, int opCntr) {
+        assertPageType(pageAddr);
+
         long addr = pageAddr + dataOff;
 
         PageUtils.putInt(addr, 16, opCntr);
@@ -428,6 +442,8 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
      * @param opCntr MVCC operation counter value.
      */
     public void rawNewMvccOperationCounter(long pageAddr, int dataOff, int opCntr) {
+        assertPageType(pageAddr);
+
         long addr = pageAddr + dataOff;
 
         // Skip xid_min.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/MarkerPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/MarkerPageIO.java
@@ -85,6 +85,8 @@ public class MarkerPageIO extends PageIO {
      * @param markerType Marker type.
      */
     public void setMarkerType(long pageAddr, int markerType) {
+        assertPageType(pageAddr);
+
         PageUtils.putInt(pageAddr, MARKER_TYPE_OFF, markerType);
     }
 
@@ -114,6 +116,8 @@ public class MarkerPageIO extends PageIO {
      * @param v Version.
      */
     public void setWalRecordSerializerVersion(long pageAddr, int v) {
+        assertPageType(pageAddr);
+
         PageUtils.putInt(pageAddr, WAL_RECORD_SERIALIZER_VERSION_OFF, v);
     }
 
@@ -142,6 +146,8 @@ public class MarkerPageIO extends PageIO {
      * @param v WAL records count.
      */
     public void setWalRecordsCnt(long pageAddr, int v) {
+        assertPageType(pageAddr);
+
         PageUtils.putInt(pageAddr, WAL_RECORDS_CNT_OFF, v);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PageIO.java
@@ -61,7 +61,7 @@ import org.apache.ignite.spi.encryption.EncryptionSpi;
  *    static methods (like {@code {@link #getPageId(long)}}) intentionally:
  *    this base format can not be changed between versions.
  *
- * 2. IO must correctly override {@link #initNewPage(long, long, int)} method and call super.
+ * 2. IO must correctly override {@link #initNewPage(long, long, int, PageMetrics)} method and call super.
  *    We have logic that relies on this behavior.
  *
  * 3. Page IO type ID constant must be declared in this class to have a list of all the
@@ -908,5 +908,23 @@ public abstract class PageIO {
         }
 
         return sb.toString();
+    }
+
+    /**
+     * Asserts that page type of the page stored at pageAddr matches page type of this PageIO.
+     *
+     * @param pageAddr address of a page to use for assertion
+     */
+    protected final void assertPageType(long pageAddr) {
+        assert getType(pageAddr) == getType() : "Expected type " + getType() + ", but got " + getType(pageAddr);
+    }
+
+    /**
+     * Asserts that page type of the page stored in the given buffer matches page type of this PageIO.
+     *
+     * @param buf   buffer where the page for assertion is stored
+     */
+    protected final void assertPageType(ByteBuffer buf) {
+        assert getType(buf) == getType() : "Expected type " + getType() + ", but got " + getType(buf);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PageMetaIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PageMetaIO.java
@@ -100,6 +100,8 @@ public class PageMetaIO extends PageIO {
      * @param treeRoot Tree root
      */
     public void setTreeRoot(long pageAddr, long treeRoot) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, TREE_ROOT_OFF, treeRoot);
     }
 
@@ -116,6 +118,8 @@ public class PageMetaIO extends PageIO {
      * @param pageId Root page ID.
      */
     public void setReuseListRoot(long pageAddr, long pageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, REUSE_LIST_ROOT_OFF, pageId);
     }
 
@@ -126,6 +130,8 @@ public class PageMetaIO extends PageIO {
      */
     @Deprecated
     public void setLastSuccessfulSnapshotId(long pageAddr, long lastSuccessfulSnapshotId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, LAST_SUCCESSFUL_SNAPSHOT_ID_OFF, lastSuccessfulSnapshotId);
     }
 
@@ -145,6 +151,8 @@ public class PageMetaIO extends PageIO {
      */
     @Deprecated
     public void setLastSuccessfulFullSnapshotId(long pageAddr, long lastSuccessfulFullSnapshotId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, LAST_SUCCESSFUL_FULL_SNAPSHOT_ID_OFF, lastSuccessfulFullSnapshotId);
     }
 
@@ -164,6 +172,8 @@ public class PageMetaIO extends PageIO {
      */
     @Deprecated
     public void setNextSnapshotTag(long pageAddr, long nextSnapshotTag) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, NEXT_SNAPSHOT_TAG_OFF, nextSnapshotTag);
     }
 
@@ -183,6 +193,8 @@ public class PageMetaIO extends PageIO {
      */
     @Deprecated
     public void setLastSuccessfulSnapshotTag(long pageAddr, long lastSuccessfulSnapshotTag) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, LAST_SUCCESSFUL_FULL_SNAPSHOT_TAG_OFF, lastSuccessfulSnapshotTag);
     }
 
@@ -202,6 +214,8 @@ public class PageMetaIO extends PageIO {
      * @param pageCnt Last allocated pages count to set
      */
     public void setLastAllocatedPageCount(final long pageAddr, final int pageCnt) {
+        assertPageType(pageAddr);
+
         PageUtils.putInt(pageAddr, LAST_PAGE_COUNT_OFF, pageCnt);
     }
 
@@ -229,6 +243,8 @@ public class PageMetaIO extends PageIO {
      * @param pageCnt Last page count.
      */
     public boolean setCandidatePageCount(long pageAddr, int pageCnt) {
+        assertPageType(pageAddr);
+
         if (getCandidatePageCount(pageAddr) == pageCnt)
             return false;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionCountersIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionCountersIO.java
@@ -101,6 +101,8 @@ public class PagePartitionCountersIO extends PageIO {
      * @param partMetaPageId Next counters page ID.
      */
     public void setNextCountersPageId(long pageAddr, long partMetaPageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, NEXT_COUNTERS_PAGE_OFF, partMetaPageId);
     }
 
@@ -113,6 +115,7 @@ public class PagePartitionCountersIO extends PageIO {
     public int writeCacheSizes(int pageSize, long pageAddr, byte[] cacheSizes, int itemsOff) {
         assert cacheSizes != null;
         assert cacheSizes.length % ITEM_SIZE == 0 : cacheSizes.length;
+        assertPageType(pageAddr);
 
         int cap = getCapacity(pageSize);
 
@@ -176,6 +179,8 @@ public class PagePartitionCountersIO extends PageIO {
      * @param last Last.
      */
     private void setLastFlag(long pageAddr, boolean last) {
+        assertPageType(pageAddr);
+
         PageUtils.putByte(pageAddr, LAST_FLAG_OFF, last ? LAST_FLAG : ~LAST_FLAG);
     }
 
@@ -193,6 +198,7 @@ public class PagePartitionCountersIO extends PageIO {
      */
     private void setCount(long pageAddr, int cnt) {
         assert cnt >= 0 && cnt <= Short.MAX_VALUE : cnt;
+        assertPageType(pageAddr);
 
         PageUtils.putShort(pageAddr, CNT_OFF, (short)cnt);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionMetaIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionMetaIO.java
@@ -82,6 +82,8 @@ public class PagePartitionMetaIO extends PageMetaIO {
      * @return {@code true} if value has changed as a result of this method's invocation.
      */
     public boolean setSize(long pageAddr, long size) {
+        assertPageType(pageAddr);
+
         if (getSize(pageAddr) == size)
             return false;
 
@@ -105,6 +107,8 @@ public class PagePartitionMetaIO extends PageMetaIO {
      * @return {@code true} if value has changed as a result of this method's invocation.
      */
     public boolean setUpdateCounter(long pageAddr, long cntr) {
+        assertPageType(pageAddr);
+
         if (getUpdateCounter(pageAddr) == cntr)
             return false;
 
@@ -128,6 +132,8 @@ public class PagePartitionMetaIO extends PageMetaIO {
      * @return {@code true} if value has changed as a result of this method's invocation.
      */
     public boolean setGlobalRemoveId(long pageAddr, long rmvId) {
+        assertPageType(pageAddr);
+
         if (getGlobalRemoveId(pageAddr) == rmvId)
             return false;
 
@@ -150,6 +156,8 @@ public class PagePartitionMetaIO extends PageMetaIO {
      * @return {@code true} if value has changed as a result of this method's invocation.
      */
     public boolean setPartitionState(long pageAddr, byte state) {
+        assertPageType(pageAddr);
+
         if (getPartitionState(pageAddr) == state)
             return false;
 
@@ -175,6 +183,8 @@ public class PagePartitionMetaIO extends PageMetaIO {
      * @param cntrsPageId New cache sizes page ID.
      */
     public void setCountersPageId(long pageAddr, long cntrsPageId) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, NEXT_PART_META_PAGE_OFF, cntrsPageId);
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionMetaIOV2.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PagePartitionMetaIOV2.java
@@ -58,6 +58,8 @@ public class PagePartitionMetaIOV2 extends PagePartitionMetaIO {
 
     /** {@inheritDoc} */
     @Override public void setPendingTreeRoot(long pageAddr, long listRoot) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, PENDING_TREE_ROOT_OFF, listRoot);
     }
 
@@ -73,6 +75,8 @@ public class PagePartitionMetaIOV2 extends PagePartitionMetaIO {
      * @param listRoot List root.
      */
     @Override public void setPartitionMetaStoreReuseListRoot(long pageAddr, long listRoot) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, PART_META_REUSE_LIST_ROOT_OFF, listRoot);
     }
 
@@ -91,6 +95,8 @@ public class PagePartitionMetaIOV2 extends PagePartitionMetaIO {
      * @return {@code true} if value has changed as a result of this method's invocation.
      */
     @Override public boolean setGapsLink(long pageAddr, long link) {
+        assertPageType(pageAddr);
+
         if (getGapsLink(pageAddr) == link)
             return false;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/SimpleDataPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/SimpleDataPageIO.java
@@ -54,6 +54,8 @@ public class SimpleDataPageIO extends AbstractDataPageIO<SimpleDataRow> {
         final int rowOff,
         final int payloadSize
     ) throws IgniteCheckedException {
+        assertPageType(buf);
+
         int written = writeSizeFragment(row, buf, rowOff, payloadSize);
 
         if (payloadSize == written)
@@ -103,6 +105,8 @@ public class SimpleDataPageIO extends AbstractDataPageIO<SimpleDataRow> {
         SimpleDataRow row,
         boolean newRow
     ) throws IgniteCheckedException {
+        assertPageType(pageAddr);
+
         long addr = pageAddr + dataOff;
 
         if (newRow)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIO.java
@@ -90,6 +90,8 @@ public class TrackingPageIO extends PageIO {
      * @return <code>-1</code> if everything is ok, otherwise last saved tag.
      */
     public long markChanged(ByteBuffer buf, long pageId, long nextSnapshotTag, long lastSuccessfulSnapshotTag, int pageSize) {
+        assertPageType(buf);
+
         long tag = validateSnapshotTag(buf, nextSnapshotTag, lastSuccessfulSnapshotTag, pageSize);
 
         int cntOfPage = countOfPageToTrack(pageSize);
@@ -265,6 +267,8 @@ public class TrackingPageIO extends PageIO {
      * @param buf Buffer.
      */
     public void resetCorruptFlag(ByteBuffer buf) {
+        assertPageType(buf);
+
         setLastSnasphotTag0(buf, getLastSnapshotTag(buf));
     }
 
@@ -274,6 +278,8 @@ public class TrackingPageIO extends PageIO {
      * @param addr Buffer.
      */
     public void resetCorruptFlag(long addr) {
+        assertPageType(addr);
+
         setLastSnasphotTag0(addr, getLastSnapshotTag(addr));
     }
 
@@ -290,6 +296,8 @@ public class TrackingPageIO extends PageIO {
      */
     public boolean wasChanged(ByteBuffer buf, long pageId, long curSnapshotTag, long lastSuccessfulSnapshotTag, int pageSize)
         throws TrackingPageIsCorruptedException {
+        assertPageType(buf);
+
         if (isCorrupted(buf))
             throw TrackingPageIsCorruptedException.INSTANCE;
 
@@ -339,10 +347,10 @@ public class TrackingPageIO extends PageIO {
     /**
      * @param snapshotTag Snapshot id.
      *
-     * @return true if snapshotTag is odd, otherwise - false.
+     * @return true if snapshotTag is even, otherwise - false.
      */
     private boolean useLeftHalf(long snapshotTag) {
-        return (snapshotTag & 0b1) == 0;
+        return (snapshotTag & 1) == 0;
     }
 
     /**
@@ -387,6 +395,8 @@ public class TrackingPageIO extends PageIO {
      */
     @Nullable public Long findNextChangedPage(ByteBuffer buf, long start, long curSnapshotTag,
         long lastSuccessfulSnapshotTag, int pageSize) throws TrackingPageIsCorruptedException {
+        assertPageType(buf);
+
         if (isCorrupted(buf))
             throw TrackingPageIsCorruptedException.INSTANCE;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractDataInnerIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractDataInnerIO.java
@@ -46,6 +46,7 @@ public abstract class AbstractDataInnerIO extends BPlusInnerIO<CacheSearchRow> i
     /** {@inheritDoc} */
     @Override public final void storeByOffset(long pageAddr, int off, CacheSearchRow row) {
         assert row.link() != 0;
+        assertPageType(pageAddr);
 
         PageUtils.putLong(pageAddr, off, row.link());
         off += 8;
@@ -111,6 +112,8 @@ public abstract class AbstractDataInnerIO extends BPlusInnerIO<CacheSearchRow> i
         long srcPageAddr,
         int srcIdx)
     {
+        assertPageType(dstPageAddr);
+
         RowLinkIO rowIo = ((RowLinkIO)srcIo);
 
         long link = rowIo.getLink(srcPageAddr, srcIdx);
@@ -164,6 +167,8 @@ public abstract class AbstractDataInnerIO extends BPlusInnerIO<CacheSearchRow> i
 
     /** {@inheritDoc} */
     @Override public void visit(long pageAddr, IgniteInClosure<CacheSearchRow> c) {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         for (int i = 0; i < cnt; i++)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractDataLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractDataLeafIO.java
@@ -44,6 +44,7 @@ public abstract class AbstractDataLeafIO extends BPlusLeafIO<CacheSearchRow> imp
     /** {@inheritDoc} */
     @Override public void storeByOffset(long pageAddr, int off, CacheSearchRow row) {
         assert row.link() != 0;
+        assertPageType(pageAddr);
 
         PageUtils.putLong(pageAddr, off, row.link());
         off += 8;
@@ -86,6 +87,8 @@ public abstract class AbstractDataLeafIO extends BPlusLeafIO<CacheSearchRow> imp
     /** {@inheritDoc} */
     @Override public void store(long dstPageAddr, int dstIdx, BPlusIO<CacheSearchRow> srcIo, long srcPageAddr,
         int srcIdx) {
+        assertPageType(dstPageAddr);
+
         RowLinkIO rowIo = (RowLinkIO) srcIo;
 
         long link = rowIo.getLink(srcPageAddr, srcIdx);
@@ -178,6 +181,8 @@ public abstract class AbstractDataLeafIO extends BPlusLeafIO<CacheSearchRow> imp
 
     /** {@inheritDoc} */
     @Override public void visit(long pageAddr, IgniteInClosure<CacheSearchRow> c) {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         for (int i = 0; i < cnt; i++)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractPendingEntryInnerIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractPendingEntryInnerIO.java
@@ -41,6 +41,7 @@ public abstract class AbstractPendingEntryInnerIO extends BPlusInnerIO<PendingRo
     @Override public void storeByOffset(long pageAddr, int off, PendingRow row) throws IgniteCheckedException {
         assert row.link != 0;
         assert row.expireTime != 0;
+        assertPageType(pageAddr);
 
         PageUtils.putLong(pageAddr, off, row.expireTime);
         PageUtils.putLong(pageAddr, off + 8, row.link);
@@ -58,6 +59,8 @@ public abstract class AbstractPendingEntryInnerIO extends BPlusInnerIO<PendingRo
         BPlusIO<PendingRow> srcIo,
         long srcPageAddr,
         int srcIdx) throws IgniteCheckedException {
+        assertPageType(dstPageAddr);
+
         int dstOff = offset(dstIdx);
 
         long link = ((PendingRowIO)srcIo).getLink(srcPageAddr, srcIdx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractPendingEntryLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/AbstractPendingEntryLeafIO.java
@@ -40,6 +40,7 @@ public abstract class AbstractPendingEntryLeafIO extends BPlusLeafIO<PendingRow>
     @Override public void storeByOffset(long pageAddr, int off, PendingRow row) throws IgniteCheckedException {
         assert row.link != 0;
         assert row.expireTime != 0;
+        assertPageType(pageAddr);
 
         PageUtils.putLong(pageAddr, off, row.expireTime);
         PageUtils.putLong(pageAddr, off + 8, row.link);
@@ -57,6 +58,8 @@ public abstract class AbstractPendingEntryLeafIO extends BPlusLeafIO<PendingRow>
         BPlusIO<PendingRow> srcIo,
         long srcPageAddr,
         int srcIdx) throws IgniteCheckedException {
+        assertPageType(dstPageAddr);
+
         int dstOff = offset(dstIdx);
 
         long link = ((PendingRowIO)srcIo).getLink(srcPageAddr, srcIdx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/mvcc/data/MvccCacheIdAwareDataLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/mvcc/data/MvccCacheIdAwareDataLeafIO.java
@@ -78,11 +78,15 @@ public final class MvccCacheIdAwareDataLeafIO extends AbstractDataLeafIO {
 
     /** {@inheritDoc} */
     @Override public void setMvccLockCoordinatorVersion(long pageAddr, int idx, long lockCrd) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset(idx) + 36, lockCrd);
     }
 
     /** {@inheritDoc} */
     @Override public void setMvccLockCounter(long pageAddr, int idx, long lockCntr) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset(idx) + 44, lockCntr);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/mvcc/data/MvccDataInnerIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/mvcc/data/MvccDataInnerIO.java
@@ -40,6 +40,8 @@ public final class MvccDataInnerIO extends AbstractDataInnerIO {
 
     /** {@inheritDoc} */
     @Override public void visit(long pageAddr, IgniteInClosure<CacheSearchRow> c) {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         for (int i = 0; i < cnt; i++)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/mvcc/data/MvccDataLeafIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/tree/mvcc/data/MvccDataLeafIO.java
@@ -40,6 +40,8 @@ public final class MvccDataLeafIO extends AbstractDataLeafIO {
 
     /** {@inheritDoc} */
     @Override public void visit(long pageAddr, IgniteInClosure<CacheSearchRow> c) {
+        assertPageType(pageAddr);
+
         int cnt = getCount(pageAddr);
 
         for (int i = 0; i < cnt; i++)
@@ -78,11 +80,15 @@ public final class MvccDataLeafIO extends AbstractDataLeafIO {
 
     /** {@inheritDoc} */
     @Override public void setMvccLockCoordinatorVersion(long pageAddr, int idx, long lockCrd) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset(idx) + 32, lockCrd);
     }
 
     /** {@inheritDoc} */
     @Override public void setMvccLockCounter(long pageAddr, int idx, long lockCntr) {
+        assertPageType(pageAddr);
+
         PageUtils.putLong(pageAddr, offset(idx) + 40, lockCntr);
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIOTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/TrackingPageIOTest.java
@@ -70,6 +70,8 @@ public class TrackingPageIOTest {
 
         buf.order(ByteOrder.nativeOrder());
 
+        PageIO.setType(GridUnsafe.bufferAddress(buf), PageIO.T_PAGE_UPDATE_TRACKING);
+
         return buf;
     }
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2ExtrasInnerIO.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2ExtrasInnerIO.java
@@ -63,7 +63,6 @@ public abstract class AbstractH2ExtrasInnerIO extends BPlusInnerIO<H2Row> implem
      * @param mvccEnabled Mvcc flag.
      * @return IOVersions for given payload.
      */
-    @SuppressWarnings("unchecked")
     public static IOVersions<? extends BPlusInnerIO<H2Row>> getVersions(int payload, boolean mvccEnabled) {
         assert payload >= 0 && payload <= PageIO.MAX_PAYLOAD_SIZE;
 
@@ -98,6 +97,8 @@ public abstract class AbstractH2ExtrasInnerIO extends BPlusInnerIO<H2Row> implem
     /** {@inheritDoc} */
     @SuppressWarnings("ForLoopReplaceableByForEach")
     @Override public final void storeByOffset(long pageAddr, int off, H2Row row) {
+        assertPageType(pageAddr);
+
         H2CacheRow row0 = (H2CacheRow)row;
 
         assert row0.link() != 0 : row0;
@@ -142,6 +143,8 @@ public abstract class AbstractH2ExtrasInnerIO extends BPlusInnerIO<H2Row> implem
 
     /** {@inheritDoc} */
     @Override public final void store(long dstPageAddr, int dstIdx, BPlusIO<H2Row> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         int srcOff = srcIo.offset(srcIdx);
 
         byte[] payload = PageUtils.getBytes(srcPageAddr, srcOff, payloadSize);

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2ExtrasLeafIO.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2ExtrasLeafIO.java
@@ -97,6 +97,8 @@ public abstract class AbstractH2ExtrasLeafIO extends BPlusLeafIO<H2Row> implemen
     /** {@inheritDoc} */
     @SuppressWarnings("ForLoopReplaceableByForEach")
     @Override public final void storeByOffset(long pageAddr, int off, H2Row row) {
+        assertPageType(pageAddr);
+
         H2CacheRow row0 = (H2CacheRow)row;
 
         assert row0.link() != 0;
@@ -123,6 +125,8 @@ public abstract class AbstractH2ExtrasLeafIO extends BPlusLeafIO<H2Row> implemen
 
     /** {@inheritDoc} */
     @Override public final void store(long dstPageAddr, int dstIdx, BPlusIO<H2Row> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         int srcOff = srcIo.offset(srcIdx);
 
         byte[] payload = PageUtils.getBytes(srcPageAddr, srcOff, payloadSize);

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2InnerIO.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2InnerIO.java
@@ -40,6 +40,8 @@ public abstract class AbstractH2InnerIO extends BPlusInnerIO<H2Row> implements H
 
     /** {@inheritDoc} */
     @Override public void storeByOffset(long pageAddr, int off, H2Row row) {
+        assertPageType(pageAddr);
+
         H2CacheRow row0 = (H2CacheRow)row;
 
         H2IOUtils.storeRow(row0, pageAddr, off, storeMvccInfo());
@@ -63,6 +65,8 @@ public abstract class AbstractH2InnerIO extends BPlusInnerIO<H2Row> implements H
 
     /** {@inheritDoc} */
     @Override public void store(long dstPageAddr, int dstIdx, BPlusIO<H2Row> srcIo, long srcPageAddr, int srcIdx) {
+        assertPageType(dstPageAddr);
+
         H2IOUtils.store(dstPageAddr, offset(dstIdx), srcIo, srcPageAddr, srcIdx, storeMvccInfo());
     }
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2LeafIO.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/database/io/AbstractH2LeafIO.java
@@ -40,6 +40,8 @@ public abstract class AbstractH2LeafIO extends BPlusLeafIO<H2Row> implements H2R
 
     /** {@inheritDoc} */
     @Override public final void storeByOffset(long pageAddr, int off, H2Row row) {
+        assertPageType(pageAddr);
+
         H2CacheRow row0 = (H2CacheRow)row;
 
         H2IOUtils.storeRow(row0, pageAddr, off, storeMvccInfo());
@@ -48,6 +50,7 @@ public abstract class AbstractH2LeafIO extends BPlusLeafIO<H2Row> implements H2R
     /** {@inheritDoc} */
     @Override public final void store(long dstPageAddr, int dstIdx, BPlusIO<H2Row> srcIo, long srcPageAddr, int srcIdx) {
         assert srcIo == this;
+        assertPageType(dstPageAddr);
 
         H2IOUtils.store(dstPageAddr, offset(dstIdx), srcIo, srcPageAddr, srcIdx, storeMvccInfo());
     }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/IgniteWalRecoveryTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/IgniteWalRecoveryTest.java
@@ -1530,7 +1530,8 @@ public class IgniteWalRecoveryTest extends GridCommonAbstractTest {
                             int realPageSize = data.length;
 
                             pageIO.compactPage(GridUnsafe.wrapPointer(bufPtr, realPageSize), buf, realPageSize);
-                            pageIO.compactPage(ByteBuffer.wrap(data), bufWal, realPageSize);
+                            pageIO.compactPage(ByteBuffer.wrap(data).order(ByteOrder.nativeOrder()),
+                                bufWal, realPageSize);
 
                             bufPtr = GridUnsafe.bufferAddress(buf);
                             data = new byte[bufWal.limit()];


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-34473

Page type is asserted on page modifications as this allows to catch errors early and the performance testing did not show any noticeable decline in throughput (even with -ea).

Cherry-picked from dfaa401f7a6b13b8d1205850f128055ee96222e5.