### PR TITLE
GG-34170 C++ thin: SSL certificates, keys and CA are not mandatory

### DIFF
--- a/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
@@ -109,28 +109,11 @@ namespace ignite
         IGNITE_IMPORT_EXPORT unsigned GetRandSeed();
 
         /**
-         * Try extract from system error stack, format and return platform-specific error.
+         * Try extract from system error stack, and return platform-specific error.
          *
-         * @param description Error description.
-         * @param advice User advice.
          * @return Error in human-readable format.
          */
-        IGNITE_IMPORT_EXPORT std::string GetLastSystemError(const std::string& description, const std::string& advice);
-
-        /**
-         * Try extract from system error stack and throw platform-specific error.
-         *
-         * @param description Error description.
-         * @param advice User advice.
-         */
-        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description, const std::string& advice);
-
-        /**
-         * Try extract from system error stack and throw platform-specific error.
-         *
-         * @param description Error description.
-         */
-        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description);
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError();
     }
 }
 

--- a/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/platform_utils.h
@@ -107,6 +107,30 @@ namespace ignite
          * @return Random seed.
          */
         IGNITE_IMPORT_EXPORT unsigned GetRandSeed();
+
+        /**
+         * Try extract from system error stack, format and return platform-specific error.
+         *
+         * @param description Error description.
+         * @param advice User advice.
+         * @return Error in human-readable format.
+         */
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError(const std::string& description, const std::string& advice);
+
+        /**
+         * Try extract from system error stack and throw platform-specific error.
+         *
+         * @param description Error description.
+         * @param advice User advice.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description, const std::string& advice);
+
+        /**
+         * Try extract from system error stack and throw platform-specific error.
+         *
+         * @param description Error description.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description);
     }
 }
 

--- a/modules/platforms/cpp/common/include/ignite/common/utils.h
+++ b/modules/platforms/cpp/common/include/ignite/common/utils.h
@@ -660,6 +660,55 @@ namespace ignite
             /** Sequence of fibonacci numbers */
             size_t sequence[size];
         };
+
+        /**
+         * Throw platform-specific error.
+         *
+         * @param msg Error message.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowSystemError(const std::string& msg);
+
+        /**
+         * Try extract from system error stack and throw platform-specific error.
+         *
+         * @param description Error description.
+         * @param advice User advice.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description, const std::string& advice);
+
+        /**
+         * Try extract from system error stack and throw platform-specific error.
+         *
+         * @param description Error description.
+         */
+        IGNITE_IMPORT_EXPORT void ThrowLastSystemError(const std::string& description);
+
+        /**
+         * Format error message.
+         *
+         * @param description Error description.
+         * @param description Error details.
+         * @param advice User advice.
+         */
+        IGNITE_IMPORT_EXPORT std::string FormatErrorMessage(const std::string& description, const std::string& details,
+            const std::string& advice);
+
+        /**
+         * Try extract from system error stack, format and return platform-specific error.
+         *
+         * @param description Error description.
+         * @return Error in human-readable format.
+         */
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError(const std::string& description);
+
+        /**
+         * Try extract from system error stack, format and return platform-specific error.
+         *
+         * @param description Error description.
+         * @param advice User advice.
+         * @return Error in human-readable format.
+         */
+        IGNITE_IMPORT_EXPORT std::string GetLastSystemError(const std::string& description, const std::string& advice);
     }
 }
 

--- a/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
@@ -22,8 +22,9 @@
 #include <dirent.h>
 #include <dlfcn.h>
 #include <glob.h>
-#include <unistd.h>
 #include <ftw.h>
+#include <unistd.h>
+#include <errno.h>
 
 #include <ignite/common/utils.h>
 
@@ -118,7 +119,7 @@ namespace ignite
             return ostr;
         }
 
-        IGNITE_IMPORT_EXPORT unsigned GetRandSeed()
+        unsigned GetRandSeed()
         {
             timespec ts;
 
@@ -129,6 +130,23 @@ namespace ignite
             res ^= static_cast<unsigned>(getpid());
 
             return res;
+        }
+
+        std::string GetLastSystemError()
+        {
+            int errorCode = errno;
+
+            std::string errorDetails;
+            if (errorCode != 0)
+            {
+                char errBuf[1024] = { 0 };
+
+                strerror_r(errorCode, errBuf, sizeof(errBuf));
+
+                errorDetails.assign(errBuf);
+            }
+
+            return errorDetails;
         }
     }
 }

--- a/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/linux/src/common/platform_utils.cpp
@@ -141,9 +141,9 @@ namespace ignite
             {
                 char errBuf[1024] = { 0 };
 
-                strerror_r(errorCode, errBuf, sizeof(errBuf));
-
-                errorDetails.assign(errBuf);
+                const char* res = strerror_r(errorCode, errBuf, sizeof(errBuf));
+                if (res)
+                    errorDetails.assign(res);
             }
 
             return errorDetails;

--- a/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
@@ -178,7 +178,7 @@ namespace ignite
             return static_cast<unsigned>(GetTickCount() ^ GetCurrentProcessId());
         }
 
-        std::string GetLastSystemError(const std::string& description, const std::string& advice)
+        std::string GetLastSystemError()
         {
             DWORD errorCode = GetLastError();
 
@@ -194,26 +194,7 @@ namespace ignite
                 errorDetails.assign(errBuf);
             }
 
-            std::stringstream messageBuilder;
-            messageBuilder << description;
-            if (!errorDetails.empty())
-                messageBuilder << ": " << errorDetails;
-
-            if (!advice.empty())
-                messageBuilder << ". " << advice;
-
-            return messageBuilder.str();
-        }
-
-        void ThrowLastSystemError(const std::string& description, const std::string& advice)
-        {
-            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, GetLastSystemError(description, advice).c_str());
-        }
-
-        void ThrowLastSystemError(const std::string& description)
-        {
-            std::string empty;
-            ThrowLastSystemError(description, empty);
+            return errorDetails;
         }
     }
 }

--- a/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
@@ -16,9 +16,11 @@
 
 #include <time.h>
 #include <vector>
+#include <sstream>
 
 #include <windows.h>
 
+#include <ignite/ignite_error.h>
 #include <ignite/common/platform_utils.h>
 
 // Original code is suggested by MSDN at
@@ -171,9 +173,47 @@ namespace ignite
             return ostr;
         }
 
-        IGNITE_IMPORT_EXPORT unsigned GetRandSeed()
+        unsigned GetRandSeed()
         {
             return static_cast<unsigned>(GetTickCount() ^ GetCurrentProcessId());
+        }
+
+        std::string GetLastSystemError(const std::string& description, const std::string& advice)
+        {
+            DWORD errorCode = GetLastError();
+
+            std::string errorDetails;
+            if (errorCode != ERROR_SUCCESS)
+            {
+                char errBuf[1024] = { 0 };
+
+                FormatMessageA(
+                        FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL, errorCode,
+                        MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), errBuf, sizeof(errBuf), NULL);
+
+                errorDetails.assign(errBuf);
+            }
+
+            std::stringstream messageBuilder;
+            messageBuilder << description;
+            if (!errorDetails.empty())
+                messageBuilder << ": " << errorDetails;
+
+            if (!advice.empty())
+                messageBuilder << ". " << advice;
+
+            return messageBuilder.str();
+        }
+
+        void ThrowLastSystemError(const std::string& description, const std::string& advice)
+        {
+            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, GetLastSystemError(description, advice).c_str());
+        }
+
+        void ThrowLastSystemError(const std::string& description)
+        {
+            std::string empty;
+            ThrowLastSystemError(description, empty);
         }
     }
 }

--- a/modules/platforms/cpp/common/src/common/utils.cpp
+++ b/modules/platforms/cpp/common/src/common/utils.cpp
@@ -15,7 +15,9 @@
  */
 
 #include <iomanip>
+#include <sstream>
 
+#include <ignite/ignite_error.h>
 #include <ignite/common/utils.h>
 
 namespace ignite
@@ -170,6 +172,47 @@ namespace ignite
                 dump << std::hex << std::setfill('0') << std::setw(2) << (int)*p << " ";
             }
             return dump.str();
+        }
+
+        void ThrowSystemError(const std::string &msg)
+        {
+            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, msg.c_str());
+        }
+
+        void ThrowLastSystemError(const std::string& description, const std::string& advice)
+        {
+            ThrowSystemError(GetLastSystemError(description, advice));
+        }
+
+        void ThrowLastSystemError(const std::string& description)
+        {
+            std::string empty;
+            ThrowLastSystemError(description, empty);
+        }
+
+        std::string FormatErrorMessage(const std::string &description, const std::string &details,
+            const std::string &advice)
+        {
+            std::stringstream messageBuilder;
+            messageBuilder << description;
+            if (!details.empty())
+                messageBuilder << ": " << details;
+
+            if (!advice.empty())
+                messageBuilder << ". " << advice;
+
+            return messageBuilder.str();
+        }
+
+        std::string GetLastSystemError(const std::string& description, const std::string& advice)
+        {
+            return common::FormatErrorMessage(description, GetLastSystemError(), advice);
+        }
+
+        std::string GetLastSystemError(const std::string &description)
+        {
+            std::string empty;
+            return GetLastSystemError(description, empty);
         }
 
     }

