### PR TITLE
GG-34574 [GG-34556] Update jackson-databind version to bypass VULNDBD-275302

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
         <hamcrest.version>2.2</hamcrest.version>
         <httpclient.version>4.5.13</httpclient.version>
         <httpcore.version>4.4.3</httpcore.version>
-        <jackson.version>2.11.4</jackson.version>
+        <jackson.version>2.12.6</jackson.version>
         <jackson1.version>1.9.13</jackson1.version>
         <jaxb.api.version>2.1</jaxb.api.version>
         <jaxb.impl.version>2.1.14</jaxb.impl.version>


### PR DESCRIPTION
https://github.com/FasterXML/jackson-databind/issues/3328

Also update log4j to 2.17.1 to pass OWASP checks