### PR TITLE
GG-34757 [IGNITE-16462] .NET: Thin client: add heartbeats

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -51,7 +51,13 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     BINARY_CONFIGURATION(8),
 
     /** Service descriptors retrieval. */
-    GET_SERVICE_DESCRIPTORS(9);
+    GET_SERVICE_DESCRIPTORS(9),
+
+    /** Invoke service methods with caller context. */
+    SERVICE_INVOKE_CALLCTX(10),
+
+    /** Handle OP_HEARTBEAT and OP_GET_IDLE_TIMEOUT. */
+    HEARTBEAT(11);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientGetIdleTimeoutRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientGetIdleTimeoutRequest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client;
+
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.configuration.ClientConnectorConfiguration;
+
+/**
+ * Get idle timeout request.
+ */
+public class ClientGetIdleTimeoutRequest extends ClientRequest {
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    ClientGetIdleTimeoutRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        return new ClientLongResponse(requestId(), getEffectiveIdleTimeout(ctx));
+    }
+
+    /**
+     * Gets the effective idle timeout.
+     *
+     * @param ctx Context.
+     * @return Idle timeout.
+     */
+    private static long getEffectiveIdleTimeout(ClientConnectionContext ctx) {
+        ClientConnectorConfiguration cfg = ctx.kernalContext().config().getClientConnectorConfiguration();
+
+        return cfg == null ? ClientConnectorConfiguration.DFLT_IDLE_TIMEOUT : cfg.getIdleTimeout();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -93,6 +93,12 @@ public class ClientMessageParser implements ClientListenerMessageParser {
     /** */
     private static final short OP_RESOURCE_CLOSE = 0;
 
+    /** */
+    private static final short OP_HEARTBEAT = 1;
+
+    /** */
+    private static final short OP_GET_IDLE_TIMEOUT = 2;
+
     /* Cache operations */
     /** */
     private static final short OP_CACHE_GET = 1000;
@@ -362,6 +368,12 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
             case OP_RESOURCE_CLOSE:
                 return new ClientResourceCloseRequest(reader);
+
+            case OP_HEARTBEAT:
+                return new ClientRequest(reader);
+
+            case OP_GET_IDLE_TIMEOUT:
+                return new ClientGetIdleTimeoutRequest(reader);
 
             case OP_CACHE_CONTAINS_KEY:
                 return new ClientCacheContainsKeyRequest(reader);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientHeartbeatTest.cs
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Configuration;
+    using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Tests client heartbeat functionality (<see cref="IgniteClientConfiguration.HeartbeatInterval"/>).
+    /// </summary>
+    [Category(TestUtils.CategoryIntensive)]
+    public class ClientHeartbeatTest : ClientTestBase
+    {
+        /** GridNioServer has hardcoded 2000ms idle check interval, so a smaller idle timeout does not make sense. */
+        private static readonly int IdleTimeout = 2000;
+
+        public ClientHeartbeatTest() : base(gridCount: 2)
+        {
+            // No-op.
+        }
+
+        [Test]
+        public void TestServerDisconnectsIdleClientWithoutHeartbeats()
+        {
+            using var client = GetClient(enableHeartbeats: false);
+
+            Assert.AreEqual(1, client.GetCacheNames().Count);
+
+            Thread.Sleep(IdleTimeout * 4);
+
+            Assert.Catch(() => client.GetCacheNames());
+        }
+
+        [Test]
+        public void TestServerDoesNotDisconnectIdleClientWithHeartbeats()
+        {
+            using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 1500);
+
+            Assert.AreEqual(1500, client.GetConfiguration().HeartbeatInterval.TotalMilliseconds);
+            Assert.IsTrue(client.GetConfiguration().EnableHeartbeats);
+            Assert.AreEqual(1, client.GetCacheNames().Count);
+
+            Thread.Sleep(IdleTimeout * 3);
+
+            Assert.DoesNotThrow(() => client.GetCacheNames());
+        }
+
+        [Test]
+        public void TestDefaultZeroIdleTimeoutUsesConfiguredHeartbeatInterval()
+        {
+            using var ignite = Ignition.Start(TestUtils.GetTestConfiguration(name: "2"));
+            using var client = GetClient(enableHeartbeats: true, port: IgniteClientConfiguration.DefaultPort + 2);
+
+            Assert.AreEqual(IgniteClientConfiguration.DefaultHeartbeatInterval,
+                client.GetConfiguration().HeartbeatInterval);
+
+            StringAssert.Contains(
+                "Server-side IdleTimeout is not set, " +
+                "using configured IgniteClientConfiguration.HeartbeatInterval: 00:00:30", GetLogString(client));
+        }
+
+        [Test]
+        public void TestCustomHeartbeatIntervalOverridesCalculatedFromIdleTimeout()
+        {
+            using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 300);
+
+            Assert.AreEqual(TimeSpan.FromMilliseconds(300), client.GetConfiguration().HeartbeatInterval);
+
+            StringAssert.Contains("Server-side IdleTimeout is 2000ms, using configured IgniteClientConfiguration." +
+                                  "HeartbeatInterval: 00:00:00.3000000", GetLogString(client));
+        }
+
+        [Test]
+        public void TestCustomHeartbeatIntervalLongerThanRecommendedDoesNotOverrideCalculatedFromIdleTimeout()
+        {
+            using var client = GetClient(enableHeartbeats: true, heartbeatInterval: 3000);
+
+            Assert.AreEqual(TimeSpan.FromMilliseconds(3000), client.GetConfiguration().HeartbeatInterval);
+
+            StringAssert.Contains(
+                "Server-side IdleTimeout is 2000ms, configured IgniteClientConfiguration.HeartbeatInterval is " +
+                "00:00:03, which is longer than recommended IdleTimeout / 3. " +
+                "Overriding heartbeat interval with IdleTimeout / 3: 00:00:00.6660000",
+                GetLogString(client));
+        }
+
+        [Test]
+        public void TestZeroOrNegativeHeartbeatIntervalThrows()
+        {
+            Assert.Throws<IgniteClientException>(() => GetClient(enableHeartbeats: true, heartbeatInterval: 0));
+            Assert.Throws<IgniteClientException>(() => GetClient(enableHeartbeats: true, heartbeatInterval: -1));
+        }
+
+        protected override IgniteConfiguration GetIgniteConfiguration()
+        {
+            return new IgniteConfiguration(base.GetIgniteConfiguration())
+            {
+                ClientConnectorConfiguration = new ClientConnectorConfiguration
+                {
+                    IdleTimeout = TimeSpan.FromMilliseconds(IdleTimeout)
+                }
+            };
+        }
+
+        protected override IgniteClientConfiguration GetClientConfiguration()
+        {
+            return new IgniteClientConfiguration(base.GetClientConfiguration())
+            {
+                // Keep default client alive.
+                EnableHeartbeats = true
+            };
+        }
+
+        private static IIgniteClient GetClient(bool enableHeartbeats, int? heartbeatInterval = null,
+            int port = IgniteClientConfiguration.DefaultPort)
+        {
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new List<string> { $"{IPAddress.Loopback}:{port}" },
+                EnableHeartbeats = enableHeartbeats,
+                Logger = new ListLogger
+                {
+                    EnabledLevels = new[] { LogLevel.Debug, LogLevel.Info, LogLevel.Warn, LogLevel.Error }
+                },
+                EnablePartitionAwareness = true
+            };
+
+            if (heartbeatInterval != null)
+            {
+                cfg.HeartbeatInterval = TimeSpan.FromMilliseconds(heartbeatInterval.Value);
+            }
+
+            return Ignition.StartClient(cfg);
+        }
+
+        private static string GetLogString(IIgniteClient client)
+        {
+            var logger = (ListLogger)client.GetConfiguration().Logger;
+
+            return string.Join(Environment.NewLine, logger.Entries.Select(e => e.Message));
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/IgniteClientConfigurationTest.cs
@@ -108,7 +108,9 @@ namespace Apache.Ignite.Core.Tests.Client
                     DefaultTimeout = TimeSpan.FromSeconds(1),
                     DefaultTransactionConcurrency = TransactionConcurrency.Optimistic,
                     DefaultTransactionIsolation = TransactionIsolation.Serializable
-                }
+                },
+                RetryLimit = 33,
+                HeartbeatInterval = TimeSpan.FromSeconds(30)
             };
 
             using (var xmlReader = XmlReader.Create(Path.Combine("Config", "Client", "IgniteClientConfiguration.xml")))

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/IgniteClientConfiguration.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Client/IgniteClientConfiguration.xml
@@ -16,8 +16,8 @@
  limitations under the License.
 -->
 