--- a/modules/platforms/cpp/core-test/CMakeLists.txt
+++ b/modules/platforms/cpp/core-test/CMakeLists.txt
@@ -27,7 +27,8 @@ find_package(Boost 1.53 REQUIRED COMPONENTS unit_test_framework chrono thread sy
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 include_directories(include)
 
-set(SOURCES src/reference_test.cpp
+set(SOURCES
+        src/reference_test.cpp
         src/bits_test.cpp
         src/binary_identity_resolver_test.cpp
         src/cache_test.cpp

--- a/modules/platforms/cpp/core-test/project/vs/core-test.vcxproj
+++ b/modules/platforms/cpp/core-test/project/vs/core-test.vcxproj
@@ -85,6 +85,7 @@
     <ClCompile Include="..\..\src\cluster_group_test.cpp" />
     <ClCompile Include="..\..\src\cluster_node_test.cpp" />
     <ClCompile Include="..\..\src\cluster_test.cpp" />
+    <ClCompile Include="..\..\src\compute_java_test.cpp" />
     <ClCompile Include="..\..\src\compute_test.cpp" />
     <ClCompile Include="..\..\src\concurrent_test.cpp" />
     <ClCompile Include="..\..\src\date_time_test.cpp" />

--- a/modules/platforms/cpp/core-test/project/vs/core-test.vcxproj.filters
+++ b/modules/platforms/cpp/core-test/project/vs/core-test.vcxproj.filters
@@ -91,9 +91,6 @@
     <ClCompile Include="..\..\src\compute_java_test.cpp">
       <Filter>Code</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\src\compute_java_test.cpp">
-      <Filter>Code</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\src\cluster_group_test.cpp">
       <Filter>Code</Filter>
     </ClCompile>

--- a/modules/platforms/cpp/network/CMakeLists.txt
+++ b/modules/platforms/cpp/network/CMakeLists.txt
@@ -83,7 +83,7 @@ foreach(_target_lib IN LISTS _target_libs)
     endif()
 
     if (WIN32)
-        target_link_libraries(${_target_lib} wsock32 ws2_32 iphlpapi)
+        target_link_libraries(${_target_lib} wsock32 ws2_32 iphlpapi crypt32)
     endif()
 
     target_include_directories(${_target_lib} INTERFACE include ${OS_INCLUDE})

--- a/modules/platforms/cpp/network/CMakeLists.txt
+++ b/modules/platforms/cpp/network/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
         src/network/network.cpp
         src/network/ssl/secure_data_filter.cpp
         src/network/ssl/secure_socket_client.cpp
+        src/network/ssl/secure_utils.cpp
         src/network/ssl/ssl_gateway.cpp)
 
 if (WIN32)

--- a/modules/platforms/cpp/network/Makefile.am
+++ b/modules/platforms/cpp/network/Makefile.am
@@ -65,6 +65,7 @@ libignite_network_la_SOURCES = \
 	src/network/network.cpp \
 	src/network/ssl/secure_data_filter.cpp \
 	src/network/ssl/secure_socket_client.cpp \
+    src/network/ssl/secure_utils.cpp \
 	src/network/ssl/ssl_gateway.cpp
 
 clean-local:

--- a/modules/platforms/cpp/network/include/Makefile.am
+++ b/modules/platforms/cpp/network/include/Makefile.am
@@ -28,6 +28,7 @@ nobase_include_HEADERS = \
 	ignite/network/length_prefix_codec.h \
 	ignite/network/network.h \
 	ignite/network/socket_client.h \
+	ignite/network/ssl/secure_configuration.h \
 	ignite/network/ssl/secure_data_filter.h \
 	ignite/network/tcp_range.h \
 	ignite/network/utils.h

--- a/modules/platforms/cpp/network/include/ignite/network/network.h
+++ b/modules/platforms/cpp/network/include/ignite/network/network.h
@@ -22,6 +22,7 @@
 #include <ignite/common/common.h>
 #include <ignite/network/socket_client.h>
 #include <ignite/network/async_client_pool.h>
+#include <ignite/network/ssl/secure_configuration.h>
 
 namespace ignite
 {
@@ -42,14 +43,11 @@ namespace ignite
             /**
              * Make secure socket for SSL/TLS connection.
              *
-             * @param certPath Certificate file path.
-             * @param keyPath Private key file path.
-             * @param caPath Certificate authority file path.
+             * @param cfg Configuration.
              *
              * @throw IgniteError if it is not possible to load SSL library.
              */
-            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const std::string& certPath,
-                const std::string& keyPath, const std::string& caPath);
+            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const SecureConfiguration& cfg);
         }
 
         /**

--- a/modules/platforms/cpp/network/include/ignite/network/ssl/secure_configuration.h
+++ b/modules/platforms/cpp/network/include/ignite/network/ssl/secure_configuration.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_NETWORK_SSL_SECURE_CONFIGURATION
+#define _IGNITE_NETWORK_SSL_SECURE_CONFIGURATION
+
+#include <string>
+
+namespace ignite
+{
+    namespace network
+    {
+        namespace ssl
+        {
+            /**
+             * TLS/SSL configuration parameters.
+             */
+            struct SecureConfiguration
+            {
+                /** Path to file containing security certificate to use. */
+                std::string certPath;
+
+                /** Path to file containing private key to use. */
+                std::string keyPath;
+
+                /** Path to file containing Certificate authority to use. */
+                std::string caPath;
+            };
+        }
+    }
+}
+
+#endif //_IGNITE_NETWORK_SSL_SECURE_CONFIGURATION

--- a/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
+++ b/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
@@ -21,7 +21,7 @@
 
 #include <ignite/common/concurrent.h>
 #include <ignite/network/data_filter_adapter.h>
