### PR TITLE
GG-34570 [IGNITE-16242] .NET: Fix platform cache behavior with persistent storage

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheContext.java
@@ -2138,7 +2138,8 @@ public class GridCacheContext<K, V> implements Externalizable {
      * @return {@code True} if it is possible to directly read offheap instead of using {@link GridCacheEntryEx#innerGet}.
      */
     public boolean readNoEntry(@Nullable IgniteCacheExpiryPolicy expiryPlc, boolean readers) {
-        return mvccEnabled() || (!config().isOnheapCacheEnabled() && !readers && expiryPlc == null);
+        return mvccEnabled()
+                || (!config().isOnheapCacheEnabled() && !readers && expiryPlc == null && config().getPlatformCacheConfiguration() == null);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -756,7 +756,8 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
 
             CacheObject val;
 
-            boolean valid = valid(tx != null ? tx.topologyVersion() : cctx.affinity().affinityTopologyVersion());
+            AffinityTopologyVersion topVer = tx != null ? tx.topologyVersion() : cctx.affinity().affinityTopologyVersion();
+            boolean valid = valid(topVer);
 
             if (valid) {
                 val = this.val;
@@ -766,6 +767,9 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
                         unswap(null, false);
 
                         val = this.val;
+
+                        if (val != null && tx == null)
+                            updatePlatformCache(val, topVer);
                     }
                 }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/PlatformContextImpl.java
@@ -607,7 +607,7 @@ public class PlatformContextImpl implements PlatformContext, PartitionsExchangeA
 
         Boolean useTls = platformCacheUpdateUseThreadLocal.get();
         if (useTls != null && useTls) {
-            long cacheIdAndPartition = ((long)part << 32) + cacheId;
+            long cacheIdAndPartition = ((long)part << 32) | cacheId;
 
             gateway().platformCacheUpdateFromThreadLocal(
                     cacheIdAndPartition, ver.topologyVersion(), ver.minorTopologyVersion());
@@ -681,7 +681,7 @@ public class PlatformContextImpl implements PlatformContext, PartitionsExchangeA
     }
 
     /** {@inheritDoc} */
-    @Override public void onDoneAfterTopologyUnlock(GridDhtPartitionsExchangeFuture fut) {
+    @Override public void onDoneBeforeTopologyUnlock(GridDhtPartitionsExchangeFuture fut) {
         AffinityTopologyVersion ver = fut.topologyVersion();
 
         if (ver != null) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/PlatformCache.java
@@ -376,6 +376,9 @@ public class PlatformCache extends PlatformAbstractTarget {
     /** */
     public static final int OP_INVOKE_JAVA = 98;
 
+    /** */
+    public static final int OP_PERSISTENCE_ENABLED = 99;
+
     /** Underlying JCache in binary mode. */
     private final IgniteCacheProxy cache;
 
@@ -1264,6 +1267,9 @@ public class PlatformCache extends PlatformAbstractTarget {
 
                 return FALSE;
             }
+
+            case OP_PERSISTENCE_ENABLED:
+                return cache.context().group().persistenceEnabled() ? TRUE : FALSE;
         }
         return super.processInLongOutLong(type, val);
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Cache\Platform\PlatformCacheTestCreateDestroy.cs" />
     <Compile Include="Cache\Platform\PlatformCacheTopologyChangeTest.cs" />
     <Compile Include="Cache\Platform\PlatformCacheTest.cs" />
+    <Compile Include="Cache\Platform\PlatformCacheWithPersistenceTest.cs" />
     <Compile Include="Cache\Platform\FailingCacheStore.cs" />
     <Compile Include="Cache\Platform\Foo.cs" />
     <Compile Include="Cache\Platform\ScanQueryPlatformCacheFilter.cs" />
@@ -625,7 +626,7 @@
   <Target Name="AfterBuild">
     <Copy SourceFiles="$(SolutionDir)Apache.Ignite\bin\$(ConfigurationName)\Apache.Ignite.exe;$(SolutionDir)Apache.Ignite\bin\$(ConfigurationName)\Apache.Ignite.exe.config" DestinationFolder="$(ProjectDir)$(OutDir)" SkipUnchangedFiles="false" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheWithPersistenceTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheWithPersistenceTest.cs
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheWithPersistenceTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Platform/PlatformCacheWithPersistenceTest.cs
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Cache.Platform
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Configuration;
+    using Apache.Ignite.Core.Cache.Query;
+    using Apache.Ignite.Core.Configuration;
+    using Apache.Ignite.Core.Impl.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests platform cache with native persistence.
+    /// </summary>
+    public class PlatformCacheWithPersistenceTest
+    {
+        /** Cache name. */
+        private const string CacheName = "persistentCache";
+
+        /** Entry count. */
+        private const int Count = 100;
+
+        /** Temp dir for WAL. */
+        private readonly string _tempDir = PathUtils.GetTempDirectoryName();
+
+        /** Cache. */
+        private ICache<int,int> _cache;
+
+        /** Current key. Every test needs a key that was not used before. */
+        private int _key = 1;
+
+        /// <summary>
+        /// Sets up the test.
+        /// </summary>
+        [TestFixtureSetUp]
+        public void FixtureSetUp()
+        {
+            TestUtils.ClearWorkDir();
+
+            // Start Ignite, put data, stop.
+            using (var ignite = StartServer())
+            {
+                var cache = ignite.GetCache<int, int>(CacheName);
+
+                cache.PutAll(Enumerable.Range(1, Count).ToDictionary(x => x, x => x));
+
+                Assert.AreEqual(Count, cache.GetSize());
+                Assert.AreEqual(Count, cache.GetLocalSize(CachePeekMode.Platform));
+            }
+
+            // Start again to test persistent data restore.
+            var ignite2 = StartServer();
+            _cache = ignite2.GetCache<int, int>(CacheName);
+
+            // Platform cache is empty initially, because all entries are only on disk.
+            Assert.AreEqual(Count, _cache.GetSize());
+            Assert.AreEqual(0, _cache.GetLocalSize(CachePeekMode.Platform));
+        }
+
+        /// <summary>
+        /// Tears down the test.
+        /// </summary>
+        [TestFixtureTearDown]
+        public void TearDown()
+        {
+            Ignition.StopAll(true);
+
+            if (Directory.Exists(_tempDir))
+            {
+                Directory.Delete(_tempDir, true);
+            }
+
+            TestUtils.ClearWorkDir();
+        }
+
+        /// <summary>
+        /// Tests get operation.
+        /// </summary>
+        [Test]
+        public void TestGetRestoresPlatformCacheDataFromPersistence()
+        {
+            TestCacheOperation(k => _cache.Get(k));
+        }
+
+        /// <summary>
+        /// Tests getAll operation.
+        /// </summary>
+        [Test]
+        public void TestGetAllRestoresPlatformCacheDataFromPersistence()
+        {
+            TestCacheOperation(k => _cache.GetAll(new[] { k }));
+        }
+
+        /// <summary>
+        /// Tests containsKey operation.
+        /// </summary>
+        [Test]
+        public void TestContainsKeyRestoresPlatformCacheDataFromPersistence()
+        {
+            TestCacheOperation(k => _cache.ContainsKey(k));
+        }
+
+        /// <summary>
+        /// Tests containsKeys operation.
+        /// </summary>
+        [Test]
+        public void TestContainsKeysRestoresPlatformCacheDataFromPersistence()
+        {
+            TestCacheOperation(k => _cache.ContainsKeys(new[] { k }));
+        }
+
+        /// <summary>
+        /// Tests put operation.
+        /// </summary>
+        [Test]
+        public void TestPutUpdatesPlatformCache()
+        {
+            TestCacheOperation(k => _cache.Put(k, -k), k => -k);
+        }
+
+        /// <summary>
+        /// Tests getAndPut operation.
+        /// </summary>
+        [Test]
+        public void TestGetAndPutUpdatesPlatformCache()
+        {
+            TestCacheOperation(k => _cache.GetAndPut(k, -k), k => -k);
+        }
+
+        /// <summary>
+        /// Tests that local partition scan optimization is disabled when persistence is enabled.
+        /// See <see cref="CacheImpl{TK,TV}.ScanPlatformCache"/>.
+        /// </summary>
+        [Test]
+        public void TestScanQueryLocalPartitionScanOptimizationDisabledWithPersistence()
+        {
+            var res = _cache.Query(new ScanQuery<int, int>()).GetAll();
+            Assert.AreEqual(Count, res.Count);
+
+            var resLocal = _cache.Query(new ScanQuery<int, int> { Local = true }).GetAll();
+            Assert.AreEqual(Count, resLocal.Count);
+
+            var resPartition = _cache.Query(new ScanQuery<int, int> { Partition = 99 }).GetAll();
+            Assert.AreEqual(1, resPartition.Count);
+
+            var resLocalPartition = _cache.Query(new ScanQuery<int, int> { Local = true, Partition = 99 }).GetAll();
+            Assert.AreEqual(1, resLocalPartition.Count);
+        }
+
+        /// <summary>
+        /// Tests that scan query with filter does not need platform cache data to return correct results.
+        /// </summary>
+        [Test]
+        public void TestScanQueryWithFilterUsesPersistentData()
+        {
+            var res = _cache.Query(new ScanQuery<int, int> { Filter = new EvenValueFilter() }).GetAll();
+            Assert.AreEqual(Count / 2, res.Count);
+        }
+
+        /// <summary>
+        /// Starts the node.
+        /// </summary>
+        private IIgnite StartServer()
+        {
+            var ignite = Ignition.Start(GetIgniteConfiguration());
+
+            ignite.GetCluster().SetActive(true);
+
+            return ignite;
+        }
+
+        /// <summary>
+        /// Gets the configuration.
+        /// </summary>
+        private IgniteConfiguration GetIgniteConfiguration()
+        {
+            return new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                DataStorageConfiguration = new DataStorageConfiguration
+                {
+                    StoragePath = Path.Combine(_tempDir, "Store"),
+                    WalPath = Path.Combine(_tempDir, "WalStore"),
+                    WalArchivePath = Path.Combine(_tempDir, "WalArchive"),
+                    DefaultDataRegionConfiguration = new DataRegionConfiguration
+                    {
+                        Name = DataStorageConfiguration.DefaultDataRegionName,
+                        PersistenceEnabled = true
+                    }
+                },
+                CacheConfiguration = new[]
+                {
+                    new CacheConfiguration
+                    {
+                        Name = CacheName,
+                        PlatformCacheConfiguration = new PlatformCacheConfiguration()
+                    }
+                }
+            };
+        }
+
+        /// <summary>
+        /// Tests that cache operation causes platform cache to be populated for the key.
+        /// </summary>
+        private void TestCacheOperation(Action<int> operation, Func<int, int> expectedFunc = null)
+        {
+            var k = _key++;
+            operation(k);
+
+            var expected = expectedFunc == null ? k : expectedFunc(k);
+            Assert.AreEqual(expected, _cache.LocalPeek(k, CachePeekMode.Platform));
+        }
+
+        private class EvenValueFilter : ICacheEntryFilter<int, int>
+        {
+            public bool Invoke(ICacheEntry<int, int> entry)
+            {
+                return entry.Value % 2 == 0;
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/IgniteExceptionTaskSelfTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/IgniteExceptionTaskSelfTest.cs
@@ -241,11 +241,11 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             _mode = ErrorMode.RmtResErrNotMarshalable;
 
-            BadException e = ExecuteWithError() as BadException;
+            var err = ExecuteWithError();
+            var badException = err as BadException;
 
-            Assert.IsNotNull(e);
-
-            Assert.AreEqual(ErrorMode.RmtResErrNotMarshalable, e.Mode);
+            Assert.IsNotNull(badException, err.ToString());
+            Assert.AreEqual(ErrorMode.RmtResErrNotMarshalable, badException.Mode);
         }
 
         /// <summary>
@@ -358,7 +358,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             RmtJobErrNotMarshalable,
 
             /** Remote job result is not marshalable. */
-            RmtJobResNotMarshalable,            
+            RmtJobResNotMarshalable,
 
             /** Error occurred during local result processing. */
             LocResErr,
@@ -488,7 +488,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Serializable]
         private class GoodJob : IComputeJob<object>, ISerializable
@@ -497,7 +497,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             private readonly bool _rmt;
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="rmt"></param>
             public GoodJob(bool rmt)
@@ -506,7 +506,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             }
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="info"></param>
             /// <param name="context"></param>
@@ -564,7 +564,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private class BadJob : IComputeJob<object>, IBinarizable
         {
@@ -594,16 +594,16 @@ namespace Apache.Ignite.Core.Tests.Compute
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Serializable]
         private class GoodJobResult : ISerializable
         {
             /** */
             public readonly bool Rmt;
-            
+
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="rmt"></param>
             public GoodJobResult(bool rmt)
@@ -612,7 +612,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             }
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="info"></param>
             /// <param name="context"></param>
@@ -629,7 +629,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private class BadJobResult : IBinarizable
         {
@@ -637,7 +637,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             public readonly bool Rmt;
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="rmt"></param>
             public BadJobResult(bool rmt)
@@ -659,7 +659,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         [Serializable]
         private class GoodTaskResult : ISerializable
@@ -668,7 +668,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             public readonly int Res;
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="res"></param>
             public GoodTaskResult(int res)
@@ -677,7 +677,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             }
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="info"></param>
             /// <param name="context"></param>
@@ -694,7 +694,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         private class BadTaskResult
         {
@@ -702,7 +702,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             public readonly int Res;
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="res"></param>
             public BadTaskResult(int res)
@@ -719,9 +719,9 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             /** */
             public readonly ErrorMode Mode;
-            
+
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="mode"></param>
             public GoodException(ErrorMode mode)
@@ -730,7 +730,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             }
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="info"></param>
             /// <param name="context"></param>
@@ -757,7 +757,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             public readonly ErrorMode Mode;
 
             /// <summary>
-            /// 
+            ///
             /// </summary>
             /// <param name="mode"></param>
             public BadException(ErrorMode mode)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/CacheOp.cs
@@ -116,6 +116,7 @@ namespace Apache.Ignite.Core.Impl.Cache
         ClearStatistics = 94,
         PutWithPlatformCache = 95,
         ReservePartition = 96,
-        ReleasePartition = 97
+        ReleasePartition = 97,
+        PersistenceEnabled = 99
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Platform/PlatformCache.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Platform/PlatformCache.cs
@@ -237,17 +237,15 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
             var currentVerBoxed = _affinityTopologyVersionFunc();
             var entryVerBoxed = entry.Version;
 
-            Debug.Assert(currentVerBoxed != null);
+            if (entryVerBoxed == null || currentVerBoxed == null)
+            {
+                return false;
+            }
 
             if (ReferenceEquals(currentVerBoxed, entryVerBoxed))
             {
                 // Happy path: true on stable topology.
                 return true;
-            }
-
-            if (entryVerBoxed == null)
-            {
-                return false;
             }
 
             var entryVer = (AffinityTopologyVersion) entryVerBoxed;
@@ -273,7 +271,10 @@ namespace Apache.Ignite.Core.Impl.Cache.Platform
         private object GetBoxedAffinityTopologyVersion(AffinityTopologyVersion ver)
         {
             var currentVerBoxed = _affinityTopologyVersionFunc();
-            return (AffinityTopologyVersion) currentVerBoxed == ver ? currentVerBoxed : ver;
+
+            return currentVerBoxed != null && (AffinityTopologyVersion) currentVerBoxed == ver
+                ? currentVerBoxed
+                : ver;
         }
     }
 }


### PR DESCRIPTION
* Disable `readNoEntry` optimization when platform cache is enabled so that `GridCacheMapEntry` gets created and updates platform cache after node restart.
* Update platform cache when entry is initially unswapped from storage.
* Fix `cacheIdAndPartition` bitwise combination.
* Use `onDoneBeforeTopologyUnlock` instead of `onDoneAfterTopologyUnlock` to update platform cache topology version earlier and avoid null value on node start.
* Disable local partition scan optimization (IGNITE-12882) when persistence is enabled - there is no guarantee that all entries are in memory.