-<igniteClientConfiguration host="test1" port="345" socketReceiveBufferSize="222" socketSendBufferSize="333"
-                           tcpNoDelay="false" socketTimeout="0:0:15" enablePartitionAwareness="true">
+<igniteClientConfiguration heartbeatInterval="0:0:30" host="test1" port="345" socketReceiveBufferSize="222" socketSendBufferSize="333"
+                           tcpNoDelay="false" socketTimeout="0:0:15" enablePartitionAwareness="true" retryLimit="33">
     <binaryConfiguration compactFooter="false" keepDeserialized="false">
         <types>
             <string>foo</string>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -24,6 +24,7 @@ namespace Apache.Ignite.Core.Client
     using System.Xml;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client.Transactions;
+    using Apache.Ignite.Core.Configuration;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Client;
     using Apache.Ignite.Core.Impl.Common;
@@ -62,6 +63,11 @@ namespace Apache.Ignite.Core.Client
         /// Default socket timeout.
         /// </summary>
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
+
+        /// <summary>
+        /// Default value for <see cref="HeartbeatInterval"/>.
+        /// </summary>
+        public static readonly TimeSpan DefaultHeartbeatInterval = TimeSpan.FromSeconds(30);
 
         /// <summary>
         /// Initializes a new instance of the <see cref="IgniteClientConfiguration"/> class.