-
+#include <ignite/network/ssl/secure_configuration.h>
 
 namespace ignite
 {
@@ -29,21 +29,6 @@ namespace ignite
     {
         namespace ssl
         {
-            /**
-             * TLS/SSL configuration parameters.
-             */
-            struct SecureConfiguration
-            {
-                /** Path to file containing security certificate to use. */
-                std::string certPath;
-
-                /** Path to file containing private key to use. */
-                std::string keyPath;
-
-                /** Path to file containing Certificate authority to use. */
-                std::string caPath;
-            };
-
             /**
              * TLS/SSL Data Filter.
              */

--- a/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
+++ b/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
@@ -122,8 +122,10 @@ namespace ignite
 
                     /**
                      * Start connection procedure including handshake.
+                     *
+                     * @return @c true, if connection complete.
                      */
-                    void DoConnect();
+                    bool DoConnect();
 
                     /**
                      * Check whether connection is established.

--- a/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
+++ b/modules/platforms/cpp/network/include/ignite/network/ssl/secure_data_filter.h
@@ -225,9 +225,6 @@ namespace ignite
                  */
                 bool SendInternal(uint64_t id, const DataBuffer& data);
 
-                /** Secure configuration. */
-                const SecureConfiguration cfg;
-
                 /** SSL context. */
                 void* sslContext;
 

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_client.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_client.cpp
@@ -70,17 +70,15 @@ namespace ignite
 
         bool LinuxAsyncClient::Close()
         {
-            State::Type stateBefore = state;
+            if (State::CLOSED == state)
+                return false;
 
-            if (state != State::CLOSED)
-            {
-                StopMonitoring();
-                close(fd);
-                fd = -1;
-                state = State::CLOSED;
-            }
+            StopMonitoring();
+            close(fd);
+            fd = -1;
+            state = State::CLOSED;
 
-            return stateBefore == State::CONNECTED;
+            return true;
         }
 
         bool LinuxAsyncClient::Send(const DataBuffer& data)

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.cpp
@@ -238,7 +238,7 @@ namespace ignite
                     HandleConnectionSuccess(client);
                 }
 
-                if (currentEvent.events & (EPOLLRDHUP | EPOLLERR))
+                if (currentEvent.events & (EPOLLRDHUP | EPOLLERR | EPOLLHUP))
                 {
                     HandleConnectionClosed(client);
 
@@ -297,8 +297,7 @@ namespace ignite
 
             nonConnected.push_back(client->GetRange());
 
-            IgniteError err(IgniteError::IGNITE_ERR_NETWORK_FAILURE, "Connection closed");
-            clientPool.CloseAndRelease(client->GetId(), &err);
+            clientPool.CloseAndRelease(client->GetId(), 0);
         }
 
         void LinuxAsyncWorkerThread::HandleConnectionSuccess(LinuxAsyncClient* client)

--- a/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.h
+++ b/modules/platforms/cpp/network/os/linux/src/network/linux_async_worker_thread.h
@@ -134,13 +134,6 @@ namespace ignite
              */
             bool ShouldInitiateNewConnection() const;
 
-            /**
-             * Throw window specific error with error code.
-             *
-             * @param msg Error message.
-             */
-            void ThrowSystemError(const std::string &msg);
-
             /** Client pool. */
             LinuxAsyncClientPool& clientPool;
 

--- a/modules/platforms/cpp/network/os/linux/src/network/sockets.cpp
+++ b/modules/platforms/cpp/network/os/linux/src/network/sockets.cpp
@@ -59,10 +59,11 @@ namespace ignite
                 if (error == 0)
                     return res.str();
 
-                char buffer[1024] = "";
+                char errBuf[1024] = { 0 };
 
-                if (!strerror_r(error, buffer, sizeof(buffer)))
-                    res << ", msg=" << buffer;
+                const char* errStr = strerror_r(error, errBuf, sizeof(errBuf));
+                if (errStr)
+                    res << ", msg=" << errStr;
 
                 return res.str();
             }

--- a/modules/platforms/cpp/network/os/win/src/network/utils.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/utils.cpp
@@ -24,6 +24,7 @@
 #include <ws2ipdef.h>
 #include <ws2tcpip.h>
 #include <windows.h>
+#include <winbase.h>
 #include <iphlpapi.h>
 
 #include <ignite/ignite_error.h>

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client.cpp
@@ -57,7 +57,6 @@ namespace ignite
             if (State::CONNECTED != state && State::IN_POOL != state)
                 return false;
 
-            std::cout << "------------- Shutdown" << std::endl;
             closeErr = err ? *err : IgniteError(IgniteError::IGNITE_ERR_GENERIC, "Connection closed by application");
 
             shutdown(socket, SD_BOTH);
@@ -72,7 +71,6 @@ namespace ignite
             if (State::CLOSED == state)
                 return false;
 
-            std::cout << "------------- Close" << std::endl;
             closesocket(socket);
 
             sendPackets.clear();

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client.cpp
@@ -18,8 +18,6 @@
 
 #include <ignite/network/utils.h>
 
-#include <ignite/impl/binary/binary_utils.h>
-
 #include "network/sockets.h"
 #include "network/win_async_client.h"
 
@@ -27,7 +25,7 @@ namespace ignite
 {
     namespace network
     {
-        WinAsyncClient::WinAsyncClient(SOCKET socket, const EndPoint &addr, const TcpRange& range, int32_t bufLen) :
+        WinAsyncClient::WinAsyncClient(SOCKET socket, const EndPoint& addr, const TcpRange& range, int32_t bufLen) :
             bufLen(bufLen),
             state(State::CONNECTED),
             socket(socket),
@@ -59,6 +57,7 @@ namespace ignite
             if (State::CONNECTED != state && State::IN_POOL != state)
                 return false;
 
+            std::cout << "------------- Shutdown" << std::endl;
             closeErr = err ? *err : IgniteError(IgniteError::IGNITE_ERR_GENERIC, "Connection closed by application");
 
             shutdown(socket, SD_BOTH);
@@ -73,6 +72,7 @@ namespace ignite
             if (State::CLOSED == state)
                 return false;
 
+            std::cout << "------------- Close" << std::endl;
             closesocket(socket);
 
             sendPackets.clear();

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.cpp
@@ -55,7 +55,7 @@ namespace ignite
 
             iocp = CreateIoCompletionPort(INVALID_HANDLE_VALUE, NULL, 0, 0);
             if (iocp == NULL)
-                ThrowSystemError("Failed to create IOCP instance");
+                common::ThrowLastSystemError("Failed to create IOCP instance");
 
             try
             {
@@ -117,7 +117,7 @@ namespace ignite
 
                 HANDLE iocp0 = clientRef.AddToIocp(iocp);
                 if (iocp0 == NULL)
-                    ThrowSystemError("Can not add socket to IOCP");
+                    common::ThrowLastSystemError("Can not add socket to IOCP");
 
                 iocp = iocp0;
 
@@ -212,15 +212,6 @@ namespace ignite
             SP_WinAsyncClient client = FindClient(id);
             if (client.IsValid() && !client.Get()->IsClosed())
                 client.Get()->Shutdown(err);
-        }
-
-        void WinAsyncClientPool::ThrowSystemError(const std::string& msg)
-        {
-            std::stringstream buf;
-
-            buf << "Windows system error: " << msg << ", system error code: " << GetLastError();
-
-            throw IgniteError(IgniteError::IGNITE_ERR_GENERIC, buf.str().c_str());
         }
 
         SP_WinAsyncClient WinAsyncClientPool::FindClient(uint64_t id) const

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.cpp
@@ -210,7 +210,7 @@ namespace ignite
         void WinAsyncClientPool::Close(uint64_t id, const IgniteError* err)
         {
             SP_WinAsyncClient client = FindClient(id);
-            if (client.IsValid() && client.Get()->IsClosed())
+            if (client.IsValid() && !client.Get()->IsClosed())
                 client.Get()->Shutdown(err);
         }
 

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.h
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_client_pool.h
@@ -177,13 +177,6 @@ namespace ignite
              */
             SP_WinAsyncClient FindClientLocked(uint64_t id) const;
 
-            /**
-             * Throw window specific error with error code.
-             *
-             * @param msg Error message.
-             */
-            static void ThrowSystemError(const std::string& msg);
-
             /** Flag indicating that pool is stopping. */
             volatile bool stopping;
 

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_worker_thread.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_worker_thread.cpp
@@ -62,8 +62,6 @@ namespace ignite
 
                 BOOL ok = GetQueuedCompletionStatus(iocp, &bytesTransferred, &key, &overlapped, INFINITE);
 
-                std::cout << "------------- Event << bytesTransferred=" << bytesTransferred << std::endl;
-
                 if (stopping)
                     break;
 

--- a/modules/platforms/cpp/network/os/win/src/network/win_async_worker_thread.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/win_async_worker_thread.cpp
@@ -62,6 +62,8 @@ namespace ignite
 
                 BOOL ok = GetQueuedCompletionStatus(iocp, &bytesTransferred, &key, &overlapped, INFINITE);
 
+                std::cout << "------------- Event << bytesTransferred=" << bytesTransferred << std::endl;
+
                 if (stopping)
                     break;
 
@@ -113,7 +115,10 @@ namespace ignite
                             if (!data.IsEmpty())
                                 clientPool->HandleMessageReceived(client->GetId(), data);
 
-                            client->Receive();
+                            bool success = client->Receive();
+
+                            if (!success)
+                                clientPool->CloseAndRelease(client->GetId(), 0);
 
                             break;
                         }

--- a/modules/platforms/cpp/network/project/vs/network.vcxproj
+++ b/modules/platforms/cpp/network/project/vs/network.vcxproj
@@ -185,6 +185,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\include\ignite\network\ssl\secure_configuration.h" />
     <ClInclude Include="..\..\include\ignite\network\ssl\secure_data_filter.h" />
     <ClInclude Include="..\..\include\ignite\network\async_client_pool.h" />
     <ClInclude Include="..\..\include\ignite\network\async_handler.h" />

--- a/modules/platforms/cpp/network/project/vs/network.vcxproj
+++ b/modules/platforms/cpp/network/project/vs/network.vcxproj
@@ -231,7 +231,7 @@
     <ClCompile Include="..\..\src\network\ssl\secure_data_filter.cpp" />
     <ClCompile Include="..\..\src\network\ssl\secure_socket_client.cpp" />
     <ClCompile Include="..\..\src\network\ssl\ssl_gateway.cpp" />
-    <ClCompile Include="..\..\src\network\ssl\ssl_utils.cpp" />
+    <ClCompile Include="..\..\src\network\ssl\secure_utils.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/modules/platforms/cpp/network/project/vs/network.vcxproj
+++ b/modules/platforms/cpp/network/project/vs/network.vcxproj
@@ -208,6 +208,7 @@
     <ClInclude Include="..\..\os\win\src\network\win_async_worker_thread.h" />
     <ClInclude Include="..\..\src\network\ssl\secure_socket_client.h" />
     <ClInclude Include="..\..\src\network\ssl\ssl_gateway.h" />
+    <ClInclude Include="..\..\src\network\ssl\secure_utils.h" />
     <ClInclude Include="..\..\src\network\async_client_pool_adapter.h" />
     <ClInclude Include="..\..\src\network\error_handling_filter.h" />
     <ClInclude Include="..\..\src\network\tcp_socket_client.h" />
@@ -230,6 +231,7 @@
     <ClCompile Include="..\..\src\network\ssl\secure_data_filter.cpp" />
     <ClCompile Include="..\..\src\network\ssl\secure_socket_client.cpp" />
     <ClCompile Include="..\..\src\network\ssl\ssl_gateway.cpp" />
+    <ClCompile Include="..\..\src\network\ssl\ssl_utils.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/modules/platforms/cpp/network/project/vs/network.vcxproj.filters
+++ b/modules/platforms/cpp/network/project/vs/network.vcxproj.filters
@@ -49,6 +49,9 @@
     <ClCompile Include="..\..\src\network\ssl\ssl_gateway.cpp">
       <Filter>Code\network\ssl</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\src\network\ssl\secure_utils.cpp">
+      <Filter>Code\network\ssl</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\os\win\src\network\win_async_worker_thread.h">
@@ -130,6 +133,9 @@
       <Filter>Code\network\ssl</Filter>
     </ClInclude>
     <ClInclude Include="..\..\src\network\ssl\ssl_gateway.h">
+      <Filter>Code\network\ssl</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\src\network\ssl\secure_utils.h">
       <Filter>Code\network\ssl</Filter>
     </ClInclude>
   </ItemGroup>

--- a/modules/platforms/cpp/network/project/vs/network.vcxproj.filters
+++ b/modules/platforms/cpp/network/project/vs/network.vcxproj.filters
@@ -120,6 +120,9 @@
     <ClInclude Include="..\..\os\win\src\network\win_async_connecting_thread.h">
       <Filter>Code\network</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\include\ignite\network\ssl\secure_configuration.h">
+      <Filter>Code\network\ssl</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\include\ignite\network\ssl\secure_data_filter.h">
       <Filter>Code\network\ssl</Filter>
     </ClInclude>

--- a/modules/platforms/cpp/network/src/network/network.cpp
+++ b/modules/platforms/cpp/network/src/network/network.cpp
@@ -16,7 +16,7 @@
 
 #include "network/sockets.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 #   include "network/win_async_client_pool.h"
 #else // Other. Assume Linux
 #   include "network/linux_async_client_pool.h"
@@ -56,7 +56,7 @@ namespace ignite
         IGNITE_IMPORT_EXPORT SP_AsyncClientPool MakeAsyncClientPool(const std::vector<SP_DataFilter>& filters)
         {
             SP_AsyncClientPool platformPool = SP_AsyncClientPool(
-#ifdef WIN32
+#ifdef _WIN32
                 new WinAsyncClientPool()
 #else // Other. Assume Linux
                 new LinuxAsyncClientPool()

--- a/modules/platforms/cpp/network/src/network/network.cpp
+++ b/modules/platforms/cpp/network/src/network/network.cpp
@@ -40,12 +40,11 @@ namespace ignite
                 SslGateway::GetInstance().LoadAll();
             }
 
-            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const std::string& certPath,
-                const std::string& keyPath, const std::string& caPath)
+            IGNITE_IMPORT_EXPORT SocketClient* MakeSecureSocketClient(const SecureConfiguration& cfg)
             {
                 EnsureSslLoaded();
 
-                return new SecureSocketClient(certPath, keyPath, caPath);
+                return new SecureSocketClient(cfg);
             }
         }
 

--- a/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
@@ -201,7 +201,6 @@ namespace ignite
 
             void SecureDataFilter::OnConnectionClosed(uint64_t id, const IgniteError *err)
             {
-                std::cout << "------------- SSL::OnConnectionClosed" << std::endl;
                 SP_SecureConnectionContext context = FindContext(id);
                 if (!context.IsValid())
                     return;
@@ -231,7 +230,6 @@ namespace ignite
 
             void SecureDataFilter::OnMessageReceived(uint64_t id, const DataBuffer &msg)
             {
-                std::cout << "------------- SSL::OnMessageReceived msg=" << msg.GetSize() << std::endl;
                 SP_SecureConnectionContext context = FindContext(id);
                 if (!context.IsValid())
                     return;
@@ -272,7 +270,6 @@ namespace ignite
 
             bool SecureDataFilter::SendInternal(uint64_t id, const DataBuffer& data)
             {
-                std::cout << "------------- SSL::SendInternal data=" << data.GetSize() << std::endl;
                 return DataFilterAdapter::Send(id, data);
             }
 
@@ -330,12 +327,10 @@ namespace ignite
 
                 SSL* ssl0 = static_cast<SSL*>(ssl);
                 int res = sslGateway.SSL_connect_(ssl0);
-                std::cout << "------------- SSL::DoConnect res=" << res << std::endl;
 
                 if (res != SSL_OPERATION_SUCCESS)
                 {
                     int sslError = sslGateway.SSL_get_error_(ssl0, res);
-                    std::cout << "------------- SSL::DoConnect sslError=" << sslError << std::endl;
                     if (IsActualError(sslError))
                     {
                         std::string msg = "Can not establish secure connection: " + GetSslError(ssl0, res);
@@ -375,7 +370,6 @@ namespace ignite
 
             bool SecureDataFilter::SecureConnectionContext::ProcessData(DataBuffer& data)
             {
-                std::cout << "------------- SSL::ProcessData data=" << data.GetSize() << std::endl;
                 SslGateway &sslGateway = SslGateway::GetInstance();
                 int res = sslGateway.BIO_write_(static_cast<BIO*>(bioIn), data.GetData(), data.GetSize());
                 if (res <= 0)
@@ -389,7 +383,6 @@ namespace ignite
                     return false;
 
                 connected = DoConnect();
-                std::cout << "------------- SSL::ProcessData connected=" << connected << std::endl;
 
                 SendPendingData();
 
@@ -413,7 +406,6 @@ namespace ignite
                 buf.Get()->Length(available);
 
                 int res = sslGateway.BIO_read_(bio0, buf.Get()->Data(), buf.Get()->Length());
-                std::cout << "------------- SSL::GetPendingData res=" << res << std::endl;
                 if (res <= 0)
                     return DataBuffer();
 

--- a/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
@@ -22,79 +22,7 @@
 #include <ignite/network/ssl/secure_data_filter.h>
 
 #include "network/ssl/ssl_gateway.h"
-
-enum
-{
-    SSL_OPERATION_SUCCESS = 1,
-};
-
-namespace
-{
-    void FreeContext(SSL_CTX* ctx)
-    {
-        using namespace ignite::network::ssl;
-
-        SslGateway &sslGateway = SslGateway::GetInstance();
-
-        assert(sslGateway.Loaded());
-
-        sslGateway.SSL_CTX_free_(ctx);
-    }
-
-    bool IsActualError(int err)
-    {
-        switch (err)
-        {
-            case SSL_ERROR_NONE:
-            case SSL_ERROR_WANT_READ:
-            case SSL_ERROR_WANT_WRITE:
-            case SSL_ERROR_WANT_X509_LOOKUP:
-            case SSL_ERROR_WANT_CONNECT:
-            case SSL_ERROR_WANT_ACCEPT:
-                return false;
-
-            default:
-                return true;
-        }
-    }
-
-    std::string GetSslError(void* ssl, int ret)
-    {
-        using namespace ignite::network::ssl;
-
-        SslGateway &sslGateway = SslGateway::GetInstance();
-
-        assert(sslGateway.Loaded());
-
-        SSL* ssl0 = reinterpret_cast<SSL*>(ssl);
-
-        int sslError = sslGateway.SSL_get_error_(ssl0, ret);
-
-        switch (sslError)
-        {
-            case SSL_ERROR_NONE:
-            case SSL_ERROR_SSL:
-                break;
-
-            case SSL_ERROR_WANT_WRITE:
-                return std::string("SSL_connect wants write");
-
-            case SSL_ERROR_WANT_READ:
-                return std::string("SSL_connect wants read");
-
-            default:
-                return std::string("SSL error: ") + ignite::common::LexicalCast<std::string>(sslError);
-        }
-
-        unsigned long error = sslGateway.ERR_get_error_();
-
-        char errBuf[1024] = { 0 };
-
-        sslGateway.ERR_error_string_n_(error, errBuf, sizeof(errBuf));
-
-        return std::string(errBuf);
-    }
-}
+#include "network/ssl/secure_utils.h"
 
 namespace ignite
 {
@@ -103,71 +31,14 @@ namespace ignite
         namespace ssl
         {
             SecureDataFilter::SecureDataFilter(const SecureConfiguration &cfg) :
-                cfg(cfg),
                 sslContext(0),
                 contexts(0),
                 contextCs()
             {
                 EnsureSslLoaded();
 
-                SslGateway &sslGateway = SslGateway::GetInstance();
+                sslContext = MakeContext(cfg);
 
-                const SSL_METHOD* method = sslGateway.SSLv23_client_method_();
-                if (!method)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, "Can not get SSL method");
-
-                SSL_CTX* sslContext0 = sslGateway.SSL_CTX_new_(method);
-                if (!sslContext0)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                        "Can not create new SSL context");
-
-                common::DeinitGuard<SSL_CTX> guard(sslContext0, &FreeContext);
-
-                sslGateway.SSL_CTX_set_verify_(sslContext0, SSL_VERIFY_PEER, 0);
-
-                sslGateway.SSL_CTX_set_verify_depth_(sslContext0, 8);
-
-                sslGateway.SSL_CTX_set_options_(sslContext0, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
-
-                if (!cfg.caPath.empty())
-                {
-                    long res = sslGateway.SSL_CTX_load_verify_locations_(sslContext0, cfg.caPath.c_str(), 0);
-                    if (res != SSL_OPERATION_SUCCESS)
-                        throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                            "Can not set Certificate Authority path for secure connection");
-                }
-                else
-                {
-                    long res = sslGateway.SSL_CTX_set_default_verify_paths_(sslContext0);
-                    if (res != SSL_OPERATION_SUCCESS)
-                        throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                            "Can not set default Certificate Authority path for secure connection");
-                }
-
-                if (!cfg.certPath.empty())
-                {
-                    long res = sslGateway.SSL_CTX_use_certificate_chain_file_(sslContext0, cfg.certPath.c_str());
-                    if (res != SSL_OPERATION_SUCCESS)
-                        throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                            "Can not set client certificate file for secure connection");
-                }
-
-                if (!cfg.keyPath.empty())
-                {
-                    long res = sslGateway.SSL_CTX_use_RSAPrivateKey_file_(sslContext0, cfg.keyPath.c_str(), SSL_FILETYPE_PEM);
-                    if (res != SSL_OPERATION_SUCCESS)
-                        throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                            "Can not set private key file for secure connection");
-                }
-
-                const char* const PREFERRED_CIPHERS = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4";
-                long res = sslGateway.SSL_CTX_set_cipher_list_(sslContext0, PREFERRED_CIPHERS);
-                if (res != SSL_OPERATION_SUCCESS)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                        "Can not set ciphers list for secure connection");
-
-                guard.Release();
-                sslContext = sslContext0;
                 contexts = new ContextMap;
             }
 
@@ -290,16 +161,15 @@ namespace ignite
 
                 ssl = sslGateway.SSL_new_(static_cast<SSL_CTX*>(filter.sslContext));
                 if (!ssl)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
-                        "Can not create secure connection");
+                    ThrowSecureError("Can not create secure connection");
 
                 bioIn = sslGateway.BIO_new_(sslGateway.BIO_s_mem_());
                 if (!bioIn)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, "Can not create input BIO");
