### PR TITLE
GG-34903 [IGNITE-16649] .NET: Fix missing binary schema update when field is removed

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySchemaChangeTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySchemaChangeTest.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Binary
+{
+    using System.Linq;
+    using Apache.Ignite.Core.Binary;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests that schema can be changed for an existing binary type.
+    /// </summary>
+    public class BinarySchemaChangeTest
+    {
+        /** */
+        private const string CacheName = "TEST";
+
+        /** */
+        private IIgnite _grid;
+
+        /** */
+        private IIgnite _clientGrid;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _grid = Ignition.Start(TestUtils.GetTestConfiguration());
+
+            _clientGrid = Ignition.Start(new IgniteConfiguration(TestUtils.GetTestConfiguration())
+            {
+                ClientMode = true,
+                IgniteInstanceName = "client"
+            });
+
+            _grid.GetOrCreateCache<int, object>(CacheName);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Ignition.StopAll(true);
+        }
+
+        [Test]
+        public void TestAddRemoveFieldsUpdatesSchema()
+        {
+            var objWith3Fields = new TestObj
+            {
+                Fields = new[] { "Field1", "Field2", "Field3" },
+                Field1 = "1",
+                Field2 = "2",
+                Field3 = "3"
+            };
+
+            var objWith2Fields = new TestObj
+            {
+                Fields = new[] { "Field1", "Field2" },
+                Field1 = "test1",
+                Field2 = "test2"
+            };
+
+            var objWith1Field = new TestObj
+            {
+                Fields = new[] { "Field1" },
+                Field1 = "test1"
+            };
+
+            var clientCache = _clientGrid.GetCache<int, TestObj>(CacheName);
+            var serverCache = _grid.GetCache<int, TestObj>(CacheName);
+
+            clientCache.Put(1, objWith2Fields);
+            serverCache.Get(1);
+
+            clientCache.Put(2, objWith1Field);
+            serverCache.Get(2);
+
+            clientCache.Put(3, objWith3Fields);
+            serverCache.Get(3);
+        }
+
+        private class TestObj : IBinarizable
+        {
+            public string[] Fields { get; set; }
+
+            public string Field1 { get; set; }
+
+            public string Field2 { get; set; }
+
+            public string Field3 { get; set; }
+
+            public void WriteBinary(IBinaryWriter writer)
+            {
+                writer.WriteStringArray(nameof(Fields), Fields);
+
+                if (Fields.Contains(nameof(Field1)))
+                    writer.WriteString(nameof(Field1), Field1);
+
+                if (Fields.Contains(nameof(Field2)))
+                    writer.WriteString(nameof(Field2), Field2);
+
+                if (Fields.Contains(nameof(Field3)))
+                    writer.WriteString(nameof(Field3), Field3);
+
+            }
+
+            public void ReadBinary(IBinaryReader reader)
+            {
+                Fields = reader.ReadStringArray(nameof(Fields));
+
+                if (Fields.Contains(nameof(Field1)))
+                    Field1 = reader.ReadString(nameof(Field1));
+
+                if (Fields.Contains(nameof(Field2)))
+                    Field2 = reader.ReadString(nameof(Field2));
+
+                if (Fields.Contains(nameof(Field3)))
+                    Field3 = reader.ReadString(nameof(Field3));
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -1238,6 +1238,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             _frame.HasCustomTypeData = false;
 
             var schemaIdx = _schema.PushSchema();
+            bool isNewSchema = false;
 
             try
             {
@@ -1272,7 +1273,10 @@ namespace Apache.Ignite.Core.Impl.Binary
 
                     // Update schema in type descriptor
                     if (desc.Schema.Get(schemaId) == null)
+                    {
                         desc.Schema.Add(schemaId, _schema.GetSchema(schemaIdx));
+                        isNewSchema = true;
+                    }
                 }
                 else
                     schemaOffset = headerSize;
@@ -1303,7 +1307,7 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
 
             // Apply structure updates if any.
-            _frame.Struct.UpdateWriterStructure(this);
+            _frame.Struct.UpdateWriterStructure(this, isNewSchema);
 
             // Restore old frame.
             _frame = oldFrame;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructure.cs
@@ -25,7 +25,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
     /// Binary type structure. Cache field IDs and metadata to improve marshalling performance.
     /// Every object write contains a set of field writes. Every unique ordered set of written fields
     /// produce write "path". We cache these paths allowing for very fast traverse over object structure
-    /// without expensive map lookups and field ID calculations. 
+    /// without expensive map lookups and field ID calculations.
     /// </summary>
     internal class BinaryStructure
     {
@@ -35,7 +35,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         /// <returns>Empty type structure.</returns>
         public static BinaryStructure CreateEmpty()
         {
-            return new BinaryStructure(new[] { new BinaryStructureEntry[0] }, 
+            return new BinaryStructure(new[] { new BinaryStructureEntry[0] },
                 new BinaryStructureJumpTable[1], new Dictionary<string, byte>());
         }
 
@@ -60,7 +60,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
             Debug.Assert(paths != null);
             Debug.Assert(jumps != null);
             Debug.Assert(fieldTypes != null);
-            
+
             _paths = paths;
             _jumps = jumps;
             _fieldTypes = fieldTypes;
@@ -78,7 +78,7 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         {
             Debug.Assert(fieldName != null);
             Debug.Assert(pathIdx <= _paths.Length);
-            
+
             // Get path.
             BinaryStructureEntry[] path = _paths[pathIdx];
 
@@ -223,6 +223,19 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         }
 
         /// <summary>
+        /// Gets a value indicating whether specified action index is at the path end or further.
+        /// </summary>
+        /// <param name="pathIdx">Path index.</param>
+        /// <param name="actionIdx">Action index.</param>
+        /// <returns>True when specified action is at or beyond the path end; false otherwise.</returns>
+        public bool IsPathEnd(int pathIdx, int actionIdx)
+        {
+            BinaryStructureEntry[] path = _paths[pathIdx];
+
+            return actionIdx >= path.Length - 1;
+        }
+
+        /// <summary>
         /// Copy and possibly expand paths.
         /// </summary>
         /// <param name="minLen">Minimum length.</param>
@@ -311,6 +324,6 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         internal IDictionary<string, byte> FieldTypes
         {
             get { return _fieldTypes; }
-        } 
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/Structure/BinaryStructureTracker.cs
@@ -92,7 +92,8 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
         /// Updates the type structure and metadata for the specified writer.
         /// </summary>
         /// <param name="writer">The writer.</param>
-        public void UpdateWriterStructure(BinaryWriter writer)
+        /// <param name="isNewSchema">Whether the current schema is know to be new.</param>
+        public void UpdateWriterStructure(BinaryWriter writer, bool isNewSchema)
         {
             if (_curStructUpdates != null)
             {
@@ -122,6 +123,11 @@ namespace Apache.Ignite.Core.Impl.Binary.Structure
                 writer.Marshaller.GetBinaryTypeHandler(_desc);
                 writer.SaveMetadata(_desc, null);
                 _desc.UpdateWriteStructure(_curStructPath, null);
+            }
+            else if (isNewSchema && _portStruct != null && !_portStruct.IsPathEnd(_curStructPath, _curStructAction))
+            {
+                // Subset of current schema is a different schema and should be saved.
+                writer.SaveMetadata(_desc, null);
             }
         }
 


### PR DESCRIPTION
When new binary object schema is a subset of existing schema, it was not sent to the cluster. Detect this case and send the schema.