@@ -133,6 +139,8 @@ namespace Apache.Ignite.Core.Client
 
             RetryLimit = cfg.RetryLimit;
             RetryPolicy = cfg.RetryPolicy;
+            EnableHeartbeats = cfg.EnableHeartbeats;
+            HeartbeatInterval = cfg.HeartbeatInterval;
         }
 
         /// <summary>
@@ -264,6 +272,30 @@ namespace Apache.Ignite.Core.Client
         /// Default is <c>0</c>: no limit on retries.
         /// </summary>
         public int RetryLimit { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether heartbeats are enabled.
+        /// <para />
+        /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+        /// to keep the connection alive and detect potential half-open state.
+        /// <para />
+        /// See also <see cref="HeartbeatInterval"/>.
+        /// </summary>
+        public bool EnableHeartbeats { get; set; }
+
+        /// <summary>
+        /// Sets the heartbeat message interval.
+        /// <para />
+        /// Default is <see cref="DefaultHeartbeatInterval"/>.
+        /// <para />
+        /// When server-side <see cref="ClientConnectorConfiguration.IdleTimeout"/> is not zero, effective heartbeat
+        /// interval is set to <c>Min(HeartbeatInterval, IdleTimeout / 3)</c>.
+        /// <para />
+        /// When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+        /// to keep the connection alive and detect potential half-open state.
+        /// </summary>
+        [DefaultValue(typeof(TimeSpan), "00:00:30")]
+        public TimeSpan HeartbeatInterval { get; set; } = DefaultHeartbeatInterval;
 
         /// <summary>
         /// Gets or sets custom binary processor. Internal property for tests.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -349,6 +349,16 @@
                     <xs:documentation>Operation retry limit when RetryPolicy is set.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="heartbeatInterval" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation>Heartbeat interval.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="enableHeartbeats" type="xs:boolean">
+                <xs:annotation>
+                    <xs:documentation>Enables periodic heartbeat messages.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
         </xs:complexType>
     </xs:element>
 </xs:schema>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientBitmaskFeature.cs
@@ -30,6 +30,8 @@ namespace Apache.Ignite.Core.Impl.Client
         ServiceInvoke = 5, // The flag is not necessary and exists for legacy reasons
         // DefaultQueryTimeout = 6, // IGNITE-13692
         QueryPartitionsBatchSize = 7,
-        BinaryConfiguration = 8
+        BinaryConfiguration = 8,
+        ServiceInvokeCtx = 10,
+        Heartbeat = 11
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientOp.cs
@@ -23,6 +23,8 @@ namespace Apache.Ignite.Core.Impl.Client
     {
         // General purpose.
         ResourceClose = 0,
+        Heartbeat = 1,
+        GetIdleTimeout = 2,
 
         // Cache.
         CacheGet = 1000,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientSocket.cs
@@ -87,6 +87,9 @@ namespace Apache.Ignite.Core.Impl.Client
         /** Request timeout checker. */
         private readonly Timer _timeoutCheckTimer;
 
+        /** Heartbeat timer. */
+        private readonly Timer _heartbeatTimer;
+
         /** Callback checker guard. */
         private volatile bool _checkingTimeouts;
 
@@ -137,6 +140,9 @@ namespace Apache.Ignite.Core.Impl.Client
         /** Features. */
         private readonly ClientFeatures _features;
 
+        /** Effective heartbeat interval. */
+        private readonly TimeSpan _heartbeatInterval;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientSocket" /> class.
         /// </summary>
@@ -170,6 +176,21 @@ namespace Apache.Ignite.Core.Impl.Client
 
             _features = Handshake(clientConfiguration, ServerVersion);
 
+            if (clientConfiguration.EnableHeartbeats)
+            {
+                if (_features.HasFeature(ClientBitmaskFeature.Heartbeat))
+                {
+                    _heartbeatInterval = GetHeartbeatInterval(clientConfiguration);
+
+                    _heartbeatTimer = new Timer(SendHeartbeat, null, dueTime: _heartbeatInterval,
+                        period: TimeSpan.FromMilliseconds(-1));
+                }
+                else
+                {
+                    _logger.Warn("Heartbeats are enabled, but server does not support heartbeat feature.");
+                }
+            }
+
             // Check periodically if any request has timed out.
             if (_timeout > TimeSpan.Zero)
             {
@@ -180,6 +201,46 @@ namespace Apache.Ignite.Core.Impl.Client
             // Continuously and asynchronously wait for data from server.
             // TaskCreationOptions.LongRunning actually means a new thread.
             TaskRunner.Run(WaitForMessages, TaskCreationOptions.LongRunning);
+        }
+
+        /// <summary>
+        /// Gets the heartbeat interval according to server-side and client-side configuration.
+        /// </summary>
+        private TimeSpan GetHeartbeatInterval(IgniteClientConfiguration clientConfiguration)
+        {
+            var serverIdleTimeoutMs = DoOutInOp(
+                ClientOp.GetIdleTimeout, null, r => r.Reader.ReadLong());
+
+            // ReSharper disable once PossibleLossOfFraction
+            var recommendedHeartbeatInterval = TimeSpan.FromMilliseconds(serverIdleTimeoutMs / 3);
+
+            if (recommendedHeartbeatInterval > TimeSpan.Zero)
+            {
+                if (clientConfiguration.HeartbeatInterval < recommendedHeartbeatInterval)
+                {
+                    _logger.Info(
+                        $"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, " +
+                        $"using configured {nameof(IgniteClientConfiguration)}." +
+                        $"{nameof(IgniteClientConfiguration.HeartbeatInterval)}: " +
+                        clientConfiguration.HeartbeatInterval);
+
+                    return clientConfiguration.HeartbeatInterval;
+                }
+
+                _logger.Warn(
+                    $"Server-side IdleTimeout is {serverIdleTimeoutMs}ms, configured " +
+                    $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +
+                    $"is {clientConfiguration.HeartbeatInterval}, which is longer than recommended IdleTimeout / 3. " +
+                    $"Overriding heartbeat interval with IdleTimeout / 3: {recommendedHeartbeatInterval}");
+
+                return recommendedHeartbeatInterval;
+            }
+
+            _logger.Info(
+                $"Server-side IdleTimeout is not set, using configured {nameof(IgniteClientConfiguration)}." +
+                $"{nameof(IgniteClientConfiguration.HeartbeatInterval)}: {clientConfiguration.HeartbeatInterval}");
+
+            return clientConfiguration.HeartbeatInterval;
         }
 
         /// <summary>
@@ -204,6 +265,13 @@ namespace Apache.Ignite.Core.Impl.Client
 
                 if (cfg.UserName == null)
                     throw new IgniteClientException("IgniteClientConfiguration.UserName cannot be null when Password is set.");
+            }
+
+            if (cfg.HeartbeatInterval <= TimeSpan.Zero)
+            {
+                throw new IgniteClientException(
+                    $"{nameof(IgniteClientConfiguration)}.{nameof(IgniteClientConfiguration.HeartbeatInterval)} " +
+                    "cannot be zero or less.");
             }
         }
 