+                    ThrowSecureError("Can not create input BIO");
 
                 bioOut = sslGateway.BIO_new_(sslGateway.BIO_s_mem_());
                 if (!bioOut)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, "Can not create output BIO");
+                    ThrowSecureError("Can not create output BIO");
 
                 sslGateway.SSL_set_bio_(static_cast<SSL*>(ssl), static_cast<BIO*>(bioIn), static_cast<BIO*>(bioOut));
                 sslGateway.SSL_set_connect_state_(static_cast<SSL*>(ssl));
@@ -332,11 +202,7 @@ namespace ignite
                 {
                     int sslError = sslGateway.SSL_get_error_(ssl0, res);
                     if (IsActualError(sslError))
-                    {
-                        std::string msg = "Can not establish secure connection: " + GetSslError(ssl0, res);
-
-                        throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, msg.c_str());
-                    }
+                        ThrowSecureError("Can not establish secure connection: " + GetSslError(ssl0, res));
                 }
 
                 SendPendingData();
@@ -373,7 +239,7 @@ namespace ignite
                 SslGateway &sslGateway = SslGateway::GetInstance();
                 int res = sslGateway.BIO_write_(static_cast<BIO*>(bioIn), data.GetData(), data.GetSize());
                 if (res <= 0)
-                    throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, "Failed to process SSL data");
+                    ThrowSecureError("Failed to process SSL data");
 
                 data.Skip(res);
 

--- a/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
@@ -136,6 +136,13 @@ namespace ignite
                         throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
                             "Can not set Certificate Authority path for secure connection");
                 }
