### PR TITLE
GG-34983 .NET: Fix verify-nuget.ps1

### DIFF
--- a/modules/platforms/dotnet/release/NuGet.config
+++ b/modules/platforms/dotnet/release/NuGet.config
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <!--
-    Copyright (C) GridGain Systems. All Rights Reserved.
-    _________        _____ __________________        _____
-    __  ____/___________(_)______  /__  ____/______ ____(_)_______
-    _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
-    / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
-    \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+ Copyright 2019 GridGain Systems, Inc. and Contributors.
+
+ Licensed under the GridGain Community Edition License (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -->
 
 <configuration>

--- a/modules/platforms/dotnet/release/NuGet.config
+++ b/modules/platforms/dotnet/release/NuGet.config
@@ -1,7 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+    Copyright (C) GridGain Systems. All Rights Reserved.
+    _________        _____ __________________        _____
+    __  ____/___________(_)______  /__  ____/______ ____(_)_______
+    _  / __  __  ___/__  / _  __  / _  / __  _  __ `/__  / __  __ \
+    / /_/ /  _  /    _  /  / /_/ /  / /_/ /  / /_/ / _  /  _  / / /
+    \____/   /_/     /_/   \_,__/   \____/   \__,_/  /_/   /_/ /_/
+-->
+
 <configuration>
     <packageSources>
-        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
         <add key="Ignite release" value="../nupkg" />
     </packageSources>
 </configuration>

--- a/modules/platforms/dotnet/release/NuGet.config
+++ b/modules/platforms/dotnet/release/NuGet.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
+        <add key="Ignite release" value="../nupkg" />
+    </packageSources>
+</configuration>

--- a/modules/platforms/dotnet/release/_global.json
+++ b/modules/platforms/dotnet/release/_global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "2.1.300",
-    "rollForward": "major"
-  }
-}

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -73,7 +73,7 @@ if ($LastExitCode -ne 0) {
 
 $packages | % {
     $packageId = $_.Name -replace '(.*?)\.\d+\.\d+\.\d+(.*)?\.nupkg', '$1'
-    $packageVer = $_.Name -replace '.*?(\.\d+\.\d+\.\d+(.*)?)\.nupkg', '$1'
+    $packageVer = $_.Name -replace '.*?\.(\d+\.\d+\.\d+(.*)?)\.nupkg', '$1'
     dotnet add package $packageId --version $packageVer
 
     if ($LastExitCode -ne 0) {

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -73,7 +73,8 @@ if ($LastExitCode -ne 0) {
 
 $packages | % {
     $packageId = $_.Name -replace '(.*?)\.\d+\.\d+\.\d+(.*)?\.nupkg', '$1'
-    dotnet add package $packageId -s $dir
+    $packageVer = $_.Name -replace '.*?(\.\d+\.\d+\.\d+(.*)?)\.nupkg', '$1'
+    dotnet add package $packageId --version $packageVer
 
     if ($LastExitCode -ne 0) {
         throw "Failed to install package $packageId"

--- a/modules/platforms/dotnet/release/verify-nuget.ps1
+++ b/modules/platforms/dotnet/release/verify-nuget.ps1
@@ -38,17 +38,6 @@ param (
 echo ".NET SDKs:"
 dotnet --list-sdks
 
-$newSdks = dotnet --list-sdks | where {$_ -match "\d+\.\d+"} | where {[int]($_.Split(".")[0]) -gt 2}
-
-if ($newSdks.Length -gt 0) {
-    # Enable global.json only when .NET SDK 3+ is present.
-    # We don't need it otherwise, and "rollForward" is not supported on lower versions.
-    echo "Enabling global.json..."
-
-    Set-Location $PSScriptRoot
-    Copy-Item _global.json global.json
-}
-
 # Find NuGet packages (*.nupkg)
 $dir = If ([System.IO.Path]::IsPathRooted($packageDir)) { $packageDir } Else { Join-Path $PSScriptRoot $packageDir }
 if (!(Test-Path $dir)) {
@@ -61,7 +50,7 @@ if ($packages.Length -eq 0) {
 }
 
 
-echo "Verifying $($packages.Length) packages from '$dir'..."  
+echo "Verifying $($packages.Length) packages from '$dir'..."
 
 
 # Clear package cache
@@ -82,7 +71,7 @@ if ($LastExitCode -ne 0) {
 }
 
 
-$packages | % { 
+$packages | % {
     $packageId = $_.Name -replace '(.*?)\.\d+\.\d+\.\d+(.*)?\.nupkg', '$1'
     dotnet add package $packageId -s $dir
 


### PR DESCRIPTION
The issue was caused by .NET Core 2.1 package restore quirks. 2.1 is out of support now.

* Remove `global.json` to get rid of .NET Core 2.1 requirement.
* Use `NuGet.config` to restore from multiple sources (local folder + nuget.org for 3rd party packages).
* Update script to install Ignite packages with specific version.