### PR TITLE
GG-34464 Cover throttling breakdown fix with integration test

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -67,6 +67,8 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
 
     /** {@inheritDoc} */
     @Override protected void beforeTest() throws Exception {
+        stopAllGrids();
+
         super.beforeTest();
 
         deleteWorkFiles();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -22,7 +22,6 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
-import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
@@ -104,6 +103,5 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
      */
     private void deleteWorkFiles() throws Exception {
         cleanPersistenceDir();
-        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "snapshot", false));
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -76,7 +76,7 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
 
         super.beforeTest();
 
-        deleteWorkFiles();
+        cleanPersistenceDir();
     }
 
     /** {@inheritDoc} */
@@ -85,7 +85,7 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
 
         super.afterTest();
 
-        deleteWorkFiles();
+        cleanPersistenceDir();
     }
 
     /** {@inheritDoc} */
@@ -116,12 +116,5 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
         }
 
         assertFalse(G.allGrids().isEmpty());
-    }
-
-    /**
-     * @throws Exception If failed.
-     */
-    private void deleteWorkFiles() throws Exception {
-        cleanPersistenceDir();
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -42,7 +42,6 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
                 .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
                         // tiny CP buffer is required to reproduce this problem easily
                         .setCheckpointPageBufferSize(3_000_000)
-                        .setName("dfltDataRegion")
                         .setPersistenceEnabled(true))
                 .setCheckpointFrequency(200)
                 .setWriteThrottlingEnabled(true);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -23,6 +23,8 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.failure.FailureHandler;
+import org.apache.ignite.failure.StopNodeFailureHandler;
 import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