+                else
+                {
+                    long res = sslGateway.SSL_CTX_set_default_verify_paths_(sslContext0);
+                    if (res != SSL_OPERATION_SUCCESS)
+                        throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE,
+                            "Can not set default Certificate Authority path for secure connection");
+                }
 
                 if (!cfg.certPath.empty())
                 {

--- a/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
@@ -161,15 +161,15 @@ namespace ignite
 
                 ssl = sslGateway.SSL_new_(static_cast<SSL_CTX*>(filter.sslContext));
                 if (!ssl)
-                    ThrowSecureError("Can not create secure connection");
+                    ThrowLastSecureError("Can not create secure connection");
 
                 bioIn = sslGateway.BIO_new_(sslGateway.BIO_s_mem_());
                 if (!bioIn)
-                    ThrowSecureError("Can not create input BIO");
+                    ThrowLastSecureError("Can not create input BIO");
 
                 bioOut = sslGateway.BIO_new_(sslGateway.BIO_s_mem_());
                 if (!bioOut)
-                    ThrowSecureError("Can not create output BIO");
+                    ThrowLastSecureError("Can not create output BIO");
 
                 sslGateway.SSL_set_bio_(static_cast<SSL*>(ssl), static_cast<BIO*>(bioIn), static_cast<BIO*>(bioOut));
                 sslGateway.SSL_set_connect_state_(static_cast<SSL*>(ssl));
@@ -202,7 +202,7 @@ namespace ignite
                 {
                     int sslError = sslGateway.SSL_get_error_(ssl0, res);
                     if (IsActualError(sslError))
-                        ThrowSecureError("Can not establish secure connection: " + GetSslError(ssl0, res));
+                        ThrowLastSecureError("Can not establish secure connection");
                 }
 
                 SendPendingData();
@@ -239,7 +239,7 @@ namespace ignite
                 SslGateway &sslGateway = SslGateway::GetInstance();
                 int res = sslGateway.BIO_write_(static_cast<BIO*>(bioIn), data.GetData(), data.GetSize());
                 if (res <= 0)
-                    ThrowSecureError("Failed to process SSL data");
+                    ThrowLastSecureError("Failed to process SSL data");
 
                 data.Skip(res);
 

--- a/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_data_filter.cpp
@@ -379,6 +379,8 @@ namespace ignite
                 if (connected)
                     return false;
 
+                std::cout << "------------- SSL::ProcessData sslGateway.SSL_is_init_finished_=" << sslGateway.SSL_is_init_finished_(static_cast<SSL*>(ssl)) << std::endl;
+
                 if (!sslGateway.SSL_is_init_finished_(static_cast<SSL*>(ssl)))
                 {
                     DoConnect();
@@ -386,7 +388,11 @@ namespace ignite
                     SendPendingData();
 
                     if (!sslGateway.SSL_is_init_finished_(static_cast<SSL*>(ssl)))
+                    {
+                        std::cout << "------------- SSL::ProcessData sslGateway.SSL_is_init_finished_=" << sslGateway.SSL_is_init_finished_(static_cast<SSL*>(ssl)) << std::endl;
+
                         return false;
+                    }
                 }
 
                 connected = true;

--- a/modules/platforms/cpp/network/src/network/ssl/secure_socket_client.h
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_socket_client.h
@@ -21,6 +21,7 @@
 #include <string>
 
 #include <ignite/network/socket_client.h>
+#include <ignite/network/ssl/secure_configuration.h>
 
 namespace ignite
 {
@@ -37,11 +38,9 @@ namespace ignite
                 /**
                  * Constructor.
                  *
-                 * @param certPath Certificate file path.
-                 * @param keyPath Private key file path.
-                 * @param caPath Certificate authority file path.
+                 * @param cfg Secure configuration.
                  */
-                SecureSocketClient(const std::string& certPath, const std::string& keyPath, const std::string& caPath);
+                SecureSocketClient(const SecureConfiguration& cfg);
 
                 /**
                  * Destructor.
@@ -98,13 +97,6 @@ namespace ignite
                 void CloseInternal();
 
                 /**
-                 * Throw SSL-related error.
-                 *
-                 * @param err Error message.
-                 */
-                static void ThrowSecureError(const std::string& err);
-
-                /**
                  * Wait on the socket for any event for specified time.
                  * This function uses poll to achive timeout functionality
                  * for every separate socket operation.
@@ -128,17 +120,6 @@ namespace ignite
                 static int WaitOnSocketIfNeeded(int res, void* ssl, int timeout);
 
                 /**
-                 * Make new context instance.
-                 *
-                 * @param certPath Certificate file path.
-                 * @param keyPath Private key file path.
-                 * @param caPath Certificate authority file path.
-                 * @return New context instance on success and null-pointer on fail.
-                 */
-                static void* MakeContext(const std::string& certPath, const std::string& keyPath,
-                    const std::string& caPath);
-
-                /**
                  * Make new SSL instance.
                  *
                  * @param context SSL context.
@@ -158,23 +139,8 @@ namespace ignite
                  */
                 static bool CompleteConnectInternal(void* ssl, int timeout);
 
-                /**
-                 * Get SSL error.
-                 *
-                 * @param ssl SSL instance.
-                 * @param ret Return value of the pervious operation.
-                 * @return Error string.
-                 */
-                static std::string GetSslError(void* ssl, int ret);
-
-                /** Certificate file path. */
-                std::string certPath;
-
-                /** Private key file path. */
-                std::string keyPath;
-
-                /** Certificate authority file path. */
-                std::string caPath;
+                /** Secure configuration. */
+                SecureConfiguration cfg;
 
                 /** SSL context. */
                 void* context;

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
@@ -30,6 +30,7 @@ namespace
 {
     void LoadDefaultCa(SSL_CTX* sslContext)
     {
+        using namespace ignite::common;
         using namespace ignite::network::ssl;
 
         assert(sslContext != 0);
@@ -45,13 +46,10 @@ namespace
         if (!sslStore)
             ThrowLastSecureError("Can not create X509_STORE certificate store", "Try setting custom CA");
 
-        HCERTSTORE sysStore = CertOpenSystemStore(NULL, L"ROOT");
+        HCERTSTORE sysStore = CertOpenSystemStoreA(NULL, "ROOT");
         if (!sysStore)
-        {
-            // TODO: System error handling
-
-            ThrowSecureError("Can not open System Certificate store for secure connection. Try setting custom CA");
-        }
+            ThrowSecureError(GetLastSystemError("Can not open System Certificate store for secure connection",
+                "Try setting custom CA"));
 
         PCCERT_CONTEXT certIter = CertEnumCertificatesInStore(sysStore, NULL);
         while (certIter)

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ignite/ignite_error.h>
+
+#include <ignite/common/utils.h>
+#include <ignite/network/network.h>
+
+#include "network/ssl/secure_utils.h"
+
+namespace ignite
+{
+    namespace network
+    {
+        namespace ssl
+        {
+            SSL_CTX* MakeContext(const SecureConfiguration& cfg)
+            {
+                EnsureSslLoaded();
+
+                SslGateway &sslGateway = SslGateway::GetInstance();
+
+                const SSL_METHOD* method = sslGateway.SSLv23_client_method_();
+                if (!method)
+                    ThrowSecureError("Can not get SSL method");
+
+                SSL_CTX* sslContext = sslGateway.SSL_CTX_new_(method);
+                if (!sslContext)
+                    ThrowSecureError("Can not create new SSL context");
+
+                common::DeinitGuard<SSL_CTX> guard(sslContext, &FreeContext);
+
+                sslGateway.SSL_CTX_set_verify_(sslContext, SSL_VERIFY_PEER, 0);
+
+                sslGateway.SSL_CTX_set_verify_depth_(sslContext, 8);
+
+                sslGateway.SSL_CTX_set_options_(sslContext, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3 | SSL_OP_NO_COMPRESSION);
+
+                if (!cfg.caPath.empty())
+                {
+                    long res = sslGateway.SSL_CTX_load_verify_locations_(sslContext, cfg.caPath.c_str(), 0);
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowSecureError("Can not set Certificate Authority path for secure connection");
+                }
+                else
+                {
+                    long res = sslGateway.SSL_CTX_set_default_verify_paths_(sslContext);
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowSecureError("Can not set default Certificate Authority path for secure connection");
+                }
+
+                if (!cfg.certPath.empty())
+                {
+                    long res = sslGateway.SSL_CTX_use_certificate_chain_file_(sslContext, cfg.certPath.c_str());
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowSecureError("Can not set client certificate file for secure connection");
+                }
+
+                if (!cfg.keyPath.empty())
+                {
+                    long res = sslGateway.SSL_CTX_use_RSAPrivateKey_file_(sslContext, cfg.keyPath.c_str(), SSL_FILETYPE_PEM);
+                    if (res != SSL_OPERATION_SUCCESS)
+                        ThrowSecureError("Can not set private key file for secure connection");
+                }
+
+                const char* const PREFERRED_CIPHERS = "HIGH:!aNULL:!kRSA:!PSK:!SRP:!MD5:!RC4";
+                long res = sslGateway.SSL_CTX_set_cipher_list_(sslContext, PREFERRED_CIPHERS);
+                if (res != SSL_OPERATION_SUCCESS)
+                    ThrowSecureError("Can not set ciphers list for secure connection");
+
+                guard.Release();
+                return sslContext;
+            }
+
+            void FreeContext(SSL_CTX* ctx)
+            {
+                using namespace ignite::network::ssl;
+
+                SslGateway &sslGateway = SslGateway::GetInstance();
+
+                assert(sslGateway.Loaded());
+
+                sslGateway.SSL_CTX_free_(ctx);
+            }
+
+            std::string GetSslError(void* ssl, int ret)
+            {
+                using namespace ignite::network::ssl;
+
+                SslGateway &sslGateway = SslGateway::GetInstance();
+
+                assert(sslGateway.Loaded());
+
+                SSL* ssl0 = reinterpret_cast<SSL*>(ssl);
+
+                int sslError = sslGateway.SSL_get_error_(ssl0, ret);
+
+                switch (sslError)
+                {
+                    case SSL_ERROR_NONE:
+                    case SSL_ERROR_SSL:
+                        break;
+
+                    case SSL_ERROR_WANT_WRITE:
+                        return std::string("SSL_connect wants write");
+
+                    case SSL_ERROR_WANT_READ:
+                        return std::string("SSL_connect wants read");
+
+                    default:
+                        return std::string("SSL error: ") + ignite::common::LexicalCast<std::string>(sslError);
+                }
+
+                unsigned long error = sslGateway.ERR_get_error_();
+
+                char errBuf[1024] = { 0 };
+
+                sslGateway.ERR_error_string_n_(error, errBuf, sizeof(errBuf));
+
+                return std::string(errBuf);
+            }
+
+            bool IsActualError(int err)
+            {
+                switch (err)
+                {
+                    case SSL_ERROR_NONE:
+                    case SSL_ERROR_WANT_READ:
+                    case SSL_ERROR_WANT_WRITE:
+                    case SSL_ERROR_WANT_X509_LOOKUP:
+                    case SSL_ERROR_WANT_CONNECT:
+                    case SSL_ERROR_WANT_ACCEPT:
+                        return false;
+
+                    default:
+                        return true;
+                }
+            }
+
+            void ThrowSecureError(const std::string& err)
+            {
+                throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, err.c_str());
+            }
+        }
+    }
+}

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
@@ -167,7 +167,7 @@ namespace ignite
                 throw IgniteError(IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE, err.c_str());
             }
 
-            void ThrowLastSecureError(const std::string& description, const std::string& advice)
+            std::string GetLastSecureError()
             {
                 using namespace ignite::network::ssl;
 
@@ -187,15 +187,12 @@ namespace ignite
                     errorDetails.assign(errBuf);
                 }
 
-                std::stringstream messageBuilder;
-                messageBuilder << description;
-                if (!errorDetails.empty())
-                    messageBuilder << ": " << errorDetails;
+                return errorDetails;
+            }
 
-                if (!advice.empty())
-                    messageBuilder << ". " << advice;
-
-                ThrowSecureError(messageBuilder.str());
+            void ThrowLastSecureError(const std::string& description, const std::string& advice)
+            {
+                ThrowSecureError(common::FormatErrorMessage(description, GetLastSecureError(), advice));
             }
 
             void ThrowLastSecureError(const std::string& description)

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.cpp
@@ -15,7 +15,10 @@
  */
 
 #include "network/sockets.h"
+
+#ifdef _WIN32
 #include <wincrypt.h>
+#endif
 
 #include <ignite/ignite_error.h>
 

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
@@ -64,6 +64,13 @@ namespace ignite
             void ThrowSecureError(const std::string& err);
 
             /**
+             * Get SSL-related error in text format.
+             *
+             * @param err Error message in human-readable format.
+             */
+            std::string GetLastSecureError();
+
+            /**
              * Try extract from OpenSSL error stack and throw SSL-related error.
              *
              * @param description Error description.

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _IGNITE_NETWORK_SSL_SECURE_UTILS
+#define _IGNITE_NETWORK_SSL_SECURE_UTILS
+
+#include <ignite/network/ssl/secure_configuration.h>
+#include "network/ssl/ssl_gateway.h"
+
+namespace ignite
+{
+    namespace network
+    {
+        namespace ssl
+        {
+            enum
+            {
+                /** OpenSSL functions return this code on success. */
+                SSL_OPERATION_SUCCESS = 1,
+            };
+
+            /**
+             * Make SSL context using configuration.
+             *
+             * @param cfg Configuration to use.
+             * @return New context instance on success.
+             * @throw IgniteError on error.
+             */
+            SSL_CTX* MakeContext(const SecureConfiguration& cfg);
+
+            /**
+             * Free context.
+             *
+             * @param ctx Context to free.
+             */
+            void FreeContext(SSL_CTX* ctx);
+
+            /**
+             * Get SSL error.
+             *
+             * @param ssl SSL instance.
+             * @param ret Last operation return code.
+             * @return String representation of last SSL error.
+             */
+            std::string GetSslError(void* ssl, int ret);
+
+            /**
+             * Check whether error is actual error or code returned when used in async environment.
+             *
+             * @param err Error obtained with SSL_get_error.
+             * @return @c true if the code returned on actual error.
+             */
+            bool IsActualError(int err);
+
+            /**
+             * Throw SSL-related error.
+             *
+             * @param err Error message.
+             */
+            void ThrowSecureError(const std::string& err);
+        }
+    }
+}
+
+#endif //_IGNITE_NETWORK_SSL_SECURE_UTILS

