### PR TITLE
GG-34536 [IGNITE-16026] Java thin: Add retry policy

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/client/ClientOperationType.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientOperationType.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import java.util.Set;
+import org.apache.ignite.cache.query.ContinuousQuery;
+import org.apache.ignite.cache.query.Query;
+import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.cluster.ClusterState;
+
+/**
+ * Client operation type.
+ */
+public enum ClientOperationType {
+    /**
+     * Create cache ({@link IgniteClient#createCache(String)},
+     * {@link IgniteClient#createCache(ClientCacheConfiguration)}).
+     */
+    CACHE_CREATE,
+
+    /**
+     * Get or create cache ({@link IgniteClient#getOrCreateCache(String)},
+     * {@link IgniteClient#getOrCreateCache(ClientCacheConfiguration)}).
+     */
+    CACHE_GET_OR_CREATE,
+
+    /**
+     * Get cache names ({@link IgniteClient#cacheNames()}).
+     */
+    CACHE_GET_NAMES,
+
+    /**
+     * Destroy cache ({@link IgniteClient#destroyCache(String)}).
+     */
+    CACHE_DESTROY,
+
+    /**
+     * Get value from cache ({@link ClientCache#get(Object)}).
+     */
+    CACHE_GET,
+
+    /**
+     * Get value from cache ({@link ClientCache#get(Object)}).
+     */
+    CACHE_PUT,
+
+    /**
+     * Determines if the cache contains a key ({@link ClientCache#containsKey(Object)}).
+     */
+    CACHE_CONTAINS_KEY,
+
+    /**
+     * Determines if the cache contains multiple keys ({@link ClientCache#containsKeys}).
+     */
+    CACHE_CONTAINS_KEYS,
+
+    /**
+     * Get cache configuration ({@link ClientCache#getConfiguration()}).
+     */
+    CACHE_GET_CONFIGURATION,
+
+    /**
+     * Get cache size ({@link ClientCache#size}).
+     */
+    CACHE_GET_SIZE,
+
+    /**
+     * Put values to cache ({@link ClientCache#putAll}).
+     */
+    CACHE_PUT_ALL,
+
+    /**
+     * Get values from cache ({@link ClientCache#getAll}).
+     */
+    CACHE_GET_ALL,
+
+    /**
+     * Replace cache value ({@link ClientCache#replace(Object, Object)},
+     * {@link ClientCache#replace(Object, Object, Object)}).
+     */
+    CACHE_REPLACE,
+
+    /**
+     * Remove entry from cache ({@link ClientCache#remove(Object)}, {@link ClientCache#remove(Object, Object)}).
+     */
+    CACHE_REMOVE_ONE,
+
+    /**
+     * Remove entries from cache ({@link ClientCache#removeAll(Set)}).
+     */
+    CACHE_REMOVE_MULTIPLE,
+
+    /**
+     * Remove everyting from cache ({@link ClientCache#removeAll()}).
+     */
+    CACHE_REMOVE_EVERYTHING,
+
+    /**
+     * Clear cache entry ({@link ClientCache#clear(Object)} ).
+     */
+    CACHE_CLEAR_ONE,
+
+    /**
+     * Clear multiple cache entries ({@link ClientCache#clearAll(Set)}).
+     */
+    CACHE_CLEAR_MULTIPLE,
+
+    /**
+     * Clear entire cache ({@link ClientCache#clear()}).
+     */
+    CACHE_CLEAR_EVERYTHING,
+
+    /**
+     * Get and put ({@link ClientCache#getAndPut(Object, Object)}).
+     */
+    CACHE_GET_AND_PUT,
+
+    /**
+     * Get and remove ({@link ClientCache#getAndRemove(Object)}).
+     */
+    CACHE_GET_AND_REMOVE,
+
+    /**
+     * Get and replace ({@link ClientCache#getAndReplace(Object, Object)}).
+     */
+    CACHE_GET_AND_REPLACE,
+
+    /**
+     * Put if absent ({@link ClientCache#putIfAbsent(Object, Object)}).
+     */
+    CACHE_PUT_IF_ABSENT,
+
+    /**
+     * Get and put if absent ({@link ClientCache#getAndPutIfAbsent(Object, Object)}).
+     */
+    CACHE_GET_AND_PUT_IF_ABSENT,
+
+    /**
+     * Scan query ({@link ClientCache#query(Query)}).
+     */
+    QUERY_SCAN,
+
+    /**
+     * SQL query ({@link ClientCache#query(SqlFieldsQuery)}).
+     */
+    QUERY_SQL,
+
+    /**
+     * Continuous query ({@link ClientCache#query(ContinuousQuery, ClientDisconnectListener)}).
+     */
+    QUERY_CONTINUOUS,
+
+    /**
+     * Start transaction ({@link ClientTransactions#txStart}).
+     */
+    TRANSACTION_START,
+
+    /**
+     * Get cluster state ({@link ClientCluster#state()}).
+     */
+    CLUSTER_GET_STATE,
+
+    /**
+     * Change cluster state ({@link ClientCluster#state(ClusterState)}).
+     */
+    CLUSTER_CHANGE_STATE,
+
+    /**
+     * Get cluster WAL state ({@link ClientCluster#isWalEnabled(String)}).
+     */
+    CLUSTER_GET_WAL_STATE,
+
+    /**
+     * Change cluster WAL state ({@link ClientCluster#enableWal(String)}, {@link ClientCluster#disableWal(String)}).
+     */
+    CLUSTER_CHANGE_WAL_STATE,
+
+    /**
+     * Get cluster nodes ({@link ClientCluster#nodes()}).
+     */
+    CLUSTER_GROUP_GET_NODES,
+
+    /**
+     * Execute compute task ({@link ClientCompute#execute(String, Object)}).
+     */
+    COMPUTE_TASK_EXECUTE,
+
+    /**
+     * Invoke service.
+     */
+    SERVICE_INVOKE,
+
+    /**
+     * Get service descriptors ({@link ClientServices#serviceDescriptors()}).
+     */
+    SERVICE_GET_DESCRIPTORS,
+
+    /**
+     * Get service descriptor ({@link ClientServices#serviceDescriptor(String)}).
+     */
+    SERVICE_GET_DESCRIPTOR
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientRetryAllPolicy.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientRetryAllPolicy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+/**
+ * Retry policy that always returns {@code true}.
+ */
+public class ClientRetryAllPolicy implements ClientRetryPolicy {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /** {@inheritDoc} */
+    @Override public boolean shouldRetry(ClientRetryPolicyContext context) {
+        return true;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientRetryNonePolicy.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientRetryNonePolicy.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+/**
+ * Retry policy that always returns {@code false}.
+ */
+public class ClientRetryNonePolicy implements ClientRetryPolicy {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /** {@inheritDoc} */
+    @Override public boolean shouldRetry(ClientRetryPolicyContext context) {
+        return false;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientRetryPolicy.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientRetryPolicy.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import java.io.Serializable;
+
+/**
+ * Client retry policy determines whether client operations that have failed due to a connection issue should be retried.
+ */
+public interface ClientRetryPolicy extends Serializable {
+    /**
+     * Gets a value indicating whether a client operation that has failed due to a connection issue should be retried.
+     *
+     * @param context Context.
+     * @return {@code true} if the operation should be retried on another connection, {@code false} otherwise.
+     */
+    public boolean shouldRetry(ClientRetryPolicyContext context);
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientRetryPolicyContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientRetryPolicyContext.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import org.apache.ignite.configuration.ClientConfiguration;
+
+/**
+ * Retry policy context. See {@link ClientRetryPolicy#shouldRetry}.
+ */
+public interface ClientRetryPolicyContext {
+    /**
+     * Gets the client configuration.
+     *
+     * @return Client configuration.
+     */
+    public ClientConfiguration configuration();
+
+    /**
+     * Gets the operation type.
+     *
+     * @return Operation type.
+     */
+    public ClientOperationType operation();
+
+    /**
+     * Gets the current iteration number (zero-based).
+     *
+     * @return Zero-based iteration counter.
+     */
+    public int iteration();
+
+    /**
+     * Gets the connection exception that caused current retry iteration.
+     *
+     * @return Exception.
+     */
+    public ClientConnectionException exception();
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientRetryReadPolicy.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientRetryReadPolicy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+/**
+ * Retry policy that returns true for all read-only operations that do not modify data.
+ */
+public class ClientRetryReadPolicy implements ClientRetryPolicy {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /** {@inheritDoc} */
+    @Override public boolean shouldRetry(ClientRetryPolicyContext context) {
+        switch (context.operation()) {
+            case CACHE_GET_NAMES:
+            case CACHE_GET:
+            case CACHE_CONTAINS_KEY:
+            case CACHE_CONTAINS_KEYS:
+            case CACHE_GET_CONFIGURATION:
+            case CACHE_GET_SIZE:
+            case CACHE_GET_ALL:
+            case QUERY_SCAN:
+            case QUERY_CONTINUOUS:
+            case CLUSTER_GET_STATE:
+            case CLUSTER_GET_WAL_STATE:
+            case CLUSTER_GROUP_GET_NODES:
+            case SERVICE_GET_DESCRIPTORS:
+            case SERVICE_GET_DESCRIPTOR:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
@@ -24,6 +24,8 @@ import java.util.concurrent.ForkJoinPool;
 import javax.cache.configuration.Factory;
 import javax.net.ssl.SSLContext;
 import org.apache.ignite.client.ClientAddressFinder;
+import org.apache.ignite.client.ClientRetryAllPolicy;
+import org.apache.ignite.client.ClientRetryPolicy;
 import org.apache.ignite.client.SslMode;
 import org.apache.ignite.client.SslProtocol;
 import org.apache.ignite.internal.client.thin.TcpIgniteClient;
@@ -120,6 +122,9 @@ public final class ClientConfiguration implements Serializable {
 
     /** Retry limit. */
     private int retryLimit = 0;
+
+    /** Retry policy. */
+    private ClientRetryPolicy retryPolicy = new ClientRetryAllPolicy();
 
     /** Executor for async operations continuations. */
     private Executor asyncContinuationExecutor;
@@ -552,6 +557,32 @@ public final class ClientConfiguration implements Serializable {
      */
     public ClientConfiguration setRetryLimit(int retryLimit) {
         this.retryLimit = retryLimit;
+
+        return this;
+    }
+
+    /**
+     * Gets the retry policy.
+     *
+     * @return Retry policy.
+     */
+    public ClientRetryPolicy getRetryPolicy() {
+        return retryPolicy;
+    }
+
+    /**
+     * Sets the retry policy. When a request fails due to a connection error, and multiple server connections
+     * are available, Ignite will retry the request if the specified policy allows it.
+     * <p />
+     * When {@link ClientConfiguration#retryLimit} is set, retry count will be limited even if the specified policy returns {@code true}.
+     * <p />
+     * Default is {@link ClientRetryAllPolicy}.
+     *
+     * @param retryPolicy Retry policy.
+     * @return {@code this} for chaining.
+     */
+    public ClientConfiguration setRetryPolicy(ClientRetryPolicy retryPolicy) {
+        this.retryPolicy = retryPolicy;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientOperation.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientOperation.java
@@ -18,10 +18,11 @@ package org.apache.ignite.internal.client.thin;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.ignite.client.ClientOperationType;
 import org.jetbrains.annotations.Nullable;
 
 /** Operation codes. */
-enum ClientOperation {
+public enum ClientOperation {
     /** Resource close. */RESOURCE_CLOSE(0),
 
     /** Cache get or create with name. */CACHE_GET_OR_CREATE_WITH_NAME(1052),
@@ -115,6 +116,136 @@ enum ClientOperation {
      */
     public ClientNotificationType notificationType() {
         return notificationType;
+    }
+
+    /**
+     * Converts this internal operation code to public {@link ClientOperationType}.
+     *
+     * @return Corresponding {@link ClientOperationType}, or {@code null} if there is no match.
+     * Some operations, such as {@link #RESOURCE_CLOSE}, do not have a public counterpart.
+     */
+    @Nullable public ClientOperationType toPublicOperationType() {
+        switch (this) {
+            case CACHE_GET_OR_CREATE_WITH_NAME:
+            case CACHE_GET_OR_CREATE_WITH_CONFIGURATION:
+                return ClientOperationType.CACHE_GET_OR_CREATE;
+
+            case CACHE_CREATE_WITH_CONFIGURATION:
+            case CACHE_CREATE_WITH_NAME:
+                return ClientOperationType.CACHE_CREATE;
+
+            case CACHE_PUT:
+                return ClientOperationType.CACHE_PUT;
+
+            case CACHE_GET:
+                return ClientOperationType.CACHE_GET;
+
+            case CACHE_GET_NAMES:
+                return ClientOperationType.CACHE_GET_NAMES;
+
+            case CACHE_DESTROY:
+                return ClientOperationType.CACHE_DESTROY;
+
+            case CACHE_CONTAINS_KEY:
+                return ClientOperationType.CACHE_CONTAINS_KEY;
+
+            case CACHE_CONTAINS_KEYS:
+                return ClientOperationType.CACHE_CONTAINS_KEYS;
+
+            case CACHE_GET_CONFIGURATION:
+                return ClientOperationType.CACHE_GET_CONFIGURATION;
+
+            case CACHE_GET_SIZE:
+                return ClientOperationType.CACHE_GET_SIZE;
+
+            case CACHE_PUT_ALL:
+                return ClientOperationType.CACHE_PUT_ALL;
+
+            case CACHE_GET_ALL:
+                return ClientOperationType.CACHE_GET_ALL;
+
+            case CACHE_REPLACE_IF_EQUALS:
+            case CACHE_REPLACE:
+                return ClientOperationType.CACHE_REPLACE;
+
+            case CACHE_REMOVE_KEY:
+            case CACHE_REMOVE_IF_EQUALS:
+                return ClientOperationType.CACHE_REMOVE_ONE;
+
+            case CACHE_REMOVE_KEYS:
+                return ClientOperationType.CACHE_REMOVE_MULTIPLE;
+
+            case CACHE_REMOVE_ALL:
+                return ClientOperationType.CACHE_REMOVE_EVERYTHING;
+
+            case CACHE_GET_AND_PUT:
+                return ClientOperationType.CACHE_GET_AND_PUT;
+
+            case CACHE_GET_AND_REMOVE:
+                return ClientOperationType.CACHE_GET_AND_REMOVE;
+
+            case CACHE_GET_AND_REPLACE:
+                return ClientOperationType.CACHE_GET_AND_REPLACE;
+
+            case CACHE_PUT_IF_ABSENT:
+                return ClientOperationType.CACHE_PUT_IF_ABSENT;
+
+            case CACHE_GET_AND_PUT_IF_ABSENT:
+                return ClientOperationType.CACHE_GET_AND_PUT_IF_ABSENT;
+
+            case CACHE_CLEAR:
+                return ClientOperationType.CACHE_CLEAR_EVERYTHING;
+
+            case CACHE_CLEAR_KEY:
+                return ClientOperationType.CACHE_CLEAR_ONE;
+
+            case CACHE_CLEAR_KEYS:
+                return ClientOperationType.CACHE_CLEAR_MULTIPLE;
+
+            case QUERY_SCAN:
+                return ClientOperationType.QUERY_SCAN;
+
+            case QUERY_SQL:
+            case QUERY_SQL_FIELDS:
+                return ClientOperationType.QUERY_SQL;
+
+            case QUERY_CONTINUOUS:
+                return ClientOperationType.QUERY_CONTINUOUS;
+
+            case TX_START:
+                return ClientOperationType.TRANSACTION_START;
+
+            case CLUSTER_GET_STATE:
+                return ClientOperationType.CLUSTER_GET_STATE;
+
+            case CLUSTER_CHANGE_STATE:
+                return ClientOperationType.CLUSTER_CHANGE_STATE;
+
+            case CLUSTER_GET_WAL_STATE:
+                return ClientOperationType.CLUSTER_GET_WAL_STATE;
+
+            case CLUSTER_CHANGE_WAL_STATE:
+                return ClientOperationType.CLUSTER_CHANGE_WAL_STATE;
+
+            case CLUSTER_GROUP_GET_NODE_IDS:
+            case CLUSTER_GROUP_GET_NODE_INFO:
+                return ClientOperationType.CLUSTER_GROUP_GET_NODES;
+
+            case COMPUTE_TASK_EXECUTE:
+                return ClientOperationType.COMPUTE_TASK_EXECUTE;
+
+            case SERVICE_INVOKE:
+                return ClientOperationType.SERVICE_INVOKE;
+
+            case SERVICE_GET_DESCRIPTORS:
+                return ClientOperationType.SERVICE_GET_DESCRIPTORS;
+
+            case SERVICE_GET_DESCRIPTOR:
+                return ClientOperationType.SERVICE_GET_DESCRIPTOR;
+
+            default:
+                return null;
+        }
     }
 
     /** Enum mapping from code to values. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientRetryPolicyContextImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientRetryPolicyContextImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.thin;
+
+import org.apache.ignite.client.ClientConnectionException;
+import org.apache.ignite.client.ClientOperationType;
+import org.apache.ignite.client.ClientRetryPolicyContext;
+import org.apache.ignite.configuration.ClientConfiguration;
+
+/**
+ * Retry policy context.
+ */
+class ClientRetryPolicyContextImpl implements ClientRetryPolicyContext {
+    /** */
+    private final ClientConfiguration configuration;
+
+    /** */
+    private final ClientOperationType operation;
+
+    /** */
+    private final int iteration;
+
+    /** */
+    private final ClientConnectionException exception;
+
+    /**
+     * Constructor.
+     *
+     * @param configuration Configuration.
+     * @param operation Operation.
+     * @param iteration Iteration.
+     * @param exception Exception.
+     */
+    public ClientRetryPolicyContextImpl(ClientConfiguration configuration, ClientOperationType operation, int iteration,
+            ClientConnectionException exception) {
+        this.configuration = configuration;
+        this.operation = operation;
+        this.iteration = iteration;
+        this.exception = exception;
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientConfiguration configuration() {
+        return configuration;
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientOperationType operation() {
+        return operation;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int iteration() {
+        return iteration;
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientConnectionException exception() {
+        return exception;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
@@ -43,6 +43,9 @@ import org.apache.ignite.client.ClientAuthenticationException;
 import org.apache.ignite.client.ClientAuthorizationException;
 import org.apache.ignite.client.ClientConnectionException;
 import org.apache.ignite.client.ClientException;
+import org.apache.ignite.client.ClientOperationType;
+import org.apache.ignite.client.ClientRetryPolicy;
+import org.apache.ignite.client.ClientRetryPolicyContext;
 import org.apache.ignite.client.IgniteClientFuture;
 import org.apache.ignite.configuration.ClientConfiguration;
 import org.apache.ignite.configuration.ClientConnectorConfiguration;
@@ -160,9 +163,7 @@ final class ReliableChannel implements AutoCloseable {
         Consumer<PayloadOutputChannel> payloadWriter,
         Function<PayloadInputChannel, T> payloadReader
     ) throws ClientException, ClientError {
-        return applyOnDefaultChannel(channel ->
-            channel.service(op, payloadWriter, payloadReader)
-        );
+        return applyOnDefaultChannel(channel -> channel.service(op, payloadWriter, payloadReader), op);
     }
 
     /**
@@ -195,7 +196,7 @@ final class ReliableChannel implements AutoCloseable {
         int attemptsCnt[] = new int[1];
 
         try {
-            ch = applyOnDefaultChannel(channel -> channel, attemptsLimit, v -> attemptsCnt[0] = v );
+            ch = applyOnDefaultChannel(channel -> channel, null, attemptsLimit, v -> attemptsCnt[0] = v);
         } catch (Throwable ex) {
             if (failure != null) {
                 failure.addSuppressed(ex);
@@ -237,13 +238,14 @@ final class ReliableChannel implements AutoCloseable {
                     else
                         failure0.addSuppressed(err);
 
-                    int leftAttempts = attemptsLimit - attemptsCnt[0];
+                    int attempt = attemptsCnt[0];
+                    int leftAttempts = attemptsLimit - attempt;
 
                     // If it is a first retry then reset attempts (as for initialization we use only 1 attempt).
                     if (failure == null)
                         leftAttempts = getRetryLimit() - 1;
 
-                    if (leftAttempts > 0) {
+                    if (leftAttempts > 0 && shouldRetry(op, attempt, failure0)) {
                         handleServiceAsync(fut, op, payloadWriter, payloadReader, leftAttempts, failure0);
 
                         return null;
@@ -308,8 +310,7 @@ final class ReliableChannel implements AutoCloseable {
 
             if (affNodeId != null) {
                 return applyOnNodeChannelWithFallback(affNodeId, channel ->
-                    channel.service(op, payloadWriter, payloadReader)
-                );
+                    channel.service(op, payloadWriter, payloadReader), op);
             }
         }
 
@@ -355,7 +356,7 @@ final class ReliableChannel implements AutoCloseable {
 
                                 int attemptsLimit = getRetryLimit() - 1;
 
-                                if (attemptsLimit == 0) {
+                                if (attemptsLimit == 0 || !shouldRetry(op, 0, failure)) {
                                     fut.completeExceptionally(err);
                                     return null;
                                 }
@@ -675,7 +676,7 @@ final class ReliableChannel implements AutoCloseable {
             return;
 
         // Apply no-op function. Establish default channel connection.
-        applyOnDefaultChannel(channel -> null);
+        applyOnDefaultChannel(channel -> null, null);
 
         if (affinityAwarenessEnabled)
             initAllChannelsAsync();
@@ -703,14 +704,15 @@ final class ReliableChannel implements AutoCloseable {
     }
 
     /** */
-    private <T> T applyOnDefaultChannel(Function<ClientChannel, T> function) {
-        return applyOnDefaultChannel(function, getRetryLimit(), DO_NOTHING);
+    private <T> T applyOnDefaultChannel(Function<ClientChannel, T> function, ClientOperation op) {
+        return applyOnDefaultChannel(function, op, getRetryLimit(), DO_NOTHING);
     }
 
     /**
      * Apply specified {@code function} on any of available channel.
      */
     private <T> T applyOnDefaultChannel(Function<ClientChannel, T> function,
+                                        ClientOperation op,
                                         int attemptsLimit,
                                         Consumer<Integer> attemptsCallback) {
         ClientConnectionException failure = null;
@@ -746,6 +748,9 @@ final class ReliableChannel implements AutoCloseable {
                     failure.addSuppressed(e);
 
                 onChannelFailure(hld, c);
+
+                if (op != null && !shouldRetry(op, attempt, e))
+                    break;
             }
         }
 
@@ -756,7 +761,7 @@ final class ReliableChannel implements AutoCloseable {
      * Try apply specified {@code function} on a channel corresponding to {@code tryNodeId}.
      * If failed then apply the function on any available channel.
      */
-    private <T> T applyOnNodeChannelWithFallback(UUID tryNodeId, Function<ClientChannel, T> function) {
+    private <T> T applyOnNodeChannelWithFallback(UUID tryNodeId, Function<ClientChannel, T> function, ClientOperation op) {
         ClientChannelHolder hld = nodeChannels.get(tryNodeId);
 
         int retryLimit = getRetryLimit();
@@ -775,12 +780,12 @@ final class ReliableChannel implements AutoCloseable {
 
                 retryLimit -= 1;
 
-                if (retryLimit == 0)
+                if (retryLimit == 0 || !shouldRetry(op, 0, e))
                     throw e;
             }
         }
 
-        return applyOnDefaultChannel(function, retryLimit, DO_NOTHING);
+        return applyOnDefaultChannel(function, op, retryLimit, DO_NOTHING);
     }
 
     /** Get retry limit. */
@@ -793,6 +798,23 @@ final class ReliableChannel implements AutoCloseable {
         int size = holders.size();
 
         return clientCfg.getRetryLimit() > 0 ? Math.min(clientCfg.getRetryLimit(), size) : size;
+    }
+
+    /** Determines whether specified operation should be retried. */
+    private boolean shouldRetry(ClientOperation op, int iteration, ClientConnectionException exception) {
+        ClientOperationType opType = op.toPublicOperationType();
+
+        if (opType == null)
+            return true; // System operation.
+
+        ClientRetryPolicy plc = clientCfg.getRetryPolicy();
+
+        if (plc == null)
+            return false;
+
+        ClientRetryPolicyContext ctx = new ClientRetryPolicyContextImpl(clientCfg, opType, iteration, exception);
+
+        return plc.shouldRetry(ctx);
     }
 
     /**
@@ -934,7 +956,7 @@ final class ReliableChannel implements AutoCloseable {
     }
 
     /**
-     * Get holders reference. For test purposes.
+     * Get holders reference. For test purposes.ClientOperation
      */
     @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType") // For tests.
     List<ClientChannelHolder> getChannelHolders() {

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.client;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.cache.Cache;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheMode;
@@ -39,6 +41,7 @@ import org.apache.ignite.cache.query.ScanQuery;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.failure.FailureHandler;
 import org.apache.ignite.internal.client.thin.AbstractThinClientTest;
+import org.apache.ignite.internal.client.thin.ClientOperation;
 import org.apache.ignite.internal.client.thin.ClientServerError;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.services.Service;
@@ -189,6 +192,132 @@ public class ReliabilityTest extends AbstractThinClientTest {
             // Reuse second address without fail.
             cachePut(cache, 0, 0);
         }
+    }
+
+    /**
+     * Test single server can be used multiple times in configuration.
+     */
+    @Test
+    public void testRetryReadPolicyRetriesCacheGet() {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(getClientConfiguration()
+                 .setRetryPolicy(new ClientRetryReadPolicy())
+                 .setAddresses(
+                     cluster.clientAddresses().iterator().next(),
+                     cluster.clientAddresses().iterator().next()))
+        ) {
+            ClientCache<Integer, Integer> cache = client.createCache("cache");
+
+            // Before fail.
+            cachePut(cache, 0, 0);
+
+            // Fail.
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            // Reuse second address without fail.
+            cache.get(0);
+        }
+    }
+
+    /**
+     * Tests that retry limit of 1 effectively disables retry/failover.
+     */
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testRetryLimitDisablesFailover() {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(getClientConfiguration()
+                 .setRetryLimit(1)
+                 .setAddresses(
+                     cluster.clientAddresses().iterator().next(),
+                     cluster.clientAddresses().iterator().next()))
+        ) {
+            ClientCache<Integer, Integer> cache = client.createCache("cache");
+
+            // Before fail.
+            cachePut(cache, 0, 0);
+
+            // Fail.
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            // Reuse second address without fail.
+            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), IgniteException.class,
+                    "Channel is closed");
+        }
+    }
+
+    /**
+     * Tests that setting retry policy to null effectively disables retry/failover.
+     */
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testNullRetryPolicyDisablesFailover() {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(getClientConfiguration()
+                 .setRetryPolicy(null)
+                 .setAddresses(
+                     cluster.clientAddresses().iterator().next(),
+                     cluster.clientAddresses().iterator().next()))
+        ) {
+            ClientCache<Integer, Integer> cache = client.createCache("cache");
+
+            // Before fail.
+            cachePut(cache, 0, 0);
+
+            // Fail.
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            // Reuse second address without fail.
+            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), IgniteException.class,
+                    "Channel is closed");
+        }
+    }
+
+    /**
+     * Tests that retry limit of 1 effectively disables retry/failover.
+     */
+    @SuppressWarnings("ThrowableNotThrown")
+    @Test
+    public void testRetryNonePolicyDisablesFailover() {
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(getClientConfiguration()
+                 .setRetryPolicy(new ClientRetryNonePolicy())
+                 .setAddresses(
+                     cluster.clientAddresses().iterator().next(),
+                     cluster.clientAddresses().iterator().next()))
+        ) {
+            ClientCache<Integer, Integer> cache = client.createCache("cache");
+
+            // Before fail.
+            cachePut(cache, 0, 0);
+
+            // Fail.
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            // Reuse second address without fail.
+            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), IgniteException.class,
+                    "Channel is closed");
+        }
+    }
+
+    /**
+     * Tests that {@link ClientOperationType} is updated accordingly when {@link ClientOperation} is added.
+     */
+    @Test
+    public void testRetryPolicyConvertOpAllOperationsSupported() {
+        List<ClientOperation> nullOps = Arrays.stream(ClientOperation.values())
+                .filter(o -> o.toPublicOperationType() == null)
+                .collect(Collectors.toList());
+
+        String nullOpsNames = nullOps.stream().map(Enum::name).collect(Collectors.joining(", "));
+
+        long expectedNullCount = 12;
+
+        String msg = expectedNullCount
+                + " operation codes do not have public equivalent. When adding new codes, update ClientOperationType too. Missing ops: "
+                + nullOpsNames;
+
+        assertEquals(msg, expectedNullCount, nullOps.size());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -31,7 +31,6 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.cache.Cache;
 import org.apache.ignite.Ignite;
-import org.apache.ignite.IgniteException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheMode;
@@ -222,7 +221,6 @@ public class ReliabilityTest extends AbstractThinClientTest {
     /**
      * Tests that retry limit of 1 effectively disables retry/failover.
      */
-    @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testRetryLimitDisablesFailover() {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
@@ -241,7 +239,7 @@ public class ReliabilityTest extends AbstractThinClientTest {
             dropAllThinClientConnections(Ignition.allGrids().get(0));
 
             // Reuse second address without fail.
-            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), IgniteException.class,
+            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), ClientConnectionException.class,
                     "Channel is closed");
         }
     }
@@ -249,7 +247,6 @@ public class ReliabilityTest extends AbstractThinClientTest {
     /**
      * Tests that setting retry policy to null effectively disables retry/failover.
      */
-    @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testNullRetryPolicyDisablesFailover() {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
@@ -268,7 +265,7 @@ public class ReliabilityTest extends AbstractThinClientTest {
             dropAllThinClientConnections(Ignition.allGrids().get(0));
 
             // Reuse second address without fail.
-            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), IgniteException.class,
+            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), ClientConnectionException.class,
                     "Channel is closed");
         }
     }
@@ -276,7 +273,6 @@ public class ReliabilityTest extends AbstractThinClientTest {
     /**
      * Tests that retry limit of 1 effectively disables retry/failover.
      */
-    @SuppressWarnings("ThrowableNotThrown")
     @Test
     public void testRetryNonePolicyDisablesFailover() {
         try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
@@ -295,7 +291,7 @@ public class ReliabilityTest extends AbstractThinClientTest {
             dropAllThinClientConnections(Ignition.allGrids().get(0));
 
             // Reuse second address without fail.
-            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), IgniteException.class,
+            GridTestUtils.assertThrows(null, () -> cachePut(cache, 0, 0), ClientConnectionException.class,
                     "Channel is closed");
         }
     }


### PR DESCRIPTION
* Add `ClientRetryPolicy` interface.
* Add predefined policies: `ClientRetryAllPolicy`, `ClientRetryNonePolicy`, `ClientRetryReadPolicy`.
* Add `ClientConfiguration.retryPolicy` property, defaults to `ClientRetryAllPolicy`.
* Default behavior is not changed.

https://cwiki.apache.org/confluence/display/IGNITE/IEP-82+Thin+Client+Retry+Policy