@@ -91,6 +93,11 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
     /** {@inheritDoc} */
     @Override protected long getTestTimeout() {
         return 3L * 60 * 1000;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected FailureHandler getFailureHandler(String igniteInstanceName) {
+        return new StopNodeFailureHandler();
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.processors.cache.persistence.pagemem;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
@@ -90,8 +89,8 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
     /***/
     @Test
     public void speedBasedThrottleShouldNotAllowCPBufferBreakdownWhenCPBufferIsSmall() throws Exception {
-        IgniteEx ignite = startGrids(1);
-        
+        Ignite ignite = startGrids(1);
+
         ignite.cluster().state(ACTIVE);
         IgniteCache<Object, Object> cache = ignite.cache(CACHE_NAME);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -85,7 +85,7 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
      * Checkpoint Buffer, it creates a spike of load on it. The test is successful if the CP Buffer protection
      * does not break down and no exception gets thrown as a result.
      *
-     * @throws Exception if something goes wrong
+     * @throws Exception if something goes wrong.
      */
     @Test
     public void speedBasedThrottleShouldNotAllowCPBufferBreakdownWhenCPBufferIsSmall() throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -106,13 +106,8 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
         IgniteCache<Object, Object> cache = ignite.cache(CACHE_NAME);
 
         for (int i = 0; i < 100_000; i++) {
-            cache.put(key(i), ThreadLocalRandom.current().nextDouble());
+            cache.put("key" + i, ThreadLocalRandom.current().nextDouble());
         }
-    }
-
-    /***/
-    private static String key(int index) {
-        return "key" + index;
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -88,7 +88,16 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
         return 3L * 60 * 1000;
     }
 
-    /***/
+    /**
+     * There was the following bug: at the very start of a checkpoint, the checkpoint progress information was not yet
+     * available to the speed-based throttler, in which case it did not apply throttling. If during that short period
+     * there was high pressure on the Checkpoint Buffer, the buffer would be exhausted causing to node failure.
+     *
+     * It was easy to reproduce with a small Checkpoint Buffer. This test does exactly this: with a small
+     * Checkpoint Buffer, it creates a spike of load on it.
+     *
+     * @throws Exception if something goes wrong
+     */
     @Test
     public void speedBasedThrottleShouldNotAllowCPBufferBreakdownWhenCPBufferIsSmall() throws Exception {
         Ignite ignite = startGrids(1);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -79,10 +79,11 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
     /**
      * There was the following bug: at the very start of a checkpoint, the checkpoint progress information was not yet
      * available to the speed-based throttler, in which case it did not apply throttling. If during that short period
-     * there was high pressure on the Checkpoint Buffer, the buffer would be exhausted causing to node failure.
+     * there was high pressure on the Checkpoint Buffer, the buffer would be exhausted causing node failure.
      *
      * It was easy to reproduce with a small Checkpoint Buffer. This test does exactly this: with a small
-     * Checkpoint Buffer, it creates a spike of load on it.
+     * Checkpoint Buffer, it creates a spike of load on it. The test is successful if the CP Buffer protection
+     * does not break down and no exception gets thrown as a result.
      *
      * @throws Exception if something goes wrong
      */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.internal.processors.cache.persistence.pagemem;
 
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
@@ -24,6 +25,8 @@ import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import static org.apache.ignite.cluster.ClusterState.ACTIVE;
 
@@ -32,7 +35,21 @@ import static org.apache.ignite.cluster.ClusterState.ACTIVE;
  *
  * @see PagesWriteSpeedBasedThrottle
  */
+@RunWith(Parameterized.class)
 public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
+    /***/
+    @Parameterized.Parameter
+    public boolean useSpeedBasedThrottling;
+
+    /** Parameters. */
+    @Parameterized.Parameters(name = "Use speed-based throttling: {0}")
+    public static Iterable<Boolean[]> data() {
+        return Arrays.asList(
+            new Boolean[] {true},
+            new Boolean[] {false}
+        );
+    }
+
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
         IgniteConfiguration cfg = super.getConfiguration(gridName);
@@ -43,7 +60,7 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
                         .setCheckpointPageBufferSize(3_000_000)
                         .setPersistenceEnabled(true))
                 .setCheckpointFrequency(200)
-                .setWriteThrottlingEnabled(true);
+                .setWriteThrottlingEnabled(useSpeedBasedThrottling);
 
         cfg.setDataStorageConfiguration(dbCfg);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.pagemem;
+
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static org.apache.ignite.cluster.ClusterState.ACTIVE;
+
+/**
+ * Tests for the cases when high load might break down speed-based throttling protection.
+ *
+ * @see PagesWriteSpeedBasedThrottle
+ */
+public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
+    /** Cache name. */
+    private static final String CACHE_NAME = "cache1";
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(gridName);
+
+        DataStorageConfiguration dbCfg = new DataStorageConfiguration()
+                .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
+                        // tiny CP buffer is required to reproduce this problem easily
+                        .setCheckpointPageBufferSize(3_000_000)
+                        .setName("dfltDataRegion")
+                        .setPersistenceEnabled(true))
+                .setCheckpointFrequency(200)
+                .setWriteThrottlingEnabled(true);
+
+        cfg.setDataStorageConfiguration(dbCfg);
+
+        CacheConfiguration ccfg1 = new CacheConfiguration();
+
+        ccfg1.setName(CACHE_NAME);
+        ccfg1.setIndexedTypes(String.class, String.class);
+
+        cfg.setCacheConfiguration(ccfg1);
+
+        cfg.setConsistentId(gridName);
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
+
+        deleteWorkFiles();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids();
+
+        super.afterTest();
+
+        deleteWorkFiles();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected long getTestTimeout() {
+        return 3L * 60 * 1000;
+    }
+
+    /***/
+    @Test
+    public void speedBasedThrottleShouldNotAllowCPBufferBreakdownWhenCPBufferIsSmall() throws Exception {
+        startGrids(1).cluster().state(ACTIVE);
+        Ignite ignite = ignite(0);
+        IgniteCache<Object, Object> cache = ignite.cache(CACHE_NAME);
+
+        for (int i = 0; i < 100_000; i++) {
+            cache.put(key(i), ThreadLocalRandom.current().nextDouble());
+        }
+    }
+
+    /***/
+    private static String key(int index) {
+        return "key" + index;
+    }
+
+    /**
+     * @throws IgniteCheckedException If failed.
+     */
+    private void deleteWorkFiles() throws Exception {
+        cleanPersistenceDir();
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "snapshot", false));
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -23,6 +23,7 @@ import org.apache.ignite.IgniteCache;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.util.typedef.G;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -113,6 +114,8 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
         for (int i = 0; i < 100_000; i++) {
             cache.put("key" + i, ThreadLocalRandom.current().nextDouble());
         }