--- a/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
+++ b/modules/platforms/cpp/network/src/network/ssl/secure_utils.h
@@ -49,15 +49,6 @@ namespace ignite
             void FreeContext(SSL_CTX* ctx);
 
             /**
-             * Get SSL error.
-             *
-             * @param ssl SSL instance.
-             * @param ret Last operation return code.
-             * @return String representation of last SSL error.
-             */
-            std::string GetSslError(void* ssl, int ret);
-
-            /**
              * Check whether error is actual error or code returned when used in async environment.
              *
              * @param err Error obtained with SSL_get_error.
@@ -71,6 +62,21 @@ namespace ignite
              * @param err Error message.
              */
             void ThrowSecureError(const std::string& err);
+
+            /**
+             * Try extract from OpenSSL error stack and throw SSL-related error.
+             *
+             * @param description Error description.
+             * @param advice User advice.
+             */
+            void ThrowLastSecureError(const std::string& description, const std::string& advice);
+
+            /**
+             * Try extract from OpenSSL error stack and throw SSL-related error.
+             *
+             * @param description Error description.
+             */
+            void ThrowLastSecureError(const std::string& description);
         }
     }
 }

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
@@ -158,6 +158,7 @@ namespace ignite
                 functions.fpSSL_CTX_free = LoadSslMethod("SSL_CTX_free");
                 functions.fpSSL_CTX_set_verify = LoadSslMethod("SSL_CTX_set_verify");
                 functions.fpSSL_CTX_set_verify_depth = LoadSslMethod("SSL_CTX_set_verify_depth");
+                functions.fpSSL_CTX_set_cert_store = LoadSslMethod("SSL_CTX_set_cert_store");
                 functions.fpSSL_CTX_set_default_verify_paths = LoadSslMethod("SSL_CTX_set_default_verify_paths");
                 functions.fpSSL_CTX_load_verify_locations = LoadSslMethod("SSL_CTX_load_verify_locations");
                 functions.fpSSL_CTX_use_certificate_chain_file = LoadSslMethod("SSL_CTX_use_certificate_chain_file");
@@ -191,6 +192,9 @@ namespace ignite
 
 
                 functions.fpOPENSSL_config = LoadSslMethod("OPENSSL_config");
+                functions.fpX509_STORE_new = LoadSslMethod("X509_STORE_new");
+                functions.fpX509_STORE_add_cert = LoadSslMethod("X509_STORE_add_cert");
+                functions.fpd2i_X509 = LoadSslMethod("d2i_X509");
                 functions.fpX509_free = LoadSslMethod("X509_free");
 
                 functions.fpBIO_free_all = LoadSslMethod("BIO_free_all");
@@ -366,6 +370,17 @@ namespace ignite
                 FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_CTX_set_verify_depth);
 
                 fp(ctx, depth);
+            }
+
+            void SslGateway::SSL_CTX_set_cert_store_(SSL_CTX* ctx, X509_STORE* store)
+            {
+                assert(functions.fpSSL_CTX_set_cert_store != 0);
+
+                typedef int (FuncType)(SSL_CTX*, X509_STORE*);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_CTX_set_cert_store);
+
+                fp(ctx, store);
             }
 
             int SslGateway::SSL_CTX_set_default_verify_paths_(SSL_CTX* ctx)
@@ -660,15 +675,48 @@ namespace ignite
                 fp(configName);
             }
 
-            void SslGateway::X509_free_(X509* a)
+            X509_STORE* SslGateway::X509_STORE_new_()
+            {
+                assert(functions.fpX509_STORE_new != 0);
+
+                typedef X509_STORE*(FuncType)();
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpX509_STORE_new);
+
+                return fp();
+            }
+
+            int SslGateway::X509_STORE_add_cert_(X509_STORE* ctx, X509* cert)
+            {
+                assert(functions.fpX509_STORE_add_cert != 0);
+
+                typedef int(FuncType)(X509_STORE*, X509*);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpX509_STORE_add_cert);
+
+                return fp(ctx, cert);
+            }
+
+            X509* SslGateway::d2i_X509_(X509** cert, const unsigned char** ppin, long length)
+            {
+                assert(functions.fpd2i_X509 != 0);
+
+                typedef X509*(FuncType)(X509**, const unsigned char**, long);
+
+                FuncType* fp = reinterpret_cast<FuncType*>(functions.fpd2i_X509);
+
+                return fp(cert, ppin, length);
+            }
+
+            void SslGateway::X509_free_(X509* cert)
             {
                 assert(functions.fpX509_free != 0);
 
-                typedef void (FuncType)(X509*);
+                typedef void(FuncType)(X509*);
 
                 FuncType* fp = reinterpret_cast<FuncType*>(functions.fpX509_free);
 
-                fp(a);
+                fp(cert);
             }
 
             BIO* SslGateway::BIO_new_(const BIO_METHOD* method)

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.cpp
@@ -583,7 +583,7 @@ namespace ignite
                 return fp(ssl);
             }
 
-            int SslGateway::SSL_is_init_finished_(const SSL* ssl)
+            int SslGateway::SSL_get_state_(const SSL* ssl)
             {
                 assert(functions.fpSSL_get_state != 0);
 
@@ -591,6 +591,11 @@ namespace ignite
 
                 FuncType* fp = reinterpret_cast<FuncType*>(functions.fpSSL_get_state);
 
+                return fp(ssl);
+            }
+
+            int SslGateway::SSL_is_init_finished_(const SSL* ssl)
+            {
                 enum {
                     IGNITE_SSL_STATE_OK =
 #ifdef SSL_ST_OK
@@ -600,7 +605,12 @@ namespace ignite
 #endif
                 };
 
-                return fp(ssl) == IGNITE_SSL_STATE_OK ? 1 : 0;
+                int state = SSL_get_state_(ssl);
+
+                std::cout << "------------- SSL::state=" << state << std::endl;
+                std::cout << "------------- SSL::IGNITE_SSL_STATE_OK=" << IGNITE_SSL_STATE_OK << std::endl;
+
+                return state == IGNITE_SSL_STATE_OK ? 1 : 0;
             }
 
             int SslGateway::SSL_get_fd_(const SSL* ssl)

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
@@ -41,6 +41,7 @@ namespace ignite
                 void *fpSSL_CTX_free;
                 void *fpSSL_CTX_set_verify;
                 void *fpSSL_CTX_set_verify_depth;
+                void *fpSSL_CTX_set_default_verify_paths;
                 void *fpSSL_CTX_load_verify_locations;
                 void *fpSSL_CTX_use_certificate_chain_file;
                 void *fpSSL_CTX_use_RSAPrivateKey_file;
