### PR TITLE
GG-34694 Fix IgniteClientConnectionLimit flakiness

### DIFF
--- a/modules/platforms/cpp/thin-client-test/include/vector_logger.h
+++ b/modules/platforms/cpp/thin-client-test/include/vector_logger.h
@@ -67,7 +67,7 @@ namespace ignite_test
             const std::string& nativeErrorInfo)
         {
             if ((categoryFilter.empty() || category.find(categoryFilter) != std::string::npos) &&
-                (messageFilter.empty() || message.find(messageFilter) != std::string::npos))
+                (!messageFilter.empty() && message.find(messageFilter) != std::string::npos))
             {
                 ignite::common::concurrent::CsLockGuard guard(lock);
 

--- a/modules/platforms/cpp/thin-client-test/src/ignite_client_test.cpp
+++ b/modules/platforms/cpp/thin-client-test/src/ignite_client_test.cpp
@@ -53,7 +53,7 @@ public:
     bool WaitForConnections(VectorLogger* logger, size_t expected, int32_t timeout = 5000)
     {
         return ignite_test::WaitForCondition(
-                boost::bind(&IgniteClientTestSuiteFixture::CheckActiveConnections, this, logger, expected),
+                boost::bind(&IgniteClientTestSuiteFixture::CheckActiveConnections, logger, expected),
                 timeout);
     }
 
@@ -82,7 +82,7 @@ public:
      * @param expect connections to expect.
      * @return @c true on success.
      */
-    bool CheckActiveConnections(VectorLogger* logger, size_t expect)
+    static bool CheckActiveConnections(VectorLogger* logger, size_t expect)
     {
         return GetActiveConnections(logger) == expect;
     }
@@ -103,10 +103,10 @@ public:
         std::vector<VectorLogger::Event> logs = logger->GetEvents();
         for (Events::iterator it = logs.begin(); it != logs.end(); ++it)
         {
-            if (it->message.find("Client connected") != std::string::npos)
+            if (it->message.find("Client connected: ") != std::string::npos)
                 ++connected;
 
-            if (it->message.find("Client disconnected") != std::string::npos)
+            if (it->message.find("Client disconnected: ") != std::string::npos)
                 ++disconnected;
         }
 


### PR DESCRIPTION
Flakiness is caused by random appearance of messages of format `Client disconnected due to an error ...` which causes client disconnection be counted twice.