+
+        assertFalse(G.allGrids().isEmpty());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -19,7 +19,6 @@ package org.apache.ignite.internal.processors.cache.persistence.pagemem;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
-import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
@@ -35,9 +34,6 @@ import static org.apache.ignite.cluster.ClusterState.ACTIVE;
  * @see PagesWriteSpeedBasedThrottle
  */
 public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
-    /** Cache name. */
-    private static final String CACHE_NAME = "cache1";
-
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String gridName) throws Exception {
         IgniteConfiguration cfg = super.getConfiguration(gridName);
@@ -52,13 +48,6 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
                 .setWriteThrottlingEnabled(true);
 
         cfg.setDataStorageConfiguration(dbCfg);
-
-        CacheConfiguration ccfg1 = new CacheConfiguration();
-
-        ccfg1.setName(CACHE_NAME);
-        ccfg1.setIndexedTypes(String.class, String.class);
-
-        cfg.setCacheConfiguration(ccfg1);
 
         cfg.setConsistentId(gridName);
 
@@ -103,7 +92,7 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
         Ignite ignite = startGrids(1);
 
         ignite.cluster().state(ACTIVE);
-        IgniteCache<Object, Object> cache = ignite.cache(CACHE_NAME);
+        IgniteCache<Object, Object> cache = ignite.createCache(DEFAULT_CACHE_NAME);
 
         for (int i = 0; i < 100_000; i++) {
             cache.put("key" + i, ThreadLocalRandom.current().nextDouble());

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedThrottleBreakdownTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 GridGain Systems, Inc. and Contributors.
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
  *
  * Licensed under the GridGain Community Edition License (the "License");
  * you may not use this file except in compliance with the License.
@@ -90,8 +90,9 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
     /***/
     @Test
     public void speedBasedThrottleShouldNotAllowCPBufferBreakdownWhenCPBufferIsSmall() throws Exception {
-        startGrids(1).cluster().state(ACTIVE);
-        Ignite ignite = ignite(0);
+        IgniteEx ignite = startGrids(1);
+        
+        ignite.cluster().state(ACTIVE);
         IgniteCache<Object, Object> cache = ignite.cache(CACHE_NAME);
 
         for (int i = 0; i < 100_000; i++) {
@@ -105,7 +106,7 @@ public class SpeedBasedThrottleBreakdownTest extends GridCommonAbstractTest {
     }
 
     /**
-     * @throws IgniteCheckedException If failed.
+     * @throws Exception If failed.
      */
     private void deleteWorkFiles() throws Exception {
         cleanPersistenceDir();

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgnitePdsTestSuite5.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgnitePdsTestSuite5.java
@@ -33,6 +33,7 @@ import org.apache.ignite.internal.processors.cache.persistence.pagemem.PageMemor
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.PageMemoryLazyAllocationWithPDSTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.PageMemoryNoStoreLeakTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.PagesWriteThrottleSmokeTest;
+import org.apache.ignite.internal.processors.cache.persistence.pagemem.SpeedBasedThrottleBreakdownTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.UsedPagesMetricTest;
 import org.apache.ignite.internal.processors.cache.persistence.pagemem.UsedPagesMetricTestPersistence;
 import org.apache.ignite.internal.processors.cache.persistence.wal.CpTriggeredWalDeltaConsistencyTest;
@@ -82,6 +83,7 @@ public class IgnitePdsTestSuite5 {
 
         // Write throttling
         GridTestUtils.addTestIfNeeded(suite, PagesWriteThrottleSmokeTest.class, ignoredTests);
+        GridTestUtils.addTestIfNeeded(suite, SpeedBasedThrottleBreakdownTest.class, ignoredTests);
 
         // Discovery data handling on node join and old cluster abnormal shutdown
         GridTestUtils.addTestIfNeeded(suite, IgnitePdsDiscoDataHandlingInNewClusterTest.class, ignoredTests);


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-34464

In GG-33675, a speed-based throttling breakage bug was fixed, but we only covered the fix with local JUnit tests. Here, we add an integration test to rest assured.