@@ -61,7 +62,6 @@ namespace ignite
                 void *fpSSL_read;
                 void *fpSSL_pending;
                 void *fpSSL_get_version;
-                void *fpSSL_get_state;
                 void *fpSSL_get_fd;
                 void *fpSSL_new;
                 void *fpSSL_free;
@@ -76,7 +76,6 @@ namespace ignite
                 void *fpBIO_ctrl;
                 void *fpERR_get_error;
                 void *fpERR_error_string_n;
-                void *fpERR_print_errors_fp;
 
                 void *fpOpenSSL_version;
                 void *fpSSL_CTX_set_options;
@@ -104,15 +103,6 @@ namespace ignite
                 void LoadAll();
 
                 /**
-                 * Get functions.
-                 * @return Functions structure.
-                 */
-                SslFunctions& GetFunctions()
-                {
-                    return functions;
-                }
-
-                /**
                  * Check whether the libraries are loaded.
                  * @return @c true if loaded.
                  */
@@ -136,6 +126,8 @@ namespace ignite
                 void SSL_CTX_set_verify_(SSL_CTX* ctx, int mode, int (*callback)(int, X509_STORE_CTX*));
 
                 void SSL_CTX_set_verify_depth_(SSL_CTX* ctx, int depth);
+
+                int SSL_CTX_set_default_verify_paths_(SSL_CTX* ctx);
 
                 int SSL_CTX_load_verify_locations_(SSL_CTX* ctx, const char* cAfile, const char* cApath);
 
@@ -175,10 +167,6 @@ namespace ignite
 
                 const char* SSL_get_version_(const SSL* ssl);
 
-                int SSL_get_state_(const SSL* ssl);
-
-                int SSL_is_init_finished_(const SSL* ssl);
-
                 int SSL_get_fd_(const SSL* ssl);
 
                 SSL* SSL_new_(SSL_CTX* ctx);
@@ -209,8 +197,6 @@ namespace ignite
 
                 long BIO_ctrl_(BIO* bp, int cmd, long larg, void* parg);
 
-                long BIO_get_fd_(BIO* bp, int* fd);
-
                 long BIO_get_ssl_(BIO* bp, SSL** ssl);
 
                 long BIO_set_nbio_(BIO* bp, long n);
@@ -220,8 +206,6 @@ namespace ignite
                 unsigned long ERR_get_error_();
 
                 void ERR_error_string_n_(unsigned long e, char* buf, size_t len);
-
-                void ERR_print_errors_fp_(FILE *fd);
 
             private:
                 /**
@@ -244,7 +228,7 @@ namespace ignite
                  * @param name Name.
                  * @return Module.
                  */
