### PR TITLE
GG-33675 Speed-based throttling hasn't managed to protect the checkpoint buffer of a node (#2187)

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointPagesWriter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointPagesWriter.java
@@ -205,7 +205,7 @@ public class CheckpointPagesWriter implements Runnable {
             pageMem.checkpointWritePage(fullId, tmpWriteBuf, pageStoreWriter, tracker);
 
             if (throttlingEnabled) {
-                while (pageMem.shouldThrottle()) {
+                while (pageMem.isCpBufferOverflowThresholdExceeded()) {
                     FullPageId cpPageId = pageMem.pullPageFromCpBuffer();
 
                     if (cpPageId.equals(FullPageId.NULL_PAGE))

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/CheckpointBufferOverflowWatchdog.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/CheckpointBufferOverflowWatchdog.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+import static org.apache.ignite.internal.processors.cache.persistence.pagemem.PagesWriteThrottlePolicy.CP_BUF_FILL_THRESHOLD;
+
+/**
+ * Logic used to determine whether Checkpoint Buffer is in danger zone and writer threads should be throttled.
+ */
+class CheckpointBufferOverflowWatchdog {
+    /** Page memory. */
+    private final PageMemoryImpl pageMemory;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param pageMemory page memory to use
+     */
+    CheckpointBufferOverflowWatchdog(PageMemoryImpl pageMemory) {
+        this.pageMemory = pageMemory;
+    }
+
+    /**
+     * Returns true if Checkpoint Buffer is in danger zone (more than
+     * {@link PagesWriteThrottlePolicy#CP_BUF_FILL_THRESHOLD} of the buffer is filled) and, hence, writer threads need
+     * to be throttled.
+     *
+     * @return {@code true} iff Checkpoint Buffer is in danger zone
+     */
+    boolean isInDangerZone() {
+        int checkpointBufLimit = (int)(pageMemory.checkpointBufferPagesSize() * CP_BUF_FILL_THRESHOLD);
+
+        return pageMemory.checkpointBufferPagesCount() > checkpointBufLimit;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ExponentialBackoff.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ExponentialBackoff.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Implements exponential backoff logic. Contains a counter and increments it on each {@link #nextDuration()}.
+ * May be reset using {@link #reset()}.
+ */
+class ExponentialBackoff {
+    /**
+     * Starting backoff duration.
+     */
+    private final long startingBackoffNanos;
+
+    /**
+     * Backoff ratio. Each next duration will be this times longer.
+     */
+    private final double backoffRatio;
+
+    /**
+     * Exponential backoff counter.
+     */
+    private final AtomicInteger exponentialBackoffCounter = new AtomicInteger(0);
+
+    /**
+     * Constructs a new instance with the given parameters.
+     *
+     * @param startingBackoffNanos duration of first backoff in nanoseconds
+     * @param backoffRatio         each next duration will be this times longer
+     */
+    public ExponentialBackoff(long startingBackoffNanos, double backoffRatio) {
+        this.startingBackoffNanos = startingBackoffNanos;
+        this.backoffRatio = backoffRatio;
+    }
+
+    /**
+     * Returns next backoff duration (in nanoseconds). As a side effect, increments the backoff counter so that
+     * next call will return a longer duration.
+     *
+     * @return next backoff duration in nanoseconds
+     */
+    public long nextDuration() {
+        int exponent = exponentialBackoffCounter.getAndIncrement();
+        return (long) (startingBackoffNanos * Math.pow(backoffRatio, exponent));
+    }
+
+    /**
+     * Resets the exponential backoff counter so that next call to {@link #nextDuration()}
+     * will return {@link #startingBackoffNanos}.
+     *
+     * @return {@code true} iff this backoff was not already in a reset state
+     */
+    public boolean reset() {
+        int oldValue = exponentialBackoffCounter.getAndSet(0);
+        return oldValue != 0;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ExponentialBackoffThrottlingStrategy.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ExponentialBackoffThrottlingStrategy.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+/**
+ * Logic used to protect memory (mainly, Checkpoint Buffer) from exhaustion using exponential backoff.
+ */
+class ExponentialBackoffThrottlingStrategy {
+    /**
+     * Starting throttle time. Limits write speed to 1000 MB/s.
+     */
+    private static final long STARTING_THROTTLE_NANOS = 4000;
+
+    /**
+     * Backoff ratio. Each next park will be this times longer.
+     */
+    private static final double BACKOFF_RATIO = 1.05;
+
+    /**
+     * Exponential backoff used to throttle threads.
+     */
+    private final ExponentialBackoff backoff = new ExponentialBackoff(STARTING_THROTTLE_NANOS, BACKOFF_RATIO);
+
+    /**
+     * Computes next duration (in nanos) to throttle a thread to protect Checkpoint Buffer.
+     *
+     * @return park time in nanos
+     */
+    long protectionParkTime() {
+        return backoff.nextDuration();
+    }
+
+    /**
+     * Resets the backoff counter. Invoked when no throttling is needed anymore.
+     *
+     * @return {@code true} iff the backoff was not already in a reset state
+     */
+    boolean resetBackoff() {
+        return backoff.reset();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryEx.java
@@ -118,7 +118,8 @@ public interface PageMemoryEx extends PageMemory {
      * @throws IgniteException If checkpoint has been already started and was not finished.
      * @param allowToReplace The sign which allows to replace pages from a checkpoint by page replacer.
      */
-    public GridMultiCollectionWrapper<FullPageId> beginCheckpoint(IgniteInternalFuture allowToReplace) throws IgniteException;
+    public GridMultiCollectionWrapper<FullPageId> beginCheckpoint(IgniteInternalFuture allowToReplace)
+            throws IgniteException;
 
     /**
      * Finishes checkpoint operation.
@@ -177,9 +178,12 @@ public interface PageMemoryEx extends PageMemory {
     public FullPageId pullPageFromCpBuffer();
 
     /**
-     * Calculates throttling condition.
+     * Checks if the Checkpoint Buffer is currently close to exhaustion.
+     *
+     * @return {@code true} if measures like throttling to protect Checkpoint Buffer should be applied,
+     * and {@code false} otherwise.
      */
-    public boolean shouldThrottle();
+    public boolean isCpBufferOverflowThresholdExceeded();
 
     /**
      * Total pages can be placed to memory.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImpl.java
@@ -931,7 +931,7 @@ public class PageMemoryImpl implements PageMemoryEx {
         int resCntr = checkpointPool.releaseFreePage(tmpBufPtr);
 
         if (resCntr == checkpointBufferPagesSize() / 2 && writeThrottle != null)
-            writeThrottle.tryWakeupThrottledThreads();
+            writeThrottle.wakeupThrottledThreads();
     }
 
     /**
@@ -1891,8 +1891,8 @@ public class PageMemoryImpl implements PageMemoryEx {
     }
 
     /** {@inheritDoc} */
-    @Override public boolean shouldThrottle() {
-        return writeThrottle.shouldThrottle();
+    @Override public boolean isCpBufferOverflowThresholdExceeded() {
+        return writeThrottle.isCpBufferOverflowThresholdExceeded();
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteSpeedBasedThrottle.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteSpeedBasedThrottle.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.processors.cache.persistence.CheckpointLockStateChecker;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointProgress;
@@ -29,62 +30,26 @@ import org.apache.ignite.lang.IgniteOutClosure;
 /**
  * Throttles threads that generate dirty pages during ongoing checkpoint.
  * Designed to avoid zero dropdowns that can happen if checkpoint buffer is overflowed.
- * Uses average checkpoint write speed and moment speed of marking pages as dirty.<br>
+ * When the page in question is not included in the current checkpoint and Checkpoint Buffer is filled over 2/3,
+ * uses exponentially growing sleep time to throttle.
+ * Otherwise, uses average checkpoint write speed and instant speed of marking pages as dirty.<br>
  *
- * See also: <a href="https://github.com/apache/ignite/tree/master/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem#speed-based-throttling">Speed-based throttling description</a>.
+ * @see <a href="https://github.com/apache/ignite/tree/master/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem#speed-based-throttling">Speed-based throttling description</a>
  */
 public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
-    /** Maximum dirty pages in region. */
-    private static final double MAX_DIRTY_PAGES = 0.75;
+    /**
+     * Throttling 'duration' used to signal that no throttling is needed, and no certain side-effects are allowed
+     * (like stats collection).
+     */
+    static final long NO_THROTTLING_MARKER = Long.MIN_VALUE;
 
     /** Page memory. */
     private final PageMemoryImpl pageMemory;
 
-    /** Database manager. */
+    /** Checkpoint progress provider. */
     private final IgniteOutClosure<CheckpointProgress> cpProgress;
 
-    /** Starting throttle time. Limits write speed to 1000 MB/s. */
-    private static final long STARTING_THROTTLE_NANOS = 4000;
-
-    /** Backoff ratio. Each next park will be this times longer. */
-    private static final double BACKOFF_RATIO = 1.05;
-
-    /** Percent of dirty pages which will not cause throttling. */
-    private static final double MIN_RATIO_NO_THROTTLE = 0.03;
-
-    /** Exponential backoff counter. */
-    private final AtomicInteger exponentialBackoffCntr = new AtomicInteger(0);
-
-    /** Counter of written pages from checkpoint. Value is saved here for detecting checkpoint start. */
-    private final AtomicInteger lastObservedWritten = new AtomicInteger(0);
-
-    /**
-     * Dirty pages ratio was observed at checkpoint start (here start is moment when first page was actually saved to
-     * store). This ratio is excluded from throttling.
-     */
-    private volatile double initDirtyRatioAtCpBegin = MIN_RATIO_NO_THROTTLE;
-
-    /**
-     * Target (maximum) dirty pages ratio, after which throttling will start using
-     * {@link #getParkTime(double, long, int, int, long, long)}.
-     */
-    private volatile double targetDirtyRatio;
-
-    /**
-     * Current dirty pages ratio (percent of dirty pages in most used segment), negative value means no cp is running.
-     */
-    private volatile double currDirtyRatio;
-
-    /** Speed average checkpoint write speed. Current and 3 past checkpoints used. Pages/second. */
-    private final IntervalBasedMeasurement speedCpWrite = new IntervalBasedMeasurement();
-
-    /** Last estimated speed for marking all clear pages as dirty till the end of checkpoint. */
-    private volatile long speedForMarkAll;
-
-    /** Threads set. Contains identifiers of all threads which were marking pages for current checkpoint. */
-    private final GridConcurrentHashSet<Long> threadIds = new GridConcurrentHashSet<>();
-
-    /** Threads set. Contains threads which is currently parked because of throttling. */
+    /** Threads set. Contains threads which are currently parked because of throttling. */
     private final GridConcurrentHashSet<Thread> parkedThreads = new GridConcurrentHashSet<>();
 
     /**
@@ -93,25 +58,32 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
      * {@link IntervalBasedMeasurement#getSpeedOpsPerSec(long)} returns pages marked/second.
      * {@link IntervalBasedMeasurement#getAverage()} returns average throttle time.
      * */
-    private final IntervalBasedMeasurement speedMarkAndAvgParkTime = new IntervalBasedMeasurement(250, 3);
-
-    /** Total pages which is possible to store in page memory. */
-    private long totalPages;
+    private final IntervalBasedMeasurement markSpeedAndAvgParkTime = new IntervalBasedMeasurement(250, 3);
 
     /** Checkpoint lock state provider. */
-    private CheckpointLockStateChecker cpLockStateChecker;
+    private final CheckpointLockStateChecker cpLockStateChecker;
 
     /** Logger. */
-    private IgniteLogger log;
+    private final IgniteLogger log;
 
     /** Previous warning time, nanos. */
-    private AtomicLong prevWarnTime = new AtomicLong();
+    private final AtomicLong prevWarnTime = new AtomicLong();
 
     /** Warning min delay nanoseconds. */
     private static final long WARN_MIN_DELAY_NS = TimeUnit.SECONDS.toNanos(10);
 
     /** Warning threshold: minimal level of pressure that causes warning messages to log. */
     static final double WARN_THRESHOLD = 0.2;
+
+    /** Checkpoint buffer protection logic. */
+    private final ExponentialBackoffThrottlingStrategy cpBufferProtector
+        = new ExponentialBackoffThrottlingStrategy();
+
+    /** Clean pages protection logic. */
+    private final SpeedBasedMemoryConsumptionThrottlingStrategy cleanPagesProtector;
+
+    /** Checkpoint Buffer-related logic used to keep it safe. */
+    private final CheckpointBufferOverflowWatchdog cpBufferWatchdog;
 
     /**
      * @param pageMemory Page memory.
@@ -127,110 +99,44 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
     ) {
         this.pageMemory = pageMemory;
         this.cpProgress = cpProgress;
-        totalPages = pageMemory.totalPages();
-        this.cpLockStateChecker = stateChecker;
+        cpLockStateChecker = stateChecker;
         this.log = log;
+
+        cleanPagesProtector = new SpeedBasedMemoryConsumptionThrottlingStrategy(pageMemory, cpProgress,
+                markSpeedAndAvgParkTime);
+        cpBufferWatchdog = new CheckpointBufferOverflowWatchdog(pageMemory);
     }
 
     /** {@inheritDoc} */
     @Override public void onMarkDirty(boolean isPageInCheckpoint) {
         assert cpLockStateChecker.checkpointLockIsHeldByThread();
 
-        CheckpointProgress progress = cpProgress.apply();
-
-        AtomicInteger writtenPagesCntr = progress == null ? null : progress.writtenPagesCounter();
-
-        if (writtenPagesCntr == null) {
-            speedForMarkAll = 0;
-            targetDirtyRatio = -1;
-            currDirtyRatio = -1;
-
-            return; // Don't throttle if checkpoint is not running.
-        }
-
-        int cpWrittenPages = writtenPagesCntr.get();
-
-        long fullyCompletedPages = (cpWrittenPages + cpSyncedPages()) / 2; // written & sync'ed
-
         long curNanoTime = System.nanoTime();
+        long throttleParkTimeNs = computeThrottlingParkTime(isPageInCheckpoint, curNanoTime);
 
-        speedCpWrite.setCounter(fullyCompletedPages, curNanoTime);
-
-        long markDirtySpeed = speedMarkAndAvgParkTime.getSpeedOpsPerSec(curNanoTime);
-
-        long curCpWriteSpeed = speedCpWrite.getSpeedOpsPerSec(curNanoTime);
-
-        threadIds.add(Thread.currentThread().getId());
-
-        ThrottleMode level = ThrottleMode.NO; //should apply delay (throttling) for current page modification
-
-        if (isPageInCheckpoint) {
-            int checkpointBufLimit = pageMemory.checkpointBufferPagesSize() * 2 / 3;
-
-            if (pageMemory.checkpointBufferPagesCount() > checkpointBufLimit)
-                level = ThrottleMode.EXPONENTIAL;
-        }
-
-        long throttleParkTimeNs = 0;
-
-        if (level == ThrottleMode.NO) {
-            int nThreads = threadIds.size();
-
-            int cpTotalPages = cpTotalPages();
-
-            if (cpTotalPages == 0) {
-                boolean throttleByCpSpeed = curCpWriteSpeed > 0 && markDirtySpeed > curCpWriteSpeed;
-
-                if (throttleByCpSpeed) {
-                    throttleParkTimeNs = calcDelayTime(curCpWriteSpeed, nThreads, 1);
-
-                    level = ThrottleMode.LIMITED;
-                }
-            }
-            else {
-                double dirtyPagesRatio = pageMemory.getDirtyPagesRatio();
-
-                currDirtyRatio = dirtyPagesRatio;
-
-                detectCpPagesWriteStart(cpWrittenPages, dirtyPagesRatio);
-
-                if (dirtyPagesRatio >= MAX_DIRTY_PAGES)
-                    level = ThrottleMode.NO; // too late to throttle, will wait on safe to update instead.
-                else {
-                    int notEvictedPagesTotal = cpTotalPages - cpEvictedPages();
-
-                    throttleParkTimeNs = getParkTime(dirtyPagesRatio,
-                        fullyCompletedPages,
-                        notEvictedPagesTotal < 0 ? 0 : notEvictedPagesTotal,
-                        nThreads,
-                        markDirtySpeed,
-                        curCpWriteSpeed);
-
-                    level = throttleParkTimeNs == 0 ? ThrottleMode.NO : ThrottleMode.LIMITED;
-                }
-            }
-        }
-
-        if (level == ThrottleMode.EXPONENTIAL) {
-            int exponent = exponentialBackoffCntr.getAndIncrement();
-
-            throttleParkTimeNs = (long)(STARTING_THROTTLE_NANOS * Math.pow(BACKOFF_RATIO, exponent));
-        }
-        else {
-            if (isPageInCheckpoint)
-                exponentialBackoffCntr.set(0);
-
-            if (level == ThrottleMode.NO)
-                throttleParkTimeNs = 0;
-        }
-
-        if (throttleParkTimeNs > 0) {
-            recurrentLogIfNeed();
-
+        if (throttleParkTimeNs == NO_THROTTLING_MARKER)
+            return;
+        else if (throttleParkTimeNs > 0) {
+            recurrentLogIfNeeded();
             doPark(throttleParkTimeNs);
         }
 
-        speedMarkAndAvgParkTime.addMeasurementForAverageCalculation(throttleParkTimeNs);
+//        pageMemory.metrics().addThrottlingTime(U.nanosToMillis(System.nanoTime() - curNanoTime));
+        markSpeedAndAvgParkTime.addMeasurementForAverageCalculation(throttleParkTimeNs);
+    }
+
+    /***/
+    private long computeThrottlingParkTime(boolean isPageInCheckpoint, long curNanoTime) {
+        if (isPageInCheckpoint && isCpBufferOverflowThresholdExceeded())
+            return cpBufferProtector.protectionParkTime();
+        else {
+            if (isPageInCheckpoint) {
+                // The fact that we are here means that we checked whether CP Buffer is in danger zone and found that
+                // it is ok, so its protector may relax, hence we reset it.
+                cpBufferProtector.resetBackoff();
+            }
+            return cleanPagesProtector.protectionParkTime(curNanoTime);
+        }
     }
 
     /**
@@ -264,34 +170,9 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
     }
 
     /**
-     * @return Number of pages in current checkpoint.
-     */
-    private int cpTotalPages() {
-        return cpProgress.apply().currentCheckpointPagesCount();
-    }
-
-    /**
-     * @return  Counter for fsynced checkpoint pages.
-     */
-    private int cpSyncedPages() {
-        AtomicInteger syncedPagesCntr = cpProgress.apply().syncedPagesCounter();
-
-        return syncedPagesCntr == null ? 0 : syncedPagesCntr.get();
-    }
-
-    /**
-     * @return number of evicted pages.
-     */
-    private int cpEvictedPages() {
-        AtomicInteger evictedPagesCntr = cpProgress.apply().evictedPagesCounter();
-
-        return evictedPagesCntr == null ? 0 : evictedPagesCntr.get();
-    }
-
-    /**
      * Prints warning to log if throttling is occurred and requires markable amount of time.
      */
-    private void recurrentLogIfNeed() {
+    private void recurrentLogIfNeeded() {
         long prevWarningNs = prevWarnTime.get();
         long curNs = System.nanoTime();
 
@@ -309,7 +190,8 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
                     "pages: (total=%d, evicted=%d, written=%d, synced=%d, cpBufUsed=%d, cpBufTotal=%d)]",
                 weight, getMarkDirtySpeed(), getCpWriteSpeed(),
                 getLastEstimatedSpeedForMarkAll(), getCurrDirtyRatio(), getTargetDirtyRatio(), throttleParkTime(),
-                cpTotalPages(), cpEvictedPages(), cpWrittenPages(), cpSyncedPages(),
+                cleanPagesProtector.cpTotalPages(), cleanPagesProtector.cpEvictedPages(), cpWrittenPages(),
+                cleanPagesProtector.cpSyncedPages(),
                 pageMemory.checkpointBufferPagesCount(), pageMemory.checkpointBufferPagesSize());
 
             log.info(msg);
@@ -317,6 +199,8 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
     }
 
     /**
+     * This is only used in tests.
+     *
      * @param dirtyPagesRatio actual percent of dirty pages.
      * @param fullyCompletedPages written & fsynced pages count.
      * @param cpTotalPages total checkpoint scope.
@@ -325,157 +209,33 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
      * @param curCpWriteSpeed average checkpoint write speed, pages/sec.
      * @return time in nanoseconds to part or 0 if throttling is not required.
      */
-    long getParkTime(
-        double dirtyPagesRatio,
-        long fullyCompletedPages,
-        int cpTotalPages,
-        int nThreads,
-        long markDirtySpeed,
-        long curCpWriteSpeed) {
-
-        long speedForMarkAll = calcSpeedToMarkAllSpaceTillEndOfCp(dirtyPagesRatio,
-            fullyCompletedPages,
-            curCpWriteSpeed,
-            cpTotalPages);
-
-        double targetDirtyRatio = calcTargetDirtyRatio(fullyCompletedPages, cpTotalPages);
-
-        this.speedForMarkAll = speedForMarkAll; //publish for metrics
-        this.targetDirtyRatio = targetDirtyRatio; //publish for metrics
-
-        boolean lowSpaceLeft = dirtyPagesRatio > targetDirtyRatio && (dirtyPagesRatio + 0.05 > MAX_DIRTY_PAGES);
-        int slowdown = lowSpaceLeft ? 3 : 1;
-
-        double multiplierForSpeedForMarkAll = lowSpaceLeft
-            ? 0.8
-            : 1.0;
-
-        boolean markingTooFast = speedForMarkAll > 0 && markDirtySpeed > multiplierForSpeedForMarkAll * speedForMarkAll;
-        boolean throttleBySizeAndMarkSpeed = dirtyPagesRatio > targetDirtyRatio && markingTooFast;
-
-        //for case of speedForMarkAll >> markDirtySpeed, allow write little bit faster than CP average
-        double allowWriteFasterThanCp = (markDirtySpeed > 0 && speedForMarkAll > markDirtySpeed)
-            ? (0.1 * speedForMarkAll / markDirtySpeed)
-            : (dirtyPagesRatio > targetDirtyRatio ? 0.0 : 0.1);
-
-        double fasterThanCpWriteSpeed = lowSpaceLeft
-            ? 1.0
-            : 1.0 + allowWriteFasterThanCp;
-        boolean throttleByCpSpeed = curCpWriteSpeed > 0 && markDirtySpeed > (fasterThanCpWriteSpeed * curCpWriteSpeed);
-
-        long delayByCpWrite;
-        if (throttleByCpSpeed) {
-            long nanosecPerDirtyPage = TimeUnit.SECONDS.toNanos(1) * nThreads / (markDirtySpeed);
-
-            delayByCpWrite = calcDelayTime(curCpWriteSpeed, nThreads, slowdown) - nanosecPerDirtyPage;
-        }
-        else
-            delayByCpWrite = 0;
-
-        long delayByMarkAllWrite = throttleBySizeAndMarkSpeed ? calcDelayTime(speedForMarkAll, nThreads, slowdown) : 0;
-        return Math.max(delayByCpWrite, delayByMarkAllWrite);
-    }
-
-    /**
-     * @param dirtyPagesRatio current percent of dirty pages.
-     * @param fullyCompletedPages count of written and sync'ed pages
-     * @param curCpWriteSpeed pages/second checkpoint write speed. 0 speed means 'no data'.
-     * @param cpTotalPages total pages in checkpoint.
-     * @return pages/second to mark to mark all clean pages as dirty till the end of checkpoint. 0 speed means 'no
-     * data'.
-     */
-    private long calcSpeedToMarkAllSpaceTillEndOfCp(double dirtyPagesRatio,
-        long fullyCompletedPages,
-        long curCpWriteSpeed,
-        int cpTotalPages) {
-
-        if (curCpWriteSpeed == 0)
-            return 0;
-
-        if (cpTotalPages <= 0)
-            return 0;
-
-        if (dirtyPagesRatio >= MAX_DIRTY_PAGES)
-            return 0;
-
-        double remainedClear = (MAX_DIRTY_PAGES - dirtyPagesRatio) * totalPages;
-
-        double timeRemainedSeconds = 1.0 * (cpTotalPages - fullyCompletedPages) / curCpWriteSpeed;
-
-        return (long)(remainedClear / timeRemainedSeconds);
-    }
-
-    /**
-     * @param fullyCompletedPages number of completed.
-     * @param cpTotalPages Total amount of pages under checkpoint.
-     * @return size-based calculation of target ratio.
-     */
-    private double calcTargetDirtyRatio(long fullyCompletedPages, int cpTotalPages) {
-        double cpProgress = ((double)fullyCompletedPages) / cpTotalPages;
-
-        // Starting with initialDirtyRatioAtCpBegin to avoid throttle right after checkpoint start
-        double constStart = initDirtyRatioAtCpBegin;
-
-        double throttleTotalWeight = 1.0 - constStart;
-
-        // .75 is maximum ratio of dirty pages
-        return (cpProgress * throttleTotalWeight + constStart) * MAX_DIRTY_PAGES;
-    }
-
-    /**
-     * @param baseSpeed speed to slow down.
-     * @param nThreads operating threads.
-     * @param coefficient how much it is needed to slowdown base speed. 1.0 means delay to get exact base speed.
-     * @return sleep time in nanoseconds.
-     */
-    private long calcDelayTime(long baseSpeed, int nThreads, double coefficient) {
-        if (coefficient <= 0.0)
-            return 0;
-
-        if (baseSpeed <= 0)
-            return 0;
-
-        long updTimeNsForOnePage = TimeUnit.SECONDS.toNanos(1) * nThreads / (baseSpeed);
-
-        return (long)(coefficient * updTimeNsForOnePage);
-    }
-
-    /**
-     * @param cpWrittenPages current counter of written pages.
-     * @param dirtyPagesRatio current percent of dirty pages.
-     */
-    private void detectCpPagesWriteStart(int cpWrittenPages, double dirtyPagesRatio) {
-        if (cpWrittenPages > 0 && lastObservedWritten.compareAndSet(0, cpWrittenPages)) {
-            double newMinRatio = dirtyPagesRatio;
-
-            if (newMinRatio < MIN_RATIO_NO_THROTTLE)
-                newMinRatio = MIN_RATIO_NO_THROTTLE;
-
-            if (newMinRatio > 1)
-                newMinRatio = 1;
-
-            //for slow cp is completed now, drop previous dirty page percent
-            initDirtyRatioAtCpBegin = newMinRatio;
-        }
+    long getCleanPagesProtectionParkTime(
+            double dirtyPagesRatio,
+            long fullyCompletedPages,
+            int cpTotalPages,
+            int nThreads,
+            long markDirtySpeed,
+            long curCpWriteSpeed) {
+        return cleanPagesProtector.getParkTime(dirtyPagesRatio, fullyCompletedPages, cpTotalPages, nThreads,
+                markDirtySpeed, curCpWriteSpeed);
     }
 
     /** {@inheritDoc} */
     @Override public void onBeginCheckpoint() {
-        speedCpWrite.setCounter(0L, System.nanoTime());
-
-        initDirtyRatioAtCpBegin = MIN_RATIO_NO_THROTTLE;
-
-        lastObservedWritten.set(0);
+        cleanPagesProtector.reset();
     }
-
 
     /** {@inheritDoc} */
     @Override public void onFinishCheckpoint() {
-        exponentialBackoffCntr.set(0);
+        cpBufferProtector.resetBackoff();
 
-        speedCpWrite.finishInterval();
-        speedMarkAndAvgParkTime.finishInterval();
-        threadIds.clear();
+        cleanPagesProtector.finish();
+        markSpeedAndAvgParkTime.finishInterval();
+        unparkParkedThreads();
+    }
+
+    /***/
+    private void unparkParkedThreads() {
         parkedThreads.forEach(LockSupport::unpark);
     }
 
@@ -483,47 +243,42 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
      * @return Exponential backoff counter.
      */
     public long throttleParkTime() {
-        return speedMarkAndAvgParkTime.getAverage();
+        return markSpeedAndAvgParkTime.getAverage();
     }
 
     /**
      * @return Target (maximum) dirty pages ratio, after which throttling will start.
      */
     public double getTargetDirtyRatio() {
-        return targetDirtyRatio;
+        return cleanPagesProtector.getTargetDirtyRatio();
     }
 
     /**
      * @return Current dirty pages ratio.
      */
     public double getCurrDirtyRatio() {
-        double ratio = currDirtyRatio;
-
-        if (ratio >= 0)
-            return ratio;
-
-        return pageMemory.getDirtyPagesRatio();
+        return cleanPagesProtector.getCurrDirtyRatio();
     }
 
     /**
      * @return  Speed of marking pages dirty. Value from past 750-1000 millis only. Pages/second.
      */
     public long getMarkDirtySpeed() {
-        return speedMarkAndAvgParkTime.getSpeedOpsPerSec(System.nanoTime());
+        return markSpeedAndAvgParkTime.getSpeedOpsPerSec(System.nanoTime());
     }
 
     /**
      * @return Speed average checkpoint write speed. Current and 3 past checkpoints used. Pages/second.
      */
     public long getCpWriteSpeed() {
-        return speedCpWrite.getSpeedOpsPerSecReadOnly();
+        return cleanPagesProtector.getCpWriteSpeed();
     }
 
     /**
-     * @return Returns {@link #speedForMarkAll}.
+     * @return last estimated speed for marking all clear pages as dirty till the end of checkpoint.
      */
     public long getLastEstimatedSpeedForMarkAll() {
-        return speedForMarkAll;
+        return cleanPagesProtector.getLastEstimatedSpeedForMarkAll();
     }
 
     /**
@@ -532,12 +287,12 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
      * @return metric started from 0.0 and showing how much throttling is involved into current marking process.
      */
     public double throttleWeight() {
-        long speed = speedMarkAndAvgParkTime.getSpeedOpsPerSec(System.nanoTime());
+        long speed = markSpeedAndAvgParkTime.getSpeedOpsPerSec(System.nanoTime());
 
         if (speed <= 0)
             return 0;
 
-        long timeForOnePage = calcDelayTime(speed, threadIds.size(), 1);
+        long timeForOnePage = cleanPagesProtector.calcDelayTime(speed);
 
         if (timeForOnePage == 0)
             return 0;
@@ -546,32 +301,16 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
     }
 
     /** {@inheritDoc} */
-    @Override public void tryWakeupThrottledThreads() {
-        if (!shouldThrottle()) {
-            exponentialBackoffCntr.set(0);
+    @Override public void wakeupThrottledThreads() {
+        if (!isCpBufferOverflowThresholdExceeded()) {
+            cpBufferProtector.resetBackoff();
 
-            parkedThreads.forEach(LockSupport::unpark);
+            unparkParkedThreads();
         }
     }
 
     /** {@inheritDoc} */
-    @Override public boolean shouldThrottle() {
-        int checkpointBufLimit = (int)(pageMemory.checkpointBufferPagesSize() * CP_BUF_FILL_THRESHOLD);
-
-        return pageMemory.checkpointBufferPagesCount() > checkpointBufLimit;
-    }
-
-    /**
-     * Throttling mode for page.
-     */
-    private enum ThrottleMode {
-        /** No delay is applied. */
-        NO,
-
-        /** Limited, time is based on target speed. */
-        LIMITED,
-
-        /** Exponential. */
-        EXPONENTIAL
+    @Override public boolean isCpBufferOverflowThresholdExceeded() {
+        return cpBufferWatchdog.isInDangerZone();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteThrottle.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteThrottle.java
@@ -18,6 +18,7 @@ package org.apache.ignite.internal.processors.cache.persistence.pagemem;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.processors.cache.persistence.CheckpointLockStateChecker;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointProgress;
@@ -39,22 +40,21 @@ public class PagesWriteThrottle implements PagesWriteThrottlePolicy {
     private final boolean throttleOnlyPagesInCheckpoint;
 
     /** Checkpoint lock state checker. */
-    private CheckpointLockStateChecker stateChecker;
+    private final CheckpointLockStateChecker stateChecker;
 
-    /** Starting throttle time. Limits write speed to 1000 MB/s. */
-    private static final long STARTING_THROTTLE_NANOS = 4000;
+    /** In-checkpoint protection logic. */
+    private final ExponentialBackoffThrottlingStrategy inCheckpointProtection
+        = new ExponentialBackoffThrottlingStrategy();
 
-    /** Backoff ratio. Each next park will be this times longer. */
-    private static final double BACKOFF_RATIO = 1.05;
+    /** Not-in-checkpoint protection logic. */
+    private final ExponentialBackoffThrottlingStrategy notInCheckpointProtection
+        = new ExponentialBackoffThrottlingStrategy();
 
-    /** Counter for dirty pages ratio throttling. */
-    private final AtomicInteger notInCheckpointBackoffCntr = new AtomicInteger(0);
-
-    /** Counter for checkpoint buffer usage ratio throttling (we need a separate one due to IGNITE-7751). */
-    private final AtomicInteger inCheckpointBackoffCntr = new AtomicInteger(0);
+    /** Checkpoint Buffer-related logic used to keep it safe. */
+    private final CheckpointBufferOverflowWatchdog cpBufferWatchdog;
 
     /** Logger. */
-    private IgniteLogger log;
+    private final IgniteLogger log;
 
     /** Threads that are throttled due to checkpoint buffer overflow. */
     private final ConcurrentHashMap<Long, Thread> cpBufThrottledThreads = new ConcurrentHashMap<>();
@@ -76,9 +76,11 @@ public class PagesWriteThrottle implements PagesWriteThrottlePolicy {
         this.cpProgress = cpProgress;
         this.stateChecker = stateChecker;
         this.throttleOnlyPagesInCheckpoint = throttleOnlyPagesInCheckpoint;
+        cpBufferWatchdog = new CheckpointBufferOverflowWatchdog(pageMemory);
         this.log = log;
 
-        assert throttleOnlyPagesInCheckpoint || cpProgress != null : "cpProgress must be not null if ratio based throttling mode is used";
+        assert throttleOnlyPagesInCheckpoint || cpProgress != null
+                : "cpProgress must be not null if ratio based throttling mode is used";
     }
 
     /** {@inheritDoc} */
@@ -88,7 +90,7 @@ public class PagesWriteThrottle implements PagesWriteThrottlePolicy {
         boolean shouldThrottle = false;
 
         if (isPageInCheckpoint)
-            shouldThrottle = shouldThrottle();
+            shouldThrottle = isCpBufferOverflowThresholdExceeded();
 
         if (!shouldThrottle && !throttleOnlyPagesInCheckpoint) {
             CheckpointProgress progress = cpProgress.apply();
@@ -116,12 +118,11 @@ public class PagesWriteThrottle implements PagesWriteThrottlePolicy {
             }
         }
 
-        AtomicInteger cntr = isPageInCheckpoint ? inCheckpointBackoffCntr : notInCheckpointBackoffCntr;
+        ExponentialBackoffThrottlingStrategy exponentialThrottle = isPageInCheckpoint
+                ? inCheckpointProtection : notInCheckpointProtection;
 
         if (shouldThrottle) {
-            int throttleLevel = cntr.getAndIncrement();
-
-            long throttleParkTimeNs = (long) (STARTING_THROTTLE_NANOS * Math.pow(BACKOFF_RATIO, throttleLevel));
+            long throttleParkTimeNs = exponentialThrottle.protectionParkTime();
 
             Thread curThread = Thread.currentThread();
 
@@ -149,20 +150,24 @@ public class PagesWriteThrottle implements PagesWriteThrottlePolicy {
                 LockSupport.parkNanos(throttleParkTimeNs);
         }
         else {
-            int oldCntr = cntr.getAndSet(0);
+            boolean backoffWasAlreadyStarted = exponentialThrottle.resetBackoff();
 
-            if (isPageInCheckpoint && oldCntr != 0)
-                cpBufThrottledThreads.values().forEach(LockSupport::unpark);
+            if (isPageInCheckpoint && backoffWasAlreadyStarted)
+                unparkParkedThreads();
         }
     }
 
     /** {@inheritDoc} */
-    @Override public void tryWakeupThrottledThreads() {
-        if (!shouldThrottle()) {
-            inCheckpointBackoffCntr.set(0);
+    @Override public void wakeupThrottledThreads() {
+        if (!isCpBufferOverflowThresholdExceeded()) {
+            inCheckpointProtection.resetBackoff();
 
-            cpBufThrottledThreads.values().forEach(LockSupport::unpark);
+            unparkParkedThreads();
         }
+    }
+
+    private void unparkParkedThreads() {
+        cpBufThrottledThreads.values().forEach(LockSupport::unpark);
     }
 
     /** {@inheritDoc} */
@@ -171,15 +176,12 @@ public class PagesWriteThrottle implements PagesWriteThrottlePolicy {
 
     /** {@inheritDoc} */
     @Override public void onFinishCheckpoint() {
-        inCheckpointBackoffCntr.set(0);
-
-        notInCheckpointBackoffCntr.set(0);
+        inCheckpointProtection.resetBackoff();
+        notInCheckpointProtection.resetBackoff();
     }
 
     /** {@inheritDoc} */
-    @Override public boolean shouldThrottle() {
-        int checkpointBufLimit = (int)(pageMemory.checkpointBufferPagesSize() * CP_BUF_FILL_THRESHOLD);
-
-        return pageMemory.checkpointBufferPagesCount() > checkpointBufLimit;
+    @Override public boolean isCpBufferOverflowThresholdExceeded() {
+        return cpBufferWatchdog.isInDangerZone();
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteThrottlePolicy.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteThrottlePolicy.java
@@ -23,14 +23,51 @@ import static org.apache.ignite.IgniteSystemProperties.IGNITE_THROTTLE_LOG_THRES
 
 /**
  * Throttling policy, encapsulates logic of delaying write operations.
+ * <p>
+ * There are two resources that get (or might get) consumed when writing:
+ * <ul>
+ *     <li>
+ *         <b>Checkpoint Buffer</b> where a page is placed when, being under checkpoint, it gets written
+ *     </li>
+ *     <li>
+ *         <b>Clean pages</b> which get dirtied when writes occur
+ *     </li>
+ * </ul>
+ * Both resources are limited in size. Both are freed when checkpoint finishes. This means that, if writers
+ * write too fast, they can consume any of these two resources before we have a chance to finish a checkpoint.
+ * If this happens, the cluster fails or stalls.
+ * <p>
+ * Write throttling solves this problem by slowing down the writers to a rate at which they do not exhaust
+ * any of the two resources.
+ * <p>
+ * An alternative to just slowing down is to wait in a loop till the resource we're after gets freed, and
+ * only then allow the write to happen. The problem with this approach is that we cannot wait in a loop/sleep
+ * under a write lock, so the logic would be a lot more complicated. Maybe in the future we'll follow this path,
+ * but for now, a simpler approach of just throttling is used (see below).
+ * <p>
+ * If we just slow writers down by throttling their writes, AND we have enough Checkpoint Buffer and pages in
+ * segments to take some load bursts, we are fine. Under such assumptions, it does not matter whether we throttle
+ * a writer thread before acquiring write lock or after it gets released; in the current implementation, this
+ * happens after write lock gets released (because it was considered simpler to implement).
+ * <p>
+ * The actual throttling happens when a page gets marked dirty by calling {@link #onMarkDirty(boolean)}.
+ * <p>
+ * There are two additional methods for interfacing with other parts of the system:
+ * <ul>
+ *     <li>{@link #wakeupThrottledThreads()} which wakes up the threads currently being throttled; in the current
+ *     implementation, it is called  when Checkpoint Buffer utilization falls below 1/2.</li>
+ *     <li>{@link #isCpBufferOverflowThresholdExceeded()} which is called by a checkpointer to see whether the Checkpoint Buffer is
+ *     in a danger zone and, if yes, it starts to prioritize writing pages from the Checkpoint Buffer over
+ *     pages from the normal checkpoint sequence.</li>
+ * </ul>
  */
 public interface PagesWriteThrottlePolicy {
-    /** Max park time. */
-    public long LOGGING_THRESHOLD = TimeUnit.SECONDS.toNanos(
+    /** Min park time which triggers logging. */
+    long LOGGING_THRESHOLD = TimeUnit.SECONDS.toNanos(
         IgniteSystemProperties.getInteger(IGNITE_THROTTLE_LOG_THRESHOLD, 10));
 
     /** Checkpoint buffer fullfill upper bound. */
-    static final float CP_BUF_FILL_THRESHOLD = 2f / 3;
+    float CP_BUF_FILL_THRESHOLD = 2f / 3;
 
     /**
      * Callback to apply throttling delay.
@@ -39,11 +76,10 @@ public interface PagesWriteThrottlePolicy {
     void onMarkDirty(boolean isPageInCheckpoint);
 
     /**
-     * Callback to try wakeup throttled threads.
+     * Callback to wakeup throttled threads. Invoked when the Checkpoint Buffer use drops below a certain
+     * threshold.
      */
-    default void tryWakeupThrottledThreads() {
-        // No-op.
-    }
+    void wakeupThrottledThreads();
 
     /**
      * Callback to notify throttling policy checkpoint was started.
@@ -56,9 +92,10 @@ public interface PagesWriteThrottlePolicy {
     void onFinishCheckpoint();
 
     /**
-     * @return {@code True} if throttling should be enabled, and {@code False} otherwise.
+     * Whether Checkpoint Buffer is currently close to exhaustion.
+     *
+     * @return {@code true} if measures like throttling to protect Checkpoint Buffer should be applied,
+     * and {@code false} otherwise.
      */
-    default boolean shouldThrottle() {
-        return false;
-    }
+    boolean isCpBufferOverflowThresholdExceeded();
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ProgressSpeedCalculation.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ProgressSpeedCalculation.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+/**
+ * Represents speed calculation of some progress starting from zero.
+ * This class not only takes into account current progress value, but also 3 previous values, each of them
+ * is pushed to history when {@link #closeInterval()} is called.
+ */
+class ProgressSpeedCalculation {
+    /**
+     * Measurement used to calculate average speed. History recording is disabled.
+     */
+    private final IntervalBasedMeasurement measurement = new IntervalBasedMeasurement();
+
+    /**
+     * Sets the value which was reached by the progress.
+     *
+     * @param progress  progress value
+     * @param nanoTime  time instant
+     */
+    public void setProgress(long progress, long nanoTime) {
+        measurement.setCounter(progress, nanoTime);
+    }
+
+    /**
+     * Returns speed of progress in operations per second calculated from the current value and 3 latest historical
+     * intervals. This method may change internal state (namely, initialize the current interval).
+     *
+     * @param nanoTime time instant at which the speed is to be calculated
+     * @return average ops per second
+     */
+    public long getOpsPerSecond(long nanoTime) {
+        return measurement.getSpeedOpsPerSec(nanoTime);
+    }
+
+    /**
+     * Returns speed of progress in operations per second calculated from the current value and 3 latest historical
+     * intervals. This method does not change internal state.
+     *
+     * @return ops per second
+     */
+    public long getOpsPerSecondReadOnly() {
+        return measurement.getSpeedOpsPerSecReadOnly();
+    }
+
+    /**
+     * Closes the current interval by pushing it to the history. The 3 latest intervals put into history affect
+     * the average speed calculation via {@link #getOpsPerSecond(long)} and {@link #getOpsPerSecondReadOnly()}.
+     */
+    public void closeInterval() {
+        measurement.finishInterval();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedMemoryConsumptionThrottlingStrategy.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedMemoryConsumptionThrottlingStrategy.java
@@ -1,0 +1,516 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointProgress;
+import org.apache.ignite.internal.util.GridConcurrentHashSet;
+import org.apache.ignite.lang.IgniteOutClosure;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Speed-based throttle used to protect clean pages from exhaustion.
+ *
+ * The main method is {@link #protectionParkTime(long)} which is used to compute park time, if throttling is needed.
+ *
+ * @see #protectionParkTime(long)
+ */
+class SpeedBasedMemoryConsumptionThrottlingStrategy {
+    /**
+     * Maximum fraction of dirty pages in a region.
+     */
+    private static final double MAX_DIRTY_PAGES = 0.75;
+
+    /**
+     * Percent of dirty pages which will not cause throttling.
+     */
+    private static final double MIN_RATIO_NO_THROTTLE = 0.03;
+
+    /**
+     * Page memory.
+     */
+    private final PageMemoryImpl pageMemory;
+
+    /**
+     * Checkpoint progress provider.
+     */
+    private final IgniteOutClosure<CheckpointProgress> cpProgress;
+
+    /**
+     * Total pages possible to store in page memory.
+     */
+    private final long totalPages;
+
+    /**
+     * Last estimated speed for marking all clear pages as dirty till the end of checkpoint.
+     */
+    private volatile long speedForMarkAll;
+
+    /**
+     * Target (maximum) dirty pages ratio, after which throttling will start using
+     * {@link #getParkTime(double, long, int, int, long, long)}.
+     */
+    private volatile double targetDirtyRatio;
+
+    /**
+     * Current dirty pages ratio (percent of dirty pages in the most used segment), negative value means no cp is running.
+     */
+    private volatile double currDirtyRatio;
+
+    /**
+     * Threads set. Contains identifiers of all threads which were marking pages for the current checkpoint.
+     */
+    private final Set<Long> threadIds = new GridConcurrentHashSet<>();
+
+    /**
+     * Counter of written pages from a checkpoint. Value is saved here for detecting a checkpoint start.
+     */
+    private final AtomicInteger lastObservedWritten = new AtomicInteger(0);
+
+    /**
+     * Dirty pages ratio that was observed at a checkpoint start (here the start is a moment when the first page was actually saved to
+     * store). This ratio is excluded from throttling.
+     */
+    private volatile double initDirtyRatioAtCpBegin = MIN_RATIO_NO_THROTTLE;
+
+    /**
+     * Average checkpoint write speed. Only the current value is used. Pages/second.
+     */
+    private final ProgressSpeedCalculation cpWriteSpeed = new ProgressSpeedCalculation();
+
+    /**
+     * Used for calculating speed of marking pages dirty.
+     * Value from past 750-1000 millis only.
+     * {@link IntervalBasedMeasurement#getSpeedOpsPerSec(long)} returns pages marked/second.
+     * {@link IntervalBasedMeasurement#getAverage()} returns average throttle time.
+     */
+    private final IntervalBasedMeasurement markSpeedAndAvgParkTime;
+
+    /***/
+    SpeedBasedMemoryConsumptionThrottlingStrategy(PageMemoryImpl pageMemory,
+                                                  IgniteOutClosure<CheckpointProgress> cpProgress,
+                                                  IntervalBasedMeasurement markSpeedAndAvgParkTime) {
+        this.pageMemory = pageMemory;
+        this.cpProgress = cpProgress;
+        this.markSpeedAndAvgParkTime = markSpeedAndAvgParkTime;
+
+        totalPages = pageMemory.totalPages();
+    }
+
+    /**
+     * Computes next duration (in nanos) to throttle a thread.
+     * Might return {@link PagesWriteSpeedBasedThrottle#NO_THROTTLING_MARKER} as a marker that no throttling should be applied.
+     *
+     * @return park time in nanos or #NO_THROTTLING_MARKER if no throttling is needed
+     */
+    long protectionParkTime(long curNanoTime) {
+        CheckpointProgress progress = cpProgress.apply();
+        AtomicInteger writtenPagesCounter = progress == null ? null : progress.writtenPagesCounter();
+
+        boolean checkpointProgressIsNotYetReported = writtenPagesCounter == null;
+        if (checkpointProgressIsNotYetReported) {
+            resetStatistics();
+
+            return PagesWriteSpeedBasedThrottle.NO_THROTTLING_MARKER;
+        }
+
+        threadIds.add(Thread.currentThread().getId());
+
+        return computeParkTime(writtenPagesCounter, curNanoTime);
+    }
+
+    /***/
+    private void resetStatistics() {
+        speedForMarkAll = 0;
+        targetDirtyRatio = -1;
+        currDirtyRatio = -1;
+    }
+
+    /***/
+    private long computeParkTime(@NotNull AtomicInteger writtenPagesCounter, long curNanoTime) {
+        final int cpWrittenPages = writtenPagesCounter.get();
+        final long donePages = cpDonePagesEstimation(cpWrittenPages);
+
+        final long markDirtySpeed = markSpeedAndAvgParkTime.getSpeedOpsPerSec(curNanoTime);
+        // NB: we update progress for speed calculation only in this (clean pages protection) scenario, because
+        // we only use the computed speed in this same scenario and for reporting in logs (where it's not super
+        // important to display an ideally accurate speed), but not in the CP Buffer protection scenario.
+        // This is to simplify code.
+        // The progress is set to 0 at the beginning of a checkpoint, so we can be sure that the start time remembered
+        // in cpWriteSpeed is pretty accurate even without writing to cpWriteSpeed from this method.
+        cpWriteSpeed.setProgress(donePages, curNanoTime);
+        final long curCpWriteSpeed = cpWriteSpeed.getOpsPerSecond(curNanoTime);
+
+        final int cpTotalPages = cpTotalPages();
+
+        if (cpTotalPages == 0) {
+            // From the current code analysis, we can only get here by accident when
+            // CheckpointProgressImpl.clearCounters() is invoked at the end of a checkpoint (by falling through
+            // between two volatile assignments). When we get here, we don't have any information about the total
+            // number of pages in the current CP, so we calculate park time by only using information we have.
+            return parkTimeToThrottleByJustCPSpeed(markDirtySpeed, curCpWriteSpeed);
+        }
+        else {
+            return speedBasedParkTime(cpWrittenPages, donePages, markDirtySpeed,
+                    curCpWriteSpeed, cpTotalPages);
+        }
+    }
+
+    /**
+     * Returns an estimation of the progress made during the current checkpoint. Currently, it is an average of
+     * written pages and fully synced pages (probably, to account for both writing (which may be pretty
+     * ahead of syncing) and syncing at the same time).
+     *
+     * @param cpWrittenPages    count of pages written during current checkpoint
+     * @return estimation of work done (in pages)
+     */
+    private int cpDonePagesEstimation(int cpWrittenPages) {
+        return (cpWrittenPages + cpSyncedPages()) / 2;
+    }
+
+    /**
+     * Simplified version of park time calculation used when we don't have information about total CP size (in pages).
+     * Such a situation seems to be very rare, but it can happen when finishing a CP.
+     *
+     * @param markDirtySpeed    speed of page dirtying
+     * @param curCpWriteSpeed   speed of CP writing pages
+     * @return park time (nanos)
+     */
+    private long parkTimeToThrottleByJustCPSpeed(long markDirtySpeed, long curCpWriteSpeed) {
+        boolean throttleByCpSpeed = curCpWriteSpeed > 0 && markDirtySpeed > curCpWriteSpeed;
+
+        if (throttleByCpSpeed) {
+            return calcDelayTime(curCpWriteSpeed);
+        }
+
+        return 0;
+    }
+
+    /***/
+    private long speedBasedParkTime(int cpWrittenPages, long donePages, long markDirtySpeed,
+                                    long curCpWriteSpeed, int cpTotalPages) {
+        final double dirtyPagesRatio = pageMemory.getDirtyPagesRatio();
+
+        currDirtyRatio = dirtyPagesRatio;
+
+        detectCpPagesWriteStart(cpWrittenPages, dirtyPagesRatio);
+
+        if (dirtyPagesRatio >= MAX_DIRTY_PAGES)
+            return 0; // too late to throttle, will wait on safe to update instead.
+        else {
+            return getParkTime(dirtyPagesRatio,
+                    donePages,
+                    notEvictedPagesTotal(cpTotalPages),
+                    threadIdsCount(),
+                    markDirtySpeed,
+                    curCpWriteSpeed);
+        }
+    }
+
+    /***/
+    private int notEvictedPagesTotal(int cpTotalPages) {
+        return Math.max(cpTotalPages - cpEvictedPages(), 0);
+    }
+
+    /**
+     * Computes park time for throttling.
+     *
+     * @param dirtyPagesRatio     actual percent of dirty pages.
+     * @param donePages           roughly, written & fsynced pages count.
+     * @param cpTotalPages        total checkpoint scope.
+     * @param nThreads            number of threads providing data during current checkpoint.
+     * @param markDirtySpeed      registered mark dirty speed, pages/sec.
+     * @param curCpWriteSpeed     average checkpoint write speed, pages/sec.
+     * @return time in nanoseconds to part or 0 if throttling is not required.
+     */
+    long getParkTime(
+            double dirtyPagesRatio,
+            long donePages,
+            int cpTotalPages,
+            int nThreads,
+            long markDirtySpeed,
+            long curCpWriteSpeed) {
+
+        final long targetSpeedToMarkAll = calcSpeedToMarkAllSpaceTillEndOfCp(dirtyPagesRatio, donePages,
+                curCpWriteSpeed, cpTotalPages);
+        final double targetCurrentDirtyRatio = targetCurrentDirtyRatio(donePages, cpTotalPages);
+
+        updateSpeedAndRatio(targetSpeedToMarkAll, targetCurrentDirtyRatio);
+
+        long delayByCpWrite = delayIfMarkingFasterThanCPWriteSpeedAllows(markDirtySpeed, curCpWriteSpeed,
+                dirtyPagesRatio, nThreads, targetSpeedToMarkAll, targetCurrentDirtyRatio);
+        long delayByMarkAllWrite = delayIfMarkingFasterThanTargetSpeedAllows(markDirtySpeed, dirtyPagesRatio, nThreads,
+                targetSpeedToMarkAll, targetCurrentDirtyRatio);
+
+        return Math.max(delayByCpWrite, delayByMarkAllWrite);
+    }
+
+    /***/
+    private long delayIfMarkingFasterThanCPWriteSpeedAllows(long markDirtySpeed, long curCpWriteSpeed,
+                                                            double dirtyPagesRatio, int nThreads,
+                                                            long targetSpeedToMarkAll, double targetCurrentDirtyRatio) {
+        final double allowedCpWriteSpeedExcessMultiplier = allowedCpWriteSpeedExcessMultiplier(markDirtySpeed,
+                dirtyPagesRatio, targetSpeedToMarkAll, targetCurrentDirtyRatio);
+        final boolean throttleByCpSpeed = curCpWriteSpeed > 0
+                && markDirtySpeed > (allowedCpWriteSpeedExcessMultiplier * curCpWriteSpeed);
+
+        if (!throttleByCpSpeed) {
+            return 0;
+        }
+
+        int slowdown = slowdownIfLowSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
+        long nanosecsToMarkOnePage = TimeUnit.SECONDS.toNanos(1) * nThreads / markDirtySpeed;
+        long nanosecsToWriteOneCPPage = calcDelayTime(curCpWriteSpeed, nThreads, slowdown);
+        return nanosecsToWriteOneCPPage - nanosecsToMarkOnePage;
+    }
+
+    /***/
+    private double allowedCpWriteSpeedExcessMultiplier(long markDirtySpeed, double dirtyPagesRatio,
+                                                       long targetSpeedToMarkAll, double targetCurrentDirtyRatio) {
+        final boolean lowSpaceLeft = lowCleanSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
+
+        // for case of speedForMarkAll >> markDirtySpeed, allow write little bit faster than CP average
+        final double allowWriteFasterThanCp;
+        if (markDirtySpeed > 0 && markDirtySpeed < targetSpeedToMarkAll)
+            allowWriteFasterThanCp = 0.1 * targetSpeedToMarkAll / markDirtySpeed;
+        else if (dirtyPagesRatio > targetCurrentDirtyRatio)
+            allowWriteFasterThanCp = 0.0;
+        else
+            allowWriteFasterThanCp = 0.1;
+
+        return lowSpaceLeft
+                ? 1.0
+                : 1.0 + allowWriteFasterThanCp;
+    }
+
+    /***/
+    private int slowdownIfLowSpaceLeft(double dirtyPagesRatio, double targetCurrentDirtyRatio) {
+        boolean lowSpaceLeft = lowCleanSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
+        return slowdownIfLowSpaceLeft(lowSpaceLeft);
+    }
+
+    /***/
+    private int slowdownIfLowSpaceLeft(boolean lowSpaceLeft) {
+        return lowSpaceLeft ? 3 : 1;
+    }
+
+    /***/
+    private long delayIfMarkingFasterThanTargetSpeedAllows(long markDirtySpeed, double dirtyPagesRatio, int nThreads,
+                                                           long targetSpeedToMarkAll, double targetCurrentDirtyRatio) {
+        final boolean lowSpaceLeft = lowCleanSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
+        final int slowdown = slowdownIfLowSpaceLeft(lowSpaceLeft);
+
+        double multiplierForSpeedToMarkAll = lowSpaceLeft ? 0.8 : 1.0;
+        boolean markingTooFastNow = targetSpeedToMarkAll > 0
+                && markDirtySpeed > multiplierForSpeedToMarkAll * targetSpeedToMarkAll;
+        boolean markedTooFastSinceCPStart = dirtyPagesRatio > targetCurrentDirtyRatio;
+        boolean markingTooFast = markedTooFastSinceCPStart && markingTooFastNow;
+        return markingTooFast ? calcDelayTime(targetSpeedToMarkAll, nThreads, slowdown) : 0;
+    }
+
+    /**
+     * Whether too low clean space is left, so more powerful measures are needed (like heavier throttling).
+     *
+     * @param dirtyPagesRatio  current dirty pages ratio
+     * @param targetDirtyRatio target dirty pages ratio
+     * @return {@code true} iff clean space left is too low
+     */
+    private boolean lowCleanSpaceLeft(double dirtyPagesRatio, double targetDirtyRatio) {
+        return dirtyPagesRatio > targetDirtyRatio && (dirtyPagesRatio + 0.05 > MAX_DIRTY_PAGES);
+    }
+
+    /***/
+    private void updateSpeedAndRatio(long speedForMarkAll, double targetDirtyRatio) {
+        this.speedForMarkAll = speedForMarkAll; //publish for metrics
+        this.targetDirtyRatio = targetDirtyRatio; //publish for metrics
+    }
+
+    /**
+     * Calculates speed needed to mark dirty all currently clean pages before the current checkpoint ends.
+     * May return 0 if the provided parameters do not give enough information to calculate the speed, OR
+     * if the current dirty pages ratio is too high (higher than {@link #MAX_DIRTY_PAGES}), in which case
+     * we're not going to throttle anyway.
+     *
+     * @param dirtyPagesRatio     current percent of dirty pages.
+     * @param donePages           roughly, count of written and sync'ed pages
+     * @param curCpWriteSpeed     pages/second checkpoint write speed. 0 speed means 'no data'.
+     * @param cpTotalPages        total pages in checkpoint.
+     * @return pages/second to mark to mark all clean pages as dirty till the end of checkpoint. 0 speed means 'no
+     * data', or when we are not going to throttle due to the current dirty pages ratio being too high
+     */
+    private long calcSpeedToMarkAllSpaceTillEndOfCp(double dirtyPagesRatio, long donePages,
+                                                    long curCpWriteSpeed, int cpTotalPages) {
+        if (curCpWriteSpeed == 0)
+            return 0;
+
+        if (cpTotalPages <= 0)
+            return 0;
+
+        if (dirtyPagesRatio >= MAX_DIRTY_PAGES)
+            return 0;
+
+        double remainedClearPages = (MAX_DIRTY_PAGES - dirtyPagesRatio) * totalPages;
+
+        double secondsTillCPEnd = 1.0 * (cpTotalPages - donePages) / curCpWriteSpeed;
+
+        return (long) (remainedClearPages / secondsTillCPEnd);
+    }
+
+    /**
+     * @param donePages         number of completed.
+     * @param cpTotalPages      Total amount of pages under checkpoint.
+     * @return size-based calculation of target ratio.
+     */
+    private double targetCurrentDirtyRatio(long donePages, int cpTotalPages) {
+        double cpProgress = ((double) donePages) / cpTotalPages;
+
+        // Starting with initialDirtyRatioAtCpBegin to avoid throttle right after checkpoint start
+        double constStart = initDirtyRatioAtCpBegin;
+
+        double fractionToVaryDirtyRatio = 1.0 - constStart;
+
+        return (cpProgress * fractionToVaryDirtyRatio + constStart) * MAX_DIRTY_PAGES;
+    }
+
+    /**
+     * @return Target (maximum) dirty pages ratio, after which throttling will start.
+     */
+    public double getTargetDirtyRatio() {
+        return targetDirtyRatio;
+    }
+
+    /**
+     * @return Current dirty pages ratio.
+     */
+    public double getCurrDirtyRatio() {
+        double ratio = currDirtyRatio;
+
+        if (ratio >= 0)
+            return ratio;
+
+        return pageMemory.getDirtyPagesRatio();
+    }
+
+    /**
+     * @return Returns {@link #speedForMarkAll}.
+     */
+    public long getLastEstimatedSpeedForMarkAll() {
+        return speedForMarkAll;
+    }
+
+    /**
+     * @return Speed average checkpoint write speed. Current and 3 past checkpoints used. Pages/second.
+     */
+    public long getCpWriteSpeed() {
+        return cpWriteSpeed.getOpsPerSecondReadOnly();
+    }
+
+    /***/
+    int threadIdsCount() {
+        return threadIds.size();
+    }
+
+    /**
+     * @return Counter for fsynced checkpoint pages.
+     */
+    int cpSyncedPages() {
+        AtomicInteger syncedPagesCntr = cpProgress.apply().syncedPagesCounter();
+
+        return syncedPagesCntr == null ? 0 : syncedPagesCntr.get();
+    }
+
+    /**
+     * @return Number of pages in current checkpoint.
+     */
+    int cpTotalPages() {
+        return cpProgress.apply().currentCheckpointPagesCount();
+    }
+
+    /**
+     * @return number of evicted pages.
+     */
+    int cpEvictedPages() {
+        AtomicInteger evictedPagesCntr = cpProgress.apply().evictedPagesCounter();
+
+        return evictedPagesCntr == null ? 0 : evictedPagesCntr.get();
+    }
+
+    /**
+     * @param baseSpeed   speed to slow down.
+     * @return sleep time in nanoseconds.
+     */
+    long calcDelayTime(long baseSpeed) {
+        return calcDelayTime(baseSpeed, threadIdsCount(), 1);
+    }
+
+    /**
+     * @param baseSpeed   speed to slow down.
+     * @param nThreads    operating threads.
+     * @param factor      how much it is needed to slowdown base speed. 1 means delay to get exact base speed.
+     * @return sleep time in nanoseconds.
+     */
+    private long calcDelayTime(long baseSpeed, int nThreads, int factor) {
+        if (factor <= 0)
+            throw new IllegalStateException("Coefficient should be positive");
+
+        if (baseSpeed <= 0)
+            return 0;
+
+        long updTimeNsForOnePage = TimeUnit.SECONDS.toNanos(1) * nThreads / (baseSpeed);
+
+        return factor * updTimeNsForOnePage;
+    }
+
+    /**
+     * @param cpWrittenPages  current counter of written pages.
+     * @param dirtyPagesRatio current percent of dirty pages.
+     */
+    private void detectCpPagesWriteStart(int cpWrittenPages, double dirtyPagesRatio) {
+        if (cpWrittenPages > 0 && lastObservedWritten.compareAndSet(0, cpWrittenPages)) {
+            double newMinRatio = dirtyPagesRatio;
+
+            if (newMinRatio < MIN_RATIO_NO_THROTTLE)
+                newMinRatio = MIN_RATIO_NO_THROTTLE;
+
+            if (newMinRatio > 1)
+                newMinRatio = 1;
+
+            //for slow cp is completed now, drop previous dirty page percent
+            initDirtyRatioAtCpBegin = newMinRatio;
+        }
+    }
+
+    /**
+     * Resets the throttle to its initial state (for example, in the beginning of a checkpoint).
+     */
+    void reset() {
+        cpWriteSpeed.setProgress(0L, System.nanoTime());
+        initDirtyRatioAtCpBegin = MIN_RATIO_NO_THROTTLE;
+        lastObservedWritten.set(0);
+    }
+
+    /**
+     * Moves the throttle to its finalized state (for example, when a checkpoint ends).
+     */
+    void finish() {
+        cpWriteSpeed.closeInterval();
+        threadIds.clear();
+    }
+}

--- a/modules/core/src/main/resources/META-INF/classnames.properties
+++ b/modules/core/src/main/resources/META-INF/classnames.properties
@@ -1106,7 +1106,6 @@ org.apache.ignite.internal.processors.cache.persistence.freelist.CorruptedFreeLi
 org.apache.ignite.internal.processors.cache.persistence.migration.UpgradePendingTreeToPerPartitionTask
 org.apache.ignite.internal.processors.cache.persistence.pagemem.PageMemoryImpl$Segment
 org.apache.ignite.internal.processors.cache.persistence.pagemem.PageMemoryImpl$ThrottlingPolicy
-org.apache.ignite.internal.processors.cache.persistence.pagemem.PagesWriteSpeedBasedThrottle$ThrottleMode
 org.apache.ignite.internal.processors.cache.persistence.snapshot.SnapshotDiscoveryMessage
 org.apache.ignite.internal.processors.cache.persistence.snapshot.SnapshotOperation
 org.apache.ignite.internal.processors.cache.persistence.snapshot.TrackingPageIsCorruptedException

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ExponentialBackoffTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ExponentialBackoffTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests for {@link ExponentialBackoff}.
+ */
+public class ExponentialBackoffTest {
+    /** Starting backoff duration used for test scenarios. */
+    private static final long STARTING_BACKOFF_NANOS = 1000;
+
+    /** Backoff ratio used for test scenarios. */
+    private static final double BACKOFF_RATIO = 1.1;
+
+    /** The object under test. */
+    private final ExponentialBackoff backoff = new ExponentialBackoff(STARTING_BACKOFF_NANOS, BACKOFF_RATIO);
+
+    @Test
+    public void firstBackoffDurationShouldEqualStartingDuration() {
+        assertThat(backoff.nextDuration(), is(STARTING_BACKOFF_NANOS));
+    }
+
+    @Test
+    public void nextBackoffDurationShouldBeLongerThanPreviousOne() {
+        backoff.nextDuration();
+
+        assertThat(backoff.nextDuration(), equalTo((long) (STARTING_BACKOFF_NANOS * BACKOFF_RATIO)));
+    }
+
+    @Test
+    public void resetInvocationShouldResetTheBackoffToInitialState() {
+        backoff.nextDuration();
+        backoff.nextDuration();
+        backoff.reset();
+
+        assertThat(backoff.nextDuration(), is(STARTING_BACKOFF_NANOS));
+    }
+
+    @Test
+    public void resetShouldReturnFalseWhenBackoffIsAlreadyAtInitialState() {
+        assertFalse(backoff.reset());
+    }
+
+    @Test
+    public void resetShouldReturnTrueWhenBackoffIsNotAtInitialState() {
+        backoff.nextDuration();
+
+        assertTrue(backoff.reset());
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgniteThrottlingUnitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgniteThrottlingUnitTest.java
@@ -21,7 +21,9 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.processors.cache.persistence.CheckpointLockStateChecker;
@@ -34,9 +36,13 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
+import org.mockito.Mockito;
 
 import static java.lang.Thread.State.TIMED_WAITING;
 import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -49,7 +55,7 @@ import static org.mockito.Mockito.when;
 public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
     /** Per test timeout */
     @Rule
-    public Timeout globalTimeout = new Timeout((int)GridTestUtils.DFLT_TEST_TIMEOUT);
+    public Timeout globalTimeout = Timeout.millis((int)GridTestUtils.DFLT_TEST_TIMEOUT);
 
     /** Logger. */
     private final IgniteLogger log = new NullLogger();
@@ -59,6 +65,12 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
 
     /** State checker. */
     private final CheckpointLockStateChecker stateChecker = () -> true;
+
+    /** {@link CheckpointProgress} mock. */
+    private final CheckpointProgress progress = mock(CheckpointProgress.class);
+
+    /** {@link CheckpointProgress} provider that always provides the mock above. */
+    private final IgniteOutClosure<CheckpointProgress> cpProvider = () -> progress;
 
     {
         when(pageMemory2g.totalPages()).thenReturn((2L * 1024 * 1024 * 1024) / 4096);
@@ -71,7 +83,7 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
     public void breakInCaseTooFast() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
-        long time = throttle.getParkTime(0.67,
+        long time = throttle.getCleanPagesProtectionParkTime(0.67,
             (362584 + 67064) / 2,
             328787,
             1,
@@ -88,14 +100,14 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
     public void noBreakIfNotFastWrite() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
-        long time = throttle.getParkTime(0.47,
+        long time = throttle.getCleanPagesProtectionParkTime(0.47,
             ((362584 + 67064) / 2),
             328787,
             1,
             20103,
             23103);
 
-        assertTrue(time == 0);
+        assertEquals(0, time);
     }
 
     /**
@@ -108,7 +120,7 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
 
         int markDirtySpeed = 34422;
         int cpWriteSpeed = 19416;
-        long time = throttle.getParkTime(0.04,
+        long time = throttle.getCleanPagesProtectionParkTime(0.04,
             ((903150 + 227217) / 2),
             903150,
             1,
@@ -193,24 +205,24 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
     public void beginOfCp() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
-        assertTrue(throttle.getParkTime(0.01, 100, 400000,
+        assertEquals(0, throttle.getCleanPagesProtectionParkTime(0.01, 100, 400000,
             1,
             20103,
-            23103) == 0);
+            23103));
 
         //mark speed 22413 for mark all remaining as dirty
-        long time = throttle.getParkTime(0.024, 100, 400000,
+        long time = throttle.getCleanPagesProtectionParkTime(0.024, 100, 400000,
             1,
             24000,
             23103);
         assertTrue(time > 0);
 
-        assertTrue(throttle.getParkTime(0.01,
+        assertEquals(0, throttle.getCleanPagesProtectionParkTime(0.01,
             100,
             400000,
             1,
             22412,
-            23103) == 0);
+            23103));
     }
 
     /**
@@ -220,16 +232,16 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
     public void enforceThrottleAtTheEndOfCp() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
-        long time1 = throttle.getParkTime(0.70, 300000, 400000,
+        long time1 = throttle.getCleanPagesProtectionParkTime(0.70, 300000, 400000,
             1, 20200, 23000);
-        long time2 = throttle.getParkTime(0.71, 300000, 400000,
+        long time2 = throttle.getCleanPagesProtectionParkTime(0.71, 300000, 400000,
             1, 20200, 23000);
 
         assertTrue(time2 >= time1 * 2); // extra slowdown should be applied.
 
-        long time3 = throttle.getParkTime(0.73, 300000, 400000,
+        long time3 = throttle.getCleanPagesProtectionParkTime(0.73, 300000, 400000,
             1, 20200, 23000);
-        long time4 = throttle.getParkTime(0.74, 300000, 400000,
+        long time4 = throttle.getCleanPagesProtectionParkTime(0.74, 300000, 400000,
             1, 20200, 23000);
 
         assertTrue(time3 > time2);
@@ -244,7 +256,7 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
         // 363308 350004 348976 10604
-        long time = throttle.getParkTime(0.75,
+        long time = throttle.getCleanPagesProtectionParkTime(0.75,
             ((350004 + 348976) / 2),
             350004 - 10604,
             4,
@@ -253,11 +265,11 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
 
         System.err.println(time);
 
-        assertTrue(time == 0);
+        assertEquals(0, time);
     }
 
     /**
-     * @throws IgniteInterruptedCheckedException if fail.
+     * @throws IgniteInterruptedCheckedException if failed.
      */
     @Test
     public void wakeupSpeedBaseThrottledThreadOnCheckpointFinish() throws IgniteInterruptedCheckedException {
@@ -271,12 +283,11 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
         PagesWriteThrottlePolicy plc = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProgress, stateChecker, log) {
             @Override protected void doPark(long throttleParkTimeNs) {
                 //Force parking to long time.
-                super.doPark(100_000);
+                super.doPark(TimeUnit.SECONDS.toNanos(1));
             }
         };
 
-        when(pageMemory2g.checkpointBufferPagesSize()).thenReturn(100);
-        when(pageMemory2g.checkpointBufferPagesCount()).thenAnswer(mock -> 70);
+        simulateCheckpointBufferInDangerZoneSituation();
 
         AtomicBoolean stopLoad = new AtomicBoolean();
         List<Thread> loadThreads = new ArrayList<>();
@@ -299,7 +310,8 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
                 assertTrue(t.getName(), waitForCondition(() -> t.getState() == TIMED_WAITING, 1000L));
 
             //when: Disable throttling
-            when(cpProgress.apply()).thenReturn(null);
+            simulateCheckpointBufferInSafeZoneSituation();
+            stopReportingCheckpointProgress(cpProgress);
 
             //and: Finish the checkpoint.
             plc.onFinishCheckpoint();
@@ -316,11 +328,16 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
         }
     }
 
+    /***/
+    private void stopReportingCheckpointProgress(IgniteOutClosure<CheckpointProgress> cpProgress) {
+        when(cpProgress.apply()).thenReturn(null);
+    }
+
     /**
      *
      */
     @Test
-    public void wakeupThrottledThread() throws IgniteInterruptedCheckedException, InterruptedException {
+    public void wakeupThrottledThread() throws IgniteInterruptedCheckedException {
         PagesWriteThrottlePolicy plc = new PagesWriteThrottle(pageMemory2g, null, stateChecker, true, log);
 
         AtomicBoolean stopLoad = new AtomicBoolean();
@@ -389,14 +406,9 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
 
         AtomicInteger written = new AtomicInteger();
 
-        CheckpointProgressImpl cl0 = mock(CheckpointProgressImpl.class);
+        Mockito.when(progress.writtenPagesCounter()).thenReturn(written);
 
-        IgniteOutClosure<CheckpointProgress> cpProgress = mock(IgniteOutClosure.class);
-        when(cpProgress.apply()).thenReturn(cl0);
-
-        when(cl0.writtenPagesCounter()).thenReturn(written);
-
-        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProgress, stateChecker, log) {
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider, stateChecker, log) {
             @Override protected void doPark(long throttleParkTimeNs) {
                 //do nothing
             }
@@ -424,5 +436,168 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
         System.out.println(throttle.throttleWeight());
 
         assertTrue(warnings.get() > 0);
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldThrottleWhenCheckpointBufferIsInDangerZone() {
+        simulateCheckpointProgressIsStarted();
+        simulateCheckpointBufferInDangerZoneSituation();
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log);
+
+        throttle.onMarkDirty(true);
+
+        assertThatThrottlingHappened(throttle);
+    }
+
+    /***/
+    private void assertThatThrottlingHappened(PagesWriteSpeedBasedThrottle throttle) {
+        assertThat(throttle.throttleParkTime(), greaterThan(0L));
+    }
+
+    /***/
+    private void simulateCheckpointBufferInDangerZoneSituation() {
+        when(pageMemory2g.checkpointBufferPagesSize()).thenReturn(100);
+        when(pageMemory2g.checkpointBufferPagesCount()).thenReturn(100);
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldThrottleWhenCheckpointCountersAreNotReadyYetButCheckpointBufferIsInDangerZone() {
+        simulateCheckpointProgressNotYetStarted();
+        simulateCheckpointBufferInDangerZoneSituation();
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log);
+
+        throttle.onMarkDirty(true);
+
+        assertThatThrottlingHappened(throttle);
+    }
+
+    /***/
+    private void simulateCheckpointProgressNotYetStarted() {
+        when(progress.writtenPagesCounter()).thenReturn(null);
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldNotLeaveTracesInStatisticsWhenCPBufferIsInSafeZoneAndProgressIsNotYetStarted() {
+        simulateCheckpointProgressNotYetStarted();
+        simulateCheckpointBufferInSafeZoneSituation();
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log);
+
+        throttle.onMarkDirty(true);
+
+        assertThat(throttle.throttleParkTime(), is(0L));
+    }
+
+    /***/
+    private void simulateCheckpointBufferInSafeZoneSituation() {
+        when(pageMemory2g.checkpointBufferPagesSize()).thenReturn(100);
+        when(pageMemory2g.checkpointBufferPagesCount()).thenReturn(0);
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldResetCPBufferProtectionParkTimeWhenItSeesThatCPBufferIsInSafeZoneAndThePageIsInCheckpoint() {
+        // preparations
+        simulateCheckpointProgressIsStarted();
+        AtomicLong parkTimeNanos = new AtomicLong();
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log) {
+            @Override protected void doPark(long throttleParkTimeNs) {
+                super.doPark(1);
+                parkTimeNanos.set(throttleParkTimeNs);
+            }
+        };
+
+        // test script starts
+
+        // cause a couple of CP Buffer protection parks
+        simulateCheckpointBufferInDangerZoneSituation();
+        throttle.onMarkDirty(true);
+        throttle.onMarkDirty(true);
+        assertThat(parkTimeNanos.get(), is(4200L));
+
+        // cause the counter to be reset
+        simulateCheckpointBufferInSafeZoneSituation();
+        throttle.onMarkDirty(true);
+
+        // check that next CP Buffer protection park starts from the beginning
+        simulateCheckpointBufferInDangerZoneSituation();
+        throttle.onMarkDirty(true);
+        assertThat(parkTimeNanos.get(), is(4000L));
+    }
+
+    /***/
+    private void simulateCheckpointProgressIsStarted() {
+        when(progress.writtenPagesCounter()).thenReturn(new AtomicInteger(1000));
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldNotResetCPBufferProtectionParkTimeWhenItSeesThatCPBufferIsInSafeZoneAndThePageIsNotInCheckpoint() {
+        // preparations
+        simulateCheckpointProgressIsStarted();
+        AtomicLong parkTimeNanos = new AtomicLong();
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log) {
+            @Override protected void doPark(long throttleParkTimeNs) {
+                super.doPark(1);
+                parkTimeNanos.set(throttleParkTimeNs);
+            }
+        };
+
+        // test script starts
+
+        // cause a couple of CP Buffer protection parks
+        simulateCheckpointBufferInDangerZoneSituation();
+        throttle.onMarkDirty(true);
+        throttle.onMarkDirty(true);
+        assertThat(parkTimeNanos.get(), is(4200L));
+
+        // this should NOT cause the counter to be reset
+        simulateCheckpointBufferInSafeZoneSituation();
+        throttle.onMarkDirty(false);
+
+        // check that next CP Buffer protection park is the third member of the progression
+        simulateCheckpointBufferInDangerZoneSituation();
+        throttle.onMarkDirty(true);
+        assertThat(parkTimeNanos.get(), is(4410L));
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldReportCpWriteSpeedWhenThePageIsNotInCheckpointAndProgressIsReported()
+            throws InterruptedException {
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log);
+        simulateCheckpointProgressIsStarted();
+        allowSomeTimeToPass();
+        throttle.onMarkDirty(false);
+
+        assertThat(throttle.getCpWriteSpeed(), is(greaterThan(0L)));
+    }
+
+    /***/
+    private void allowSomeTimeToPass() throws InterruptedException {
+        Thread.sleep(10);
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldResetCPProgressToZeroOnCheckpointStart() throws InterruptedException {
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, cpProvider,
+                stateChecker, log);
+        simulateCheckpointProgressIsStarted();
+        allowSomeTimeToPass();
+        throttle.onMarkDirty(false);
+
+        throttle.onBeginCheckpoint();
+
+        // verify progress speed to make a conclusion about progress itself
+        assertThat(throttle.getCpWriteSpeed(), is(0L));
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImplTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImplTest.java
@@ -342,7 +342,7 @@ public class PageMemoryImplTest extends GridCommonAbstractTest {
 
             memory.checkpointWritePage(cpPage, buf, pageStoreWriter, null);
 
-            while (memory.shouldThrottle()) {
+            while (memory.isCpBufferOverflowThresholdExceeded()) {
                 FullPageId cpPageId = memory.pullPageFromCpBuffer();
 
                 if (cpPageId.equals(FullPageId.NULL_PAGE))

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ProgressSpeedCalculationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/ProgressSpeedCalculationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Tests for {@link ProgressSpeedCalculation}.
+ */
+public class ProgressSpeedCalculationTest {
+    /** The object under test. */
+    private final ProgressSpeedCalculation calculation = new ProgressSpeedCalculation();
+
+    /***/
+    @Test
+    public void getOpsPerSecondCalculatesCorrectSpeed() {
+        calculation.setProgress(1000, 0);
+
+        assertThat(calculation.getOpsPerSecond(1_000_000_000), is(1000L));
+    }
+
+    /***/
+    @Test
+    public void getOpsPerSecondShouldReturnZeroWhenNoValueIsRegisteredYet() {
+        assertThat(calculation.getOpsPerSecond(System.nanoTime()), is(0L));
+    }
+
+    /***/
+    @Test
+    public void getOpsPerSecondReadOnlyShouldReturnZeroWhenNoValueIsRegisteredYet() {
+        assertThat(calculation.getOpsPerSecondReadOnly(), is(0L));
+    }
+
+    /***/
+    @Test
+    public void closeIntervalAffectsSubsequentGetOpsPerSecond() throws InterruptedException {
+        putNonZeroProgressToHistory();
+
+        assertThat(calculation.getOpsPerSecond(System.nanoTime()), is(greaterThan(0L)));
+    }
+
+    /***/
+    private void putNonZeroProgressToHistory() throws InterruptedException {
+        calculation.setProgress(1000, System.nanoTime());
+        Thread.sleep(10);
+        calculation.closeInterval();
+    }
+
+    /***/
+    @Test
+    public void closeIntervalAffectsSubsequentGetOpsPerSecondReadOnly() throws InterruptedException {
+        putNonZeroProgressToHistory();
+
+        assertThat(calculation.getOpsPerSecondReadOnly(), is(greaterThan(0L)));
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -79,6 +79,7 @@ import org.apache.ignite.internal.processors.cache.distributed.IgniteRejectConne
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.EvictPartitionInLogTest;
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.PartitionEvictionOrderTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.ClockPageReplacementFlagsTest;
+import org.apache.ignite.internal.processors.cache.persistence.pagemem.ExponentialBackoffTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.PagePoolTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.SegmentedLruPageListTest;
 import org.apache.ignite.internal.processors.cache.query.continuous.DiscoveryDataDeserializationFailureHanderTest;
@@ -320,7 +321,8 @@ import org.junit.runners.Suite;
     // Other tests
     CacheLockCandidatesThreadTest.class,
     RemoveAllDeadlockTest.class,
-    JvmConfigurationSuggestionsTest.class
+    JvmConfigurationSuggestionsTest.class,
+    ExponentialBackoffTest.class
 })
 public class IgniteBasicTestSuite {
 }


### PR DESCRIPTION
- speed-based throttling had a bug that prevented it to protect CP Buffer when CP progress was not yet reported; it's fixed here
- speed-based throttling has been heavily refactored to make it easier to understand
- the machinery comprising and surrounding write throttling has been commented

Cherry-picked from 953902d23317a0be62c865dd3daa45c5fc65b5cc.