### PR TITLE
GG-34872 [IGNITE-16530] Java thin: add heartbeats

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
@@ -129,6 +129,12 @@ public final class ClientConfiguration implements Serializable {
     /** Executor for async operations continuations. */
     private Executor asyncContinuationExecutor;
 
+    /** Whether heartbeats should be enabled. */
+    private boolean heartbeatEnabled;
+
+    /** Heartbeat interval, in milliseconds. */
+    private long heartbeatInterval = 30_000L;
+
     /**
      * @return Host addresses.
      */
@@ -649,6 +655,70 @@ public final class ClientConfiguration implements Serializable {
      */
     public ClientConfiguration setAsyncContinuationExecutor(Executor asyncContinuationExecutor) {
         this.asyncContinuationExecutor = asyncContinuationExecutor;
+
+        return this;
+    }
+
+    /**
+     * Gets a value indicating whether heartbeats are enabled.
+     * <p />
+     * When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+     * to keep the connection alive and detect potential half-open state.
+     * <p />
+     * See also {@link ClientConfiguration#heartbeatInterval}.
+     *
+     * @return Whether heartbeats are enabled.
+     */
+    public boolean isHeartbeatEnabled() {
+        return heartbeatEnabled;
+    }
+
+    /**
+     * Sets a value indicating whether heartbeats are enabled.
+     * <p />
+     * When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+     * to keep the connection alive and detect potential half-open state.
+     * <p />
+     * See also {@link ClientConfiguration#heartbeatInterval}.
+     *
+     * @param heartbeatEnabled Whether to enable heartbeats.
+     * @return {@code this} for chaining.
+     */
+    public ClientConfiguration setHeartbeatEnabled(boolean heartbeatEnabled) {
+        this.heartbeatEnabled = heartbeatEnabled;
+
+        return this;
+    }
+
+    /**
+     * Gets the heartbeat message interval, in milliseconds. Default is <code>30_000</code>.
+     * <p />
+     * When server-side {@link ClientConnectorConfiguration#getIdleTimeout()} is not zero, effective heartbeat
+     * interval is set to <code>min(heartbeatInterval, idleTimeout / 3)</code>.
+     * <p />
+     * When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+     * to keep the connection alive and detect potential half-open state.     *
+     *
+     * @return Heartbeat interval.
+     */
+    public long getHeartbeatInterval() {
+        return heartbeatInterval;
+    }
+
+    /**
+     * Sets the heartbeat message interval, in milliseconds. Default is <code>30_000</code>.
+     * <p />
+     * When server-side {@link ClientConnectorConfiguration#getIdleTimeout()} is not zero, effective heartbeat
+     * interval is set to <code>min(heartbeatInterval, idleTimeout / 3)</code>.
+     * <p />
+     * When thin client connection is idle (no operations are performed), heartbeat messages are sent periodically
+     * to keep the connection alive and detect potential half-open state.     *
+     *
+     * @param heartbeatInterval Heartbeat interval, in milliseconds.
+     * @return {@code this} for chaining.
+     */
+    public ClientConfiguration setHeartbeatInterval(long heartbeatInterval) {
+        this.heartbeatInterval = heartbeatInterval;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientChannelConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientChannelConfiguration.java
@@ -95,6 +95,12 @@ final class ClientChannelConfiguration {
     /** User attributes. */
     private final Map<String, String> userAttrs;
 
+    /** Heartbeats. */
+    private final boolean heartbeatEnabled;
+
+    /** Heartbeat interval, in milliseconds. */
+    private final long heartbeatInterval;
+
     /**
      * Constructor.
      */
@@ -122,6 +128,8 @@ final class ClientChannelConfiguration {
         this.addr = addr;
         this.userAttrs = cfg.getUserAttributes();
         this.asyncContinuationExecutor = cfg.getAsyncContinuationExecutor();
+        this.heartbeatEnabled = cfg.isHeartbeatEnabled();
+        this.heartbeatInterval = cfg.getHeartbeatInterval();
     }
 
     /**
@@ -277,5 +285,19 @@ final class ClientChannelConfiguration {
      */
     public Executor getAsyncContinuationExecutor() {
         return asyncContinuationExecutor;
+    }
+
+    /**
+     * @return Whether heartbeats are enabled.
+     */
+    public boolean getHeartbeatEnabled() {
+        return heartbeatEnabled;
+    }
+
+    /**
+     * @return Heartbeat interval, in milliseconds.
+     */
+    public long getHeartbeatInterval() {
+        return heartbeatInterval;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientOperation.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientOperation.java
@@ -24,6 +24,8 @@ import org.jetbrains.annotations.Nullable;
 /** Operation codes. */
 public enum ClientOperation {
     /** Resource close. */RESOURCE_CLOSE(0),
+    /** Heartbeat. */ HEARTBEAT(1),
+    /** Get idle timeout. */ GET_IDLE_TIMEOUT(2),
 
     /** Cache get or create with name. */CACHE_GET_OR_CREATE_WITH_NAME(1052),
     /** Cache put. */CACHE_PUT(1001),

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -53,7 +53,13 @@ public enum ProtocolBitmaskFeature {
     BINARY_CONFIGURATION(8),
 
     /** Handle of {@link ClientServices#serviceDescriptors()}. */
-    GET_SERVICE_DESCRIPTORS(9);
+    GET_SERVICE_DESCRIPTORS(9),
+
+    /** Invoke service methods with caller context. */
+    SERVICE_INVOKE_CALLCTX(10),
+
+    /** Handle OP_HEARTBEAT and OP_GET_IDLE_TIMEOUT. */
+    HEARTBEAT(11);
 
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -24,6 +24,8 @@ import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Queue;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,6 +71,7 @@ import org.apache.ignite.internal.util.typedef.T2;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
 
+import static org.apache.ignite.internal.client.thin.ProtocolBitmaskFeature.HEARTBEAT;
 import static org.apache.ignite.internal.client.thin.ProtocolVersion.CURRENT_VER;
 import static org.apache.ignite.internal.client.thin.ProtocolVersion.V1_0_0;
 import static org.apache.ignite.internal.client.thin.ProtocolVersion.V1_1_0;
@@ -103,6 +106,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         V1_1_0,
         V1_0_0
     );
+
+    /** GridNioServer has minimum idle check interval of 2 seconds, even if idleTimeout is lower. */
+    private static final long MIN_RECOMMENDED_HEARTBEAT_INTERVAL = 500;
 
     /** Preallocated empty bytes. */
     public static final byte[] EMPTY_BYTES = new byte[0];
@@ -149,6 +155,12 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     /** Send/receive timeout in milliseconds. */
     private final int timeout;
 
+    /** Heartbeat timer. */
+    private final Timer heartbeatTimer;
+
+    /** Last send operation timestamp. */
+    private volatile long lastSendMillis;
+
     /** Constructor. */
     TcpClientChannel(ClientChannelConfiguration cfg, ClientConnectionMultiplexer connMgr)
         throws ClientConnectionException, ClientAuthenticationException, ClientProtocolError {
@@ -167,6 +179,10 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         sock = connMgr.open(cfg.getAddress(), this, this);
 
         handshake(DEFAULT_VERSION, cfg.getUserName(), cfg.getUserPassword(), cfg.getUserAttributes());
+
+        heartbeatTimer = protocolCtx.isFeatureSupported(HEARTBEAT) && cfg.getHeartbeatEnabled()
+                ? initHeartbeat(cfg.getHeartbeatInterval())
+                : null;
     }
 
     /** {@inheritDoc} */
@@ -189,6 +205,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
      */
     private void close(Exception cause) {
         if (closed.compareAndSet(false, true)) {
+            if (heartbeatTimer != null)
+                heartbeatTimer.cancel();
+
             U.closeQuiet(sock);
 
             for (ClientRequestFuture pendingReq : pendingReqs.values())
@@ -553,6 +572,8 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             error = "At least one Ignite server node must be specified in the Ignite client configuration";
         else if (addr.getPort() < 1024 || addr.getPort() > 49151)
             error = String.format("Ignite client port %s is out of valid ports range 1024...49151", addr.getPort());
+        else if (cfg.getHeartbeatInterval() <= 0)
+            error = "heartbeatInterval cannot be zero or less.";
 
         if (error != null)
             throw new IllegalArgumentException(error);
@@ -684,6 +705,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
         try {
             sock.send(buf, onDone);
+            lastSendMillis = System.currentTimeMillis();
         }
         catch (IgniteCheckedException e) {
             throw new ClientConnectionException(e.getMessage(), e);
@@ -706,8 +728,68 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     }
 
     /**
+     * Initializes heartbeats.
+     *
+     * @param configuredInterval Configured heartbeat interval, in milliseconds.
+     * @return Heartbeat timer.
+     */
+    private Timer initHeartbeat(long configuredInterval) {
+        long heartbeatInterval = getHeartbeatInterval(configuredInterval);
+
+        Timer timer = new Timer("tcp-client-channel-heartbeats-" + hashCode());
+
+        timer.schedule(new HeartbeatTask(heartbeatInterval), heartbeatInterval, heartbeatInterval);
+
+        return timer;
+    }
+
+    /**
+     * Gets the heartbeat interval based on the configured value and served-side idle timeout.
+     *
+     * @param configuredInterval Configured interval.
+     * @return Resolved interval.
+     */
+    private long getHeartbeatInterval(long configuredInterval) {
+        long serverIdleTimeoutMs = service(ClientOperation.GET_IDLE_TIMEOUT, null, in -> in.in().readLong());
+
+        if (serverIdleTimeoutMs <= 0)
+            return configuredInterval;
+
+        long recommendedHeartbeatInterval = serverIdleTimeoutMs / 3;
+
+        if (recommendedHeartbeatInterval < MIN_RECOMMENDED_HEARTBEAT_INTERVAL)
+            recommendedHeartbeatInterval = MIN_RECOMMENDED_HEARTBEAT_INTERVAL;
+
+        return Math.min(configuredInterval, recommendedHeartbeatInterval);
+    }
+
+    /**
      *
      */
     private static class ClientRequestFuture extends GridFutureAdapter<ByteBuffer> {
+    }
+
+    /**
+     * Sends heartbeat messages.
+     */
+    private class HeartbeatTask extends TimerTask {
+        /** Heartbeat interval. */
+        private final long interval;
+
+        /** Constructor. */
+        public HeartbeatTask(long interval) {
+            this.interval = interval;
+        }
+
+        /** {@inheritDoc} */
+        @Override public void run() {
+            try {
+                if (System.currentTimeMillis() - lastSendMillis > interval)
+                    service(ClientOperation.HEARTBEAT, null, null);
+            }
+            catch (Throwable ignored) {
+                // Ignore failed heartbeats.
+            }
+        }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/client/ClientConfigurationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ClientConfigurationTest.java
@@ -68,7 +68,9 @@ public class ClientConfigurationTest {
             .setSslTrustCertificateKeyStorePath(GridTestUtils.keyStorePath("trustone"))
             .setSslTrustCertificateKeyStoreType(DFLT_STORE_TYPE)
             .setSslTrustCertificateKeyStorePassword(GridTestUtils.keyStorePassword())
-            .setSslKeyAlgorithm(DFLT_KEY_ALGORITHM);
+            .setSslKeyAlgorithm(DFLT_KEY_ALGORITHM)
+            .setHeartbeatInterval(3000)
+            .setHeartbeatEnabled(true);
 
         ByteArrayOutputStream outBytes = new ByteArrayOutputStream();
 
@@ -114,5 +116,16 @@ public class ClientConfigurationTest {
             Assert.assertTrue(containsMsg);
             Assert.assertEquals(1, collect.size());
         }
+    }
+
+    /**
+     * Tests that invalid heartbat interval values are not allowed.
+     */
+    @Test
+    public void testInvalidHeartbeatIntervalThrows() {
+        ClientConfiguration cfg = new ClientConfiguration().setHeartbeatInterval(-1).setAddresses("127.0.0.1");
+
+        GridTestUtils.assertThrowsAnyCause(null, () -> Ignition.startClient(cfg), IllegalArgumentException.class,
+                "heartbeatInterval cannot be zero or less.");
     }
 }


### PR DESCRIPTION
Implement heartbeats in Java thin client: https://cwiki.apache.org/confluence/display/IGNITE/IEP-83+Thin+Client+Keepalive

  * `ClientConfiguration.heartbeatsEnabled`, default `false`.
  * `ClientConfiguration.heartbeatInterval`, default 30 seconds.
  * When heartbeats are enabled, get idle timeout from server, set effective heartbeat interval to `Math.min(heartbeatInterval, idleTimeout / 3)`.