@@ -828,6 +896,9 @@ namespace Apache.Ignite.Core.Impl.Client
             try
             {
                 _stream.Write(buf, 0, len);
+
+                // Reset heartbeat timer - don't sent heartbeats when connection is active anyway.
+                _heartbeatTimer?.Change(dueTime: _heartbeatInterval, period: TimeSpan.FromMilliseconds(-1));
             }
             catch (Exception e)
             {
@@ -945,6 +1016,24 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /// <summary>
+        /// Sends heartbeat message.
+        /// </summary>
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "Thread root must catch all exceptions to avoid crashing the process.")]
+        private void SendHeartbeat(object unused)
+        {
+            try
+            {
+                DoOutInOp<object>(ClientOp.Heartbeat, null, null);
+            }
+            catch (Exception e)
+            {
+                _exception = e;
+                Dispose();
+            }
+        }
+
+        /// <summary>
         /// Gets the int from buffer.
         /// </summary>
         private static unsafe int GetInt(byte[] buf)
@@ -1018,6 +1107,9 @@ namespace Apache.Ignite.Core.Impl.Client
                 // Set disposed state before ending requests so that request continuations see disconnected socket.
                 _isDisposed = true;
 
+                // Stop heartbeat timer before closing the socket.
+                _heartbeatTimer?.Dispose();
+
                 _exception = _exception ?? new ObjectDisposedException(typeof(ClientSocket).FullName);
                 EndRequestsWithError();
 
@@ -1027,10 +1119,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 _listenerEvent.Set();
                 _listenerEvent.Dispose();
 
-                if (_timeoutCheckTimer != null)
-                {
-                    _timeoutCheckTimer.Dispose();
-                }
+                _timeoutCheckTimer?.Dispose();
             }
         }
 


### PR DESCRIPTION
Implement keepalive: https://cwiki.apache.org/confluence/display/IGNITE/IEP-83+Thin+Client+Keepalive
* Add `OP_HEARTBEAT`, `OP_GET_IDLE_TIMEOUT` on server with `HEARTBEAT` feature flag.
* Implement heartbeats in .NET thin client:
  * `IgniteClientConfiguration.EnableHeartbeats`, default `false`.
  * `IgniteClientConfiguration.HeartbeatInterval`, default 30 seconds.
  * When heartbeats are enabled, get idle timeout from server, set effective heartbeat interval to `Math.Min(HeartbeatInterval, IdleTimeout / 3)`. Log warning when user-defined value is overridden.