### PR TITLE
GG-34735 [IGNITE-13389] Thin client: optionally append server exception stack trace to error message

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/ThinClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ThinClientConfiguration.java
@@ -36,6 +36,9 @@ public class ThinClientConfiguration {
     /** Active compute tasks per connection limit. */
     private int maxActiveComputeTasksPerConn = DFLT_MAX_ACTIVE_COMPUTE_TASKS_PER_CONNECTION;
 
+    /** If {@code true} sends a server exception stack trace to the client side. */
+    private boolean sendServerExcStackTraceToClient;
+
     /**
      * Creates thin-client configuration with all default values.
      */
@@ -53,6 +56,7 @@ public class ThinClientConfiguration {
 
         maxActiveTxPerConn = cfg.maxActiveTxPerConn;
         maxActiveComputeTasksPerConn = cfg.maxActiveComputeTasksPerConn;
+        sendServerExcStackTraceToClient = cfg.sendServerExcStackTraceToClient;
     }
 
     /**
@@ -92,6 +96,20 @@ public class ThinClientConfiguration {
         this.maxActiveComputeTasksPerConn = maxActiveComputeTasksPerConn;
 
         return this;
+    }
+
+    /**
+     * @return If {@code true} sends a server exception stack to the client side.
+     */
+    public boolean sendServerExceptionStackTraceToClient() {
+        return sendServerExcStackTraceToClient;
+    }
+
+    /**
+     * @param sendServerExcStackTraceToClient If {@code true} sends a server exception stack to the client side.
+     */
+    public void sendServerExceptionStackTraceToClient(boolean sendServerExcStackTraceToClient) {
+        this.sendServerExcStackTraceToClient = sendServerExcStackTraceToClient;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -6324,7 +6324,14 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
                 CacheLazyEntry<Object, Object> interceptEntry =
                     new CacheLazyEntry<>(cctx, entry.key, null, oldVal, null, keepBinary);
 
-                Object interceptorVal = cctx.config().getInterceptor().onBeforePut(interceptEntry, updated0);
+                Object interceptorVal = null;
+
+                try {
+                    interceptorVal = cctx.config().getInterceptor().onBeforePut(interceptEntry, updated0);
+                }
+                catch (Throwable e) {
+                    throw new IgniteCheckedException(e);
+                }
 
                 wasIntercepted = true;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/configuration/distributed/DistributedThinClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/configuration/distributed/DistributedThinClientConfiguration.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.configuration.distributed;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.processors.subscription.GridInternalSubscriptionProcessor;
+import org.apache.ignite.internal.util.future.GridFutureAdapter;
+import org.jetbrains.annotations.Nullable;
+
+import static org.apache.ignite.internal.cluster.DistributedConfigurationUtils.makeUpdateListener;
+import static org.apache.ignite.internal.processors.configuration.distributed.DistributedBooleanProperty.detachedBooleanProperty;
+
+/**
+ * Thin client distributed configuration.
+ */
+public class DistributedThinClientConfiguration {
+    /** */
+    private final IgniteLogger log;
+
+    /** . */
+    private final DistributedChangeableProperty<Boolean> showStackTrace =
+        detachedBooleanProperty("thinClientProperty.showStackTrace");
+
+    /** Message of baseline auto-adjust parameter was changed. */
+    private static final String PROPERTY_UPDATE_MESSAGE =
+        "ThinClientProperty parameter '%s' was changed from '%s' to '%s'";
+
+    /**
+     * @param ctx Kernal context.
+     */
+    public DistributedThinClientConfiguration(
+        GridKernalContext ctx
+    ) {
+        log = ctx.log(DistributedThinClientConfiguration.class);
+
+        GridInternalSubscriptionProcessor isp = ctx.internalSubscriptionProcessor();
+
+        isp.registerDistributedConfigurationListener(
+            new DistributedConfigurationLifecycleListener() {
+                @Override public void onReadyToRegister(DistributedPropertyDispatcher dispatcher) {
+                    showStackTrace.addListener(makeUpdateListener(PROPERTY_UPDATE_MESSAGE, log));
+
+                    dispatcher.registerProperties(showStackTrace);
+                }
+            }
+        );
+    }
+
+    /**
+     * @param showStack If {@code true} shows full stack trace on the client side.
+     * @return Future for update operation.
+     */
+    public GridFutureAdapter<?> updateThinClientSendServerStackTraceAsync(boolean showStack) throws IgniteCheckedException {
+        return showStackTrace.propagateAsync(showStack);
+    }
+
+    /**
+     * @return If {@code true}, thin client response will include full stack trace when exception occurs.
+     * When {@code false}, only top level exception message is included.
+     */
+    @Nullable public Boolean sendServerExceptionStackTraceToClient() {
+        return showStackTrace.get();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/configuration/distributed/DistributedThinClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/configuration/distributed/DistributedThinClientConfiguration.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
@@ -29,6 +29,7 @@ import javax.management.JMException;
 import javax.management.ObjectName;
 import javax.net.ssl.SSLContext;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.OdbcConfiguration;
@@ -38,6 +39,7 @@ import org.apache.ignite.internal.direct.DirectMessageWriter;
 import org.apache.ignite.internal.managers.systemview.walker.ClientConnectionViewWalker;
 import org.apache.ignite.internal.processors.GridProcessorAdapter;
 import org.apache.ignite.internal.processors.authentication.AuthorizationContext;
+import org.apache.ignite.internal.processors.configuration.distributed.DistributedThinClientConfiguration;
 import org.apache.ignite.internal.processors.odbc.jdbc.JdbcConnectionContext;
 import org.apache.ignite.internal.processors.odbc.odbc.OdbcConnectionContext;
 import org.apache.ignite.internal.ssl.SSLContextClientAuthWrapper;
@@ -91,6 +93,9 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
 
     /** Executor service. */
     private ExecutorService execSvc;
+
+    /** Thin client distributed configuration. */
+    private DistributedThinClientConfiguration distrThinCfg;
 
     /**
      * @param ctx Kernal context.
@@ -199,6 +204,8 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
                     new ClientConnectionViewWalker(),
                     srv.sessions(),
                     ClientConnectionView::new);
+
+                distrThinCfg = new DistributedThinClientConfiguration(ctx);
             }
             catch (Exception e) {
                 throw new IgniteCheckedException("Failed to start client connector processor.", e);
@@ -565,6 +572,16 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
     }
 
     /**
+     * @return If {@code true} sends a server exception stack to the client side.
+     */
+    public boolean sendServerExceptionStackTraceToClient() {
+        Boolean send = distrThinCfg.sendServerExceptionStackTraceToClient();
+
+        return send == null ?
+            ctx.config().getClientConnectorConfiguration().getThinClientConfiguration().sendServerExceptionStackTraceToClient() : send;
+    }
+
+    /**
      * ClientProcessorMXBean interface.
      */
     private class ClientProcessorMXBeanImpl implements ClientProcessorMXBean {
@@ -625,6 +642,16 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
             }
 
             return false;
+        }
+
+        /** {@inheritDoc} */
+        @Override public void showFullStackOnClientSide(boolean show) {
+            try {
+                distrThinCfg.updateThinClientSendServerStackTraceAsync(show).get();
+            }
+            catch (IgniteCheckedException e) {
+                throw new IgniteException(e);
+            }
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientRequestHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientRequestHandler.java
@@ -31,6 +31,8 @@ import org.apache.ignite.internal.processors.platform.client.cache.ClientCacheSq
 import org.apache.ignite.internal.processors.platform.client.cache.ClientCacheSqlQueryRequest;
 import org.apache.ignite.internal.processors.platform.client.tx.ClientTxAwareRequest;
 import org.apache.ignite.internal.processors.platform.client.tx.ClientTxContext;
+import org.apache.ignite.internal.util.typedef.X;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.plugin.security.SecurityException;
 
 import static org.apache.ignite.internal.processors.platform.client.ClientProtocolVersionFeature.BITMAP_FEATURES;
@@ -121,6 +123,10 @@ public class ClientRequestHandler implements ClientListenerRequestHandler {
             String sqlState = IgniteQueryErrorCode.codeToSqlState(SqlListenerUtils.exceptionToSqlErrorCode(e));
             msg = sqlState + ": " + msg;
         }
+
+        if ((X.getCause(e) != null || !X.getSuppressedList(e).isEmpty())
+                && ctx.kernalContext().sqlListener().sendServerExceptionStackTraceToClient())
+            msg = msg + U.nl() + X.getFullStackTrace(e);
 
         return new ClientResponse(req.requestId(), status, msg);
     }

--- a/modules/core/src/main/java/org/apache/ignite/mxbean/ClientProcessorMXBean.java
+++ b/modules/core/src/main/java/org/apache/ignite/mxbean/ClientProcessorMXBean.java
@@ -47,4 +47,14 @@ public interface ClientProcessorMXBean {
     public boolean dropConnection(
         @MXBeanParameter(name = "id", description = "Client connection ID.") long id
     );
+
+    /**
+     * If sets to {@code true} shows full stack trace otherwise highlevel short error message.
+     *
+     * @param show Show flag.
+     */
+    @MXBeanDescription("Show error full stack.")
+    void showFullStackOnClientSide(
+        @MXBeanParameter(name = "show", description = "Show error full stack.") boolean show
+    );
 }

--- a/modules/core/src/test/java/org/apache/ignite/client/IgniteBinaryTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/IgniteBinaryTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.cache.Cache;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteBinary;
 import org.apache.ignite.IgniteCache;
@@ -34,23 +35,30 @@ import org.apache.ignite.binary.BinarySerializer;
 import org.apache.ignite.binary.BinaryType;
 import org.apache.ignite.binary.BinaryTypeConfiguration;
 import org.apache.ignite.binary.BinaryWriter;
+import org.apache.ignite.cache.CacheInterceptorAdapter;
 import org.apache.ignite.configuration.BinaryConfiguration;
+import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.binary.BinaryObjectImpl;
 import org.apache.ignite.internal.binary.GridBinaryMarshaller;
+import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
+import org.apache.ignite.internal.util.typedef.X;
+import org.apache.ignite.mxbean.ClientProcessorMXBean;
 import org.apache.ignite.testframework.GridTestUtils;
+import org.apache.ignite.testframework.ListeningTestLogger;
+import org.apache.ignite.testframework.LogListener;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.Timeout;
 
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Ignite {@link BinaryObject} API system tests.
  */
-public class IgniteBinaryTest {
+public class IgniteBinaryTest extends GridCommonAbstractTest {
     /** Per test timeout */
     @Rule
     public Timeout globalTimeout = new Timeout((int) GridTestUtils.DFLT_TEST_TIMEOUT);
@@ -130,6 +138,76 @@ public class IgniteBinaryTest {
                 assertBinaryObjectsEqual(val, cachedVal);
             }
         }
+    }
+
+    /**
+     * Tests that {@code org.apache.ignite.cache.CacheInterceptor#onBeforePut(javax.cache.Cache.Entry, java.lang.Object)}
+     * throws correct exception in case while cache operations are called from thin client. Only BinaryObject`s are
+     * acceptable in this case.
+     */
+    @Test
+    public void testBinaryWithNotGenericInterceptor() throws Exception {
+        IgniteConfiguration ccfg = Config.getServerConfiguration()
+            .setCacheConfiguration(new CacheConfiguration("test").setInterceptor(new ThinBinaryValueInterceptor()));
+
+        String castErr = "cannot be cast to";
+        String treeErr = "B+Tree is corrupted";
+
+        ListeningTestLogger srvLog = new ListeningTestLogger(log);
+
+        LogListener lsnrCast = LogListener.matches(castErr).
+            andMatches(str -> !str.contains(treeErr)).build();
+
+        srvLog.registerListener(lsnrCast);
+
+        ccfg.setGridLogger(srvLog);
+
+        try (Ignite ign = Ignition.start(ccfg)) {
+            try (IgniteClient client =
+                     Ignition.startClient(new ClientConfiguration().setAddresses(Config.SERVER))
+            ) {
+                ClientCache<Integer, ThinBinaryValue> cache = client.cache("test");
+
+                try {
+                    cache.put(1, new ThinBinaryValue());
+
+                    fail();
+                }
+                catch (Exception e) {
+                    assertFalse(X.getFullStackTrace(e).contains(castErr));
+                }
+
+                ClientProcessorMXBean serverMxBean = getMxBean(ign.name(), "Clients",
+                        ClientProcessorMXBean.class, ClientListenerProcessor.class);
+
+                serverMxBean.showFullStackOnClientSide(true);
+
+                try {
+                    cache.put(1, new ThinBinaryValue());
+                }
+                catch (Exception e) {
+                    assertTrue(X.getFullStackTrace(e).contains(castErr));
+                }
+            }
+        }
+
+        assertTrue(lsnrCast.check());
+    }
+
+    /**
+     * Test interceptor implementation.
+     */
+    private static class ThinBinaryValueInterceptor extends CacheInterceptorAdapter<String, ThinBinaryValue> {
+        /** {@inheritDoc} */
+        @Override public ThinBinaryValue onBeforePut(Cache.Entry<String, ThinBinaryValue> entry, ThinBinaryValue newVal) {
+            return super.onBeforePut(entry, newVal);
+        }
+    }
+
+    /**
+     * Test value class.
+     */
+    private static class ThinBinaryValue {
     }
 
     /**


### PR DESCRIPTION
* Add `ThinClientConfiguration.sendServerExceptionStackTraceToClient`, default false. When true, include exception stack trace with error message in thin client response.
* Add `DistributedThinClientConfiguration` and `ClientProcessorMXBean.showFullStackOnClientSide` to control the behavior for the entire cluster at runtime.

Co-authored-by: zstan <stanilovsky@gmail.com>
Co-authored-by: Sergei Ryzhov <s.vi.ryzhov@gmail.com>