-                common::dynamic::Module LoadSslLibrary(const char* name);
+                static common::dynamic::Module LoadSslLibrary(const char* name);
 
                 /**
                  * Load all SSL libraries.

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
@@ -41,6 +41,7 @@ namespace ignite
                 void *fpSSL_CTX_free;
                 void *fpSSL_CTX_set_verify;
                 void *fpSSL_CTX_set_verify_depth;
+                void *fpSSL_CTX_set_cert_store;
                 void *fpSSL_CTX_set_default_verify_paths;
                 void *fpSSL_CTX_load_verify_locations;
                 void *fpSSL_CTX_use_certificate_chain_file;
@@ -66,6 +67,9 @@ namespace ignite
                 void *fpSSL_new;
                 void *fpSSL_free;
                 void *fpOPENSSL_config;
+                void *fpX509_STORE_new;
+                void *fpX509_STORE_add_cert;
+                void *fpd2i_X509;
                 void *fpX509_free;
                 void *fpBIO_new;
                 void *fpBIO_new_ssl_connect;
@@ -127,6 +131,8 @@ namespace ignite
 
                 void SSL_CTX_set_verify_depth_(SSL_CTX* ctx, int depth);
 
+                void SSL_CTX_set_cert_store_(SSL_CTX* ctx, X509_STORE* store);
+
                 int SSL_CTX_set_default_verify_paths_(SSL_CTX* ctx);
 
                 int SSL_CTX_load_verify_locations_(SSL_CTX* ctx, const char* cAfile, const char* cApath);
@@ -179,7 +185,13 @@ namespace ignite
 
                 void OPENSSL_config_(const char* configName);
 
-                void X509_free_(X509* a);
+                X509_STORE* X509_STORE_new_();
+
+                int X509_STORE_add_cert_(X509_STORE* ctx, X509* cert);
+
+                X509* d2i_X509_(X509** cert, const unsigned char** ppin, long length);
+
+                void X509_free_(X509* cert);
 
                 BIO* BIO_new_(const BIO_METHOD* method);
 

--- a/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
+++ b/modules/platforms/cpp/network/src/network/ssl/ssl_gateway.h
@@ -175,6 +175,8 @@ namespace ignite
 
                 const char* SSL_get_version_(const SSL* ssl);
 
+                int SSL_get_state_(const SSL* ssl);
+
                 int SSL_is_init_finished_(const SSL* ssl);
 
                 int SSL_get_fd_(const SSL* ssl);

--- a/modules/platforms/cpp/odbc-test/CMakeLists.txt
+++ b/modules/platforms/cpp/odbc-test/CMakeLists.txt
@@ -29,7 +29,8 @@ find_package(ODBC REQUIRED)
 include_directories(SYSTEM ${ODBC_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 include_directories(include ../odbc/include ../network/include ../network/src)
 
-set(SOURCES src/teamcity/teamcity_boost.cpp
+set(SOURCES
+        src/teamcity/teamcity_boost.cpp
         src/teamcity/teamcity_messages.cpp
         src/parser_test.cpp
         src/cursor_test.cpp

--- a/modules/platforms/cpp/odbc/project/vs/odbc.vcxproj
+++ b/modules/platforms/cpp/odbc/project/vs/odbc.vcxproj
@@ -99,7 +99,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
     </Link>
@@ -115,7 +115,7 @@
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
     </Link>
@@ -135,7 +135,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -153,7 +153,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <ModuleDefinitionFile>module.def</ModuleDefinitionFile>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/modules/platforms/cpp/odbc/src/connection.cpp
+++ b/modules/platforms/cpp/odbc/src/connection.cpp
@@ -164,8 +164,12 @@ namespace ignite
                 return SqlResult::AI_ERROR;
             }
 
-            socket.reset(network::ssl::MakeSecureSocketClient(
-                config.GetSslCertFile(), config.GetSslKeyFile(), config.GetSslCaFile()));
+            network::ssl::SecureConfiguration sslCfg;
+            sslCfg.certPath = config.GetSslCertFile();
+            sslCfg.keyPath = config.GetSslKeyFile();
+            sslCfg.caPath = config.GetSslCaFile();
+
+            socket.reset(network::ssl::MakeSecureSocketClient(sslCfg));
 
             return SqlResult::AI_SUCCESS;
         }

--- a/modules/platforms/cpp/thin-client-test/CMakeLists.txt
+++ b/modules/platforms/cpp/thin-client-test/CMakeLists.txt
@@ -27,7 +27,8 @@ find_package(Boost 1.53 REQUIRED COMPONENTS unit_test_framework chrono thread sy
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS} ${JNI_INCLUDE_DIRS})
 include_directories(include)
 
-set(SOURCES src/teamcity/teamcity_boost.cpp
+set(SOURCES
+        src/teamcity/teamcity_boost.cpp
         src/teamcity/teamcity_messages.cpp
         src/cache_client_test.cpp
         src/compute_client_test.cpp
@@ -53,7 +54,7 @@ endif()
 
 set(TEST_TARGET IgniteThinClientTest)
 
-add_test(NAME ${TEST_TARGET} COMMAND ${TARGET} --catch_system_errors=no --log_level=all --run_test=IgniteClientTestSuite)
+add_test(NAME ${TEST_TARGET} COMMAND ${TARGET} --catch_system_errors=no --log_level=all)
 
 set_tests_properties(${TEST_TARGET} PROPERTIES ENVIRONMENT
         IGNITE_NATIVE_TEST_CPP_THIN_CONFIG_PATH=${PROJECT_SOURCE_DIR}/config)

--- a/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-32.xml
+++ b/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-32.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="ssl-no-client-auth-default.xml"/>
+
+    <bean parent="no-client-auth.cfg">
+        <property name="memoryConfiguration">
+            <bean class="org.apache.ignite.configuration.MemoryConfiguration">
+                <property name="systemCacheInitialSize" value="#{10 * 1024 * 1024}"/>
+                <property name="systemCacheMaxSize" value="#{40 * 1024 * 1024}"/>
+                <property name="defaultMemoryPolicyName" value="dfltPlc"/>
+
+                <property name="memoryPolicies">
+                    <list>
+                        <bean class="org.apache.ignite.configuration.MemoryPolicyConfiguration">
+                            <property name="name" value="dfltPlc"/>
+                            <property name="maxSize" value="#{100 * 1024 * 1024}"/>
+                            <property name="initialSize" value="#{10 * 1024 * 1024}"/>
+                        </bean>
+                    </list>
+                </property>
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-default.xml
+++ b/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth-default.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/util
+        http://www.springframework.org/schema/util/spring-util.xsd">
+
+    <!--
+        Initialize property configurer so we can reference environment variables.
+    -->
+    <bean id="propertyConfigurer" class="org.springframework.beans.factory.config.PropertyPlaceholderConfigurer">
+        <property name="systemPropertiesModeName" value="SYSTEM_PROPERTIES_MODE_FALLBACK"/>
+        <property name="searchSystemEnvironment" value="true"/>
+    </bean>
+  
+    <bean abstract="true" id="no-client-auth.cfg" class="org.apache.ignite.configuration.IgniteConfiguration">
+        <property name="localHost" value="127.0.0.1"/>
+        <property name="connectorConfiguration"><null/></property>
+
+        <property name="clientConnectorConfiguration">
+            <bean class="org.apache.ignite.configuration.ClientConnectorConfiguration">
+                <property name="host" value="127.0.0.1"/>
+                <property name="port" value="11110"/>
+                <property name="portRange" value="10"/>
+                <property name="sslEnabled" value="true"/>
+                <property name="useIgniteSslContextFactory" value="false"/>
+                <property name="sslClientAuth" value="false"/>
+
+                <!-- Provide Ssl context. -->
+                <property name="sslContextFactory">
+                    <bean class="org.apache.ignite.ssl.SslContextFactory">
+                        <property name="keyStoreFilePath" value="${IGNITE_NATIVE_TEST_CPP_THIN_CONFIG_PATH}/ssl/server.jks"/>
+                        <property name="keyStorePassword" value="123456"/>
+                        <property name="trustStoreFilePath" value="${IGNITE_NATIVE_TEST_CPP_THIN_CONFIG_PATH}/ssl/trust.jks"/>
+                        <property name="trustStorePassword" value="123456"/>
+                    </bean>
+                </property>
+            </bean>
+        </property>
+
+        <!-- Explicitly configure TCP discovery SPI to provide list of initial nodes. -->
+        <property name="discoverySpi">
+            <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
+                <property name="ipFinder">
+                    <!--
+                        Ignite provides several options for automatic discovery that can be used
+                        instead os static IP based discovery.
+                    -->
+                    <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <property name="addresses">
+                            <list>
+                                <!-- In distributed environment, replace with actual host IP address. -->
+                                <value>127.0.0.1:47500</value>
+                            </list>
+                        </property>
+                    </bean>
+                </property>
+                <property name="socketTimeout" value="300" />
+            </bean>
+        </property>
+    </bean>
+</beans>

--- a/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth.xml
+++ b/modules/platforms/cpp/thin-client-test/config/ssl-no-client-auth.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+        http://www.springframework.org/schema/beans
+        http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <import resource="ssl-no-client-auth-default.xml"/>
+
+    <bean parent="no-client-auth.cfg"/>
+
+</beans>

--- a/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
+++ b/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
@@ -41,6 +41,11 @@ public:
         return ignite_test::StartCrossPlatformServerNode("non-ssl.xml", name.c_str());
     }
 
+    ignite::Ignite StartSslNoClientAuthNode(const std::string& name = "ServerNode")
+    {
+        return ignite_test::StartCrossPlatformServerNode("ssl-no-client-auth.xml", name.c_str());
+    }
+
     SslTestSuiteFixture()
     {
         // No-op.
@@ -197,29 +202,15 @@ BOOST_AUTO_TEST_CASE(SslCacheClientPutGet)
 
 BOOST_AUTO_TEST_CASE(SslConnectionNoCerts)
 {
-    StartSslNode();
+    StartSslNoClientAuthNode();
 
     IgniteClientConfiguration cfg;
     cfg.SetEndPoints("127.0.0.1:11110");
 
     cfg.SetSslMode(SslMode::REQUIRE);
+    cfg.SetSslCaFile(GetConfigFile("ca.pem"));
 
     IgniteClient client = IgniteClient::Start(cfg);
-
-    cache::CacheClient<int32_t, std::string> cache =
-            client.CreateCache<int32_t, std::string>("test");
-
-    enum { OPS_NUM = 100 };
-    for (int32_t j = 0; j < OPS_NUM; ++j)
-    {
-        int32_t key = OPS_NUM + j;
-        std::string value = "value_" + ignite::common::LexicalCast<std::string>(key);
-
-        cache.Put(key, value);
-        std::string retrieved = cache.Get(key);
-
-        BOOST_REQUIRE_EQUAL(value, retrieved);
-    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
+++ b/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
@@ -213,4 +213,111 @@ BOOST_AUTO_TEST_CASE(SslConnectionNoCerts)
     IgniteClient client = IgniteClient::Start(cfg);
 }
 
+/**
+ * Check whether error is "file not exists".
+ *
+ * @param err Error to check
+ * @return @true is Error is of expected kind.
+ */
+bool IsNonExisting(const ignite::IgniteError& err)
+{
+    if (err.GetCode() != ignite::IgniteError::IGNITE_ERR_SECURE_CONNECTION_FAILURE)
+        return false;
+
+    std::string msg(err.GetText());
+
+    if (msg.find("error:02001002") == std::string::npos)
+        return false;
+
+    if (msg.find("No such file or directory") == std::string::npos)
+        return false;
+
+    return true;
+}
+
+/**
+ * Check whether error is "CA file not exists".
+ *
+ * @param err Error to check
+ * @return @true is Error is of expected kind.
+ */
+bool IsNonExistingCa(const ignite::IgniteError& err)
+{
+    if (!IsNonExisting(err))
+        return false;
+
+    std::string msg(err.GetText());
+    return msg.find("Can not set Certificate Authority path for secure connection") != std::string::npos;
+}
+
+BOOST_AUTO_TEST_CASE(SslConnectionErrorNonExistingCa)
+{
+    StartSslNoClientAuthNode();
+
+    IgniteClientConfiguration cfg;
+    cfg.SetEndPoints("127.0.0.1:11110");
+
+    cfg.SetSslMode(SslMode::REQUIRE);
+    cfg.SetSslCaFile(GetConfigFile("non_existing_ca.pem"));
+
+    BOOST_CHECK_EXCEPTION(IgniteClient::Start(cfg), ignite::IgniteError, IsNonExistingCa);
+}
+
+/**
+ * Check whether error is "private key file not exists".
+ *
+ * @param err Error to check
+ * @return @true is Error is of expected kind.
+ */
+bool IsNonExistingKey(const ignite::IgniteError& err)
+{
+    if (!IsNonExisting(err))
+        return false;
+
+    std::string msg(err.GetText());
+    return msg.find("Can not set private key file for secure connection") != std::string::npos;
+}
+
+BOOST_AUTO_TEST_CASE(SslConnectionErrorNonExistingKey)
+{
+    StartSslNoClientAuthNode();
+
+    IgniteClientConfiguration cfg;
+    cfg.SetEndPoints("127.0.0.1:11110");
+
+    cfg.SetSslMode(SslMode::REQUIRE);
+    cfg.SetSslKeyFile(GetConfigFile("non_existing_key.pem"));
+
+    BOOST_CHECK_EXCEPTION(IgniteClient::Start(cfg), ignite::IgniteError, IsNonExistingKey);
+}
+
+
+/**
+ * Check whether error is "certificate file not exists".
+ *
+ * @param err Error to check
+ * @return @true is Error is of expected kind.
+ */
+bool IsNonExistingCert(const ignite::IgniteError& err)
+{
+    if (!IsNonExisting(err))
+        return false;
+
+    std::string msg(err.GetText());
+    return msg.find("Can not set client certificate file for secure connection") != std::string::npos;
+}
+
+BOOST_AUTO_TEST_CASE(SslConnectionErrorNonExistingCert)
+{
+    StartSslNoClientAuthNode();
+
+    IgniteClientConfiguration cfg;
+    cfg.SetEndPoints("127.0.0.1:11110");
+
+    cfg.SetSslMode(SslMode::REQUIRE);
+    cfg.SetSslCertFile(GetConfigFile("non_existing_Cert.pem"));
+
+    BOOST_CHECK_EXCEPTION(IgniteClient::Start(cfg), ignite::IgniteError, IsNonExistingCert);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
+++ b/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
@@ -195,4 +195,31 @@ BOOST_AUTO_TEST_CASE(SslCacheClientPutGet)
     }
 }
 
+BOOST_AUTO_TEST_CASE(SslConnectionNoCerts)
+{
+    StartSslNode();
+
+    IgniteClientConfiguration cfg;
+    cfg.SetEndPoints("127.0.0.1:11110");
+
+    cfg.SetSslMode(SslMode::REQUIRE);
+
+    IgniteClient client = IgniteClient::Start(cfg);
+
+    cache::CacheClient<int32_t, std::string> cache =
+            client.CreateCache<int32_t, std::string>("test");
+
+    enum { OPS_NUM = 100 };
+    for (int32_t j = 0; j < OPS_NUM; ++j)
+    {
+        int32_t key = OPS_NUM + j;
+        std::string value = "value_" + ignite::common::LexicalCast<std::string>(key);
+
+        cache.Put(key, value);
+        std::string retrieved = cache.Get(key);
+
+        BOOST_REQUIRE_EQUAL(value, retrieved);
+    }
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
+++ b/modules/platforms/cpp/thin-client-test/src/ssl_test.cpp
@@ -226,10 +226,12 @@ bool IsNonExisting(const ignite::IgniteError& err)
 
     std::string msg(err.GetText());
 
-    if (msg.find("error:02001002") == std::string::npos)
+    if (msg.find("error:02001002") == std::string::npos &&
+        msg.find("error:2006D080") == std::string::npos)
         return false;
 
-    if (msg.find("No such file or directory") == std::string::npos)
+    if (msg.find("No such file or directory") == std::string::npos &&
+        msg.find("no such file") == std::string::npos)
         return false;
 
     return true;
@@ -271,6 +273,7 @@ BOOST_AUTO_TEST_CASE(SslConnectionErrorNonExistingCa)
  */
 bool IsNonExistingKey(const ignite::IgniteError& err)
 {
+    std::cout << err.GetText() << std::endl;
     if (!IsNonExisting(err))
         return false;
 

--- a/modules/platforms/cpp/thin-client/project/vs/thin-client.vcxproj
+++ b/modules/platforms/cpp/thin-client/project/vs/thin-client.vcxproj
@@ -98,7 +98,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
     </Link>
@@ -113,7 +113,7 @@
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>
       </DelayLoadDLLs>
     </Link>
@@ -132,7 +132,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -149,7 +149,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>Ws2_32.lib;Mswsock.lib;Advapi32.lib;Shlwapi.lib;iphlpapi.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
- Improved error reporting during SSL failures.
- Fixed issue when client compiled and run with different OpenSSL versions.
- Re-factored to remove SSL-related code duplication.
- Added missing tests to some test suites.
- Certificate, private key and CA are not mandatory parameters for client now. Also, implemented extracting and usage of system CA for Windows by default.