### PR TITLE
GG-35239 [IGNITE-16857] Java thin: Add AtomicLong

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/client/ClientAtomicConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientAtomicConfiguration.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import org.apache.ignite.IgniteAtomicSequence;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.internal.util.typedef.internal.S;
+import static org.apache.ignite.cache.CacheMode.PARTITIONED;
+
+/**
+ * Configuration for atomic data structures.
+ */
+public class ClientAtomicConfiguration {
+    /** Default number of backups. */
+    public static final int DFLT_BACKUPS = 1;
+
+    /** Cache mode. */
+    public static final CacheMode DFLT_CACHE_MODE = PARTITIONED;
+
+    /** Default atomic sequence reservation size. */
+    public static final int DFLT_ATOMIC_SEQUENCE_RESERVE_SIZE = 1000;
+
+    /** Atomic sequence reservation size. */
+    private int seqReserveSize = DFLT_ATOMIC_SEQUENCE_RESERVE_SIZE;
+
+    /** Cache mode. */
+    private CacheMode cacheMode = DFLT_CACHE_MODE;
+
+    /** Number of backups. */
+    private int backups = DFLT_BACKUPS;
+
+    /** Group name. */
+    private String grpName;
+
+    /**
+     * Gets the number of backup nodes.
+     *
+     * @return Number of backup nodes.
+     */
+    public int getBackups() {
+        return backups;
+    }
+
+    /**
+     * Sets the number of backup nodes.
+     *
+     * @param backups Number of backup nodes.
+     * @return {@code this} for chaining.
+     */
+    public ClientAtomicConfiguration setBackups(int backups) {
+        this.backups = backups;
+
+        return this;
+    }
+
+    /**
+     * Gets the cache mode.
+     *
+     * @return Cache mode.
+     */
+    public CacheMode getCacheMode() {
+        return cacheMode;
+    }
+
+    /**
+     * Sets the cache mode.
+     *
+     * @param cacheMode Cache mode.
+     * @return {@code this} for chaining.
+     */
+    public ClientAtomicConfiguration setCacheMode(CacheMode cacheMode) {
+        this.cacheMode = cacheMode;
+
+        return this;
+    }
+
+    /**
+     * Gets default number of sequence values reserved for {@link IgniteAtomicSequence} instances. After
+     * a certain number has been reserved, consequent increments of sequence will happen locally,
+     * without communication with other nodes, until the next reservation has to be made.
+     * <p>
+     * Default value is {@link #DFLT_ATOMIC_SEQUENCE_RESERVE_SIZE}.
+     *
+     * @return Atomic sequence reservation size.
+     */
+    public int getAtomicSequenceReserveSize() {
+        return seqReserveSize;
+    }
+
+    /**
+     * Sets default number of sequence values reserved for {@link IgniteAtomicSequence} instances. After a certain
+     * number has been reserved, consequent increments of sequence will happen locally, without communication with other
+     * nodes, until the next reservation has to be made.
+     *
+     * @param seqReserveSize Atomic sequence reservation size.
+     * @see #getAtomicSequenceReserveSize()
+     * @return {@code this} for chaining.
+     */
+    public ClientAtomicConfiguration setAtomicSequenceReserveSize(int seqReserveSize) {
+        this.seqReserveSize = seqReserveSize;
+
+        return this;
+    }
+
+    /**
+     * Sets the cache group name.
+     *
+     * @return Cache group name.
+     */
+    public String getGroupName() {
+        return grpName;
+    }
+
+    /**
+     * Gets the cache group name.
+     *
+     * @param grpName Cache group name.
+     * @return {@code this} for chaining.
+     */
+    public ClientAtomicConfiguration setGroupName(String grpName) {
+        this.grpName = grpName;
+
+        return this;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(ClientAtomicConfiguration.class, this);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientAtomicLong.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientAtomicLong.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import java.io.Closeable;
+import org.apache.ignite.IgniteException;
+
+/**
+ * Distributed atomic long API.
+ * <p>
+ * <h1 class="header">Functionality</h1>
+ * Distributed atomic long includes the following main functionality:
+ * <ul>
+ * <li>
+ * Method {@link #get()} gets current value of atomic long.
+ * </li>
+ * <li>
+ * Various {@code get..(..)} methods get current value of atomic long
+ * and increase or decrease value of atomic long.
+ * </li>
+ * <li>
+ * Method {@link #addAndGet(long l)} sums {@code l} with current value of atomic long
+ * and returns result.
+ * </li>
+ * <li>
+ * Method {@link #incrementAndGet()} increases value of atomic long and returns result.
+ * </li>
+ * <li>
+ * Method {@link #decrementAndGet()} decreases value of atomic long and returns result.
+ * </li>
+ * <li>
+ * Method {@link #getAndSet(long l)} gets current value of atomic long and sets {@code l}
+ * as value of atomic long.
+ * </li>
+ * <li>
+ * Method {@link #name()} gets name of atomic long.
+ * </li>
+ * </ul>
+ * <p>
+ * <h1 class="header">Creating Distributed Atomic Long</h1>
+ * Instance of distributed atomic long can be created by calling the following method:
+ * <ul>
+ *     <li>{@link IgniteClient#atomicLong(String, long, boolean)}</li>
+ * </ul>
+ * @see IgniteClient#atomicLong(String, long, boolean)
+ */
+public interface ClientAtomicLong extends Closeable {
+    /**
+     * Name of atomic long.
+     *
+     * @return Name of atomic long.
+     */
+    public String name();
+
+    /**
+     * Gets current value of atomic long.
+     *
+     * @return Current value of atomic long.
+     */
+    public long get() throws IgniteException;
+
+    /**
+     * Increments and gets current value of atomic long.
+     *
+     * @return Value.
+     */
+    public long incrementAndGet() throws IgniteException;
+
+    /**
+     * Gets and increments current value of atomic long.
+     *
+     * @return Value.
+     */
+    public long getAndIncrement() throws IgniteException;
+
+    /**
+     * Adds {@code l} and gets current value of atomic long.
+     *
+     * @param l Number which will be added.
+     * @return Value.
+     */
+    public long addAndGet(long l) throws IgniteException;
+
+    /**
+     * Gets current value of atomic long and adds {@code l}.
+     *
+     * @param l Number which will be added.
+     * @return Value.
+     */
+    public long getAndAdd(long l) throws IgniteException;
+
+    /**
+     * Decrements and gets current value of atomic long.
+     *
+     * @return Value.
+     */
+    public long decrementAndGet() throws IgniteException;
+
+    /**
+     * Gets and decrements current value of atomic long.
+     *
+     * @return Value.
+     */
+    public long getAndDecrement() throws IgniteException;
+
+    /**
+     * Gets current value of atomic long and sets new value {@code l} of atomic long.
+     *
+     * @param l New value of atomic long.
+     * @return Value.
+     */
+    public long getAndSet(long l) throws IgniteException;
+
+    /**
+     * Atomically compares current value to the expected value, and if they are equal, sets current value
+     * to new value.
+     *
+     * @param expVal Expected atomic long's value.
+     * @param newVal New atomic long's value to set if current value equal to expected value.
+     * @return {@code True} if comparison succeeded, {@code false} otherwise.
+     */
+    public boolean compareAndSet(long expVal, long newVal) throws IgniteException;
+
+    /**
+     * Gets status of atomic.
+     *
+     * @return {@code true} if atomic was removed from cache, {@code false} in other case.
+     */
+    public boolean removed();
+
+    /**
+     * Removes this atomic long.
+     */
+    @Override public void close();
+}

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientOperationType.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientOperationType.java
@@ -212,5 +212,43 @@ public enum ClientOperationType {
     /**
      * Get service descriptor ({@link ClientServices#serviceDescriptor(String)}).
      */
-    SERVICE_GET_DESCRIPTOR
+    SERVICE_GET_DESCRIPTOR,
+
+    /**
+     * Get or create an AtomicLong ({@link IgniteClient#atomicLong(String, long, boolean)},
+     * {@link IgniteClient#atomicLong(String, ClientAtomicConfiguration, long, boolean)}).
+     */
+    ATOMIC_LONG_CREATE,
+
+    /**
+     * Remove an AtomicLong ({@link ClientAtomicLong#close()}).
+     */
+    ATOMIC_LONG_REMOVE,
+
+    /**
+     * Check if AtomicLong exists ({@link ClientAtomicLong#removed()}).
+     */
+    ATOMIC_LONG_EXISTS,
+
+    /**
+     * AtomicLong.get ({@link ClientAtomicLong#get()}).
+     */
+    ATOMIC_LONG_VALUE_GET,
+
+    /**
+     * AtomicLong.addAndGet (includes {@link ClientAtomicLong#addAndGet(long)}, {@link ClientAtomicLong#incrementAndGet()},
+     * {@link ClientAtomicLong#getAndIncrement()}, {@link ClientAtomicLong#getAndAdd(long)}, {@link ClientAtomicLong#decrementAndGet()},
+     * {@link ClientAtomicLong#getAndDecrement()}).
+     */
+    ATOMIC_LONG_VALUE_ADD_AND_GET,
+
+    /**
+     * AtomicLong.getAndSet ({@link ClientAtomicLong#getAndSet(long)}).
+     */
+    ATOMIC_LONG_VALUE_GET_AND_SET,
+
+    /**
+     * AtomicLong.compareAndSet ({@link ClientAtomicLong#compareAndSet(long, long)}).
+     */
+    ATOMIC_LONG_VALUE_COMPARE_AND_SET
 }

--- a/modules/core/src/main/java/org/apache/ignite/client/IgniteClient.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/IgniteClient.java
@@ -192,6 +192,29 @@ public interface IgniteClient extends AutoCloseable {
     public ClientServices services(ClientClusterGroup grp);
 
     /**
+     * Gets an atomic long from cache and creates one if it has not been created yet and {@code create} flag
+     * is {@code true}.
+     *
+     * @param name Name of atomic long.
+     * @param initVal Initial value for atomic long. Ignored if {@code create} flag is {@code false}.
+     * @param create Boolean flag indicating whether data structure should be created if it does not exist.
+     * @return Atomic long.
+     */
+    public ClientAtomicLong atomicLong(String name, long initVal, boolean create);
+
+    /**
+     * Gets an atomic long from cache and creates one if it has not been created yet and {@code create} flag
+     * is {@code true}.
+     *
+     * @param name Name of atomic long.
+     * @param cfg Configuration.
+     * @param initVal Initial value for atomic long. Ignored if {@code create} flag is {@code false}.
+     * @param create Boolean flag indicating whether data structure should be created if it does not exist.
+     * @return Atomic long.
+     */
+    public ClientAtomicLong atomicLong(String name, ClientAtomicConfiguration cfg, long initVal, boolean create);
+
+    /**
      * Closes this client's open connections and relinquishes all underlying resources.
      */
     @Override public void close();

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.thin;
+
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.client.ClientAtomicLong;
+import org.apache.ignite.internal.binary.BinaryRawWriterEx;
+import org.apache.ignite.internal.binary.BinaryWriterExImpl;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Client atomic long.
+ */
+public class ClientAtomicLongImpl implements ClientAtomicLong {
+    /** */
+    private final String name;
+
+    /** */
+    private final String groupName;
+
+    /** */
+    private final ReliableChannel ch;
+
+    /**
+     * Constructor.
+     *
+     * @param name Atomic long name.
+     * @param groupName Cache group name.
+     * @param ch Channel.
+     */
+    public ClientAtomicLongImpl(String name, @Nullable String groupName, ReliableChannel ch) {
+        // name and groupName uniquely identify the data structure.
+        this.name = name;
+        this.groupName = groupName;
+        this.ch = ch;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String name() {
+        return name;
+    }
+
+    /** {@inheritDoc} */
+    @Override public long get() throws IgniteException {
+        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_GET, this::writeName, in -> in.in().readLong());
+    }
+
+    /** {@inheritDoc} */
+    @Override public long incrementAndGet() throws IgniteException {
+        return addAndGet(1);
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getAndIncrement() throws IgniteException {
+        return incrementAndGet() - 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override public long addAndGet(long l) throws IgniteException {
+        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_ADD_AND_GET, out -> {
+            writeName(out);
+            out.out().writeLong(l);
+        }, in -> in.in().readLong());
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getAndAdd(long l) throws IgniteException {
+        return addAndGet(l) - l;
+    }
+
+    /** {@inheritDoc} */
+    @Override public long decrementAndGet() throws IgniteException {
+        return addAndGet(-1);
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getAndDecrement() throws IgniteException {
+        return decrementAndGet() + 1;
+    }
+
+    /** {@inheritDoc} */
+    @Override public long getAndSet(long l) throws IgniteException {
+        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_GET_AND_SET, out -> {
+            writeName(out);
+            out.out().writeLong(l);
+        }, in -> in.in().readLong());
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean compareAndSet(long expVal, long newVal) throws IgniteException {
+        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_COMPARE_AND_SET, out -> {
+            writeName(out);
+            out.out().writeLong(expVal);
+            out.out().writeLong(newVal);
+        }, in -> in.in().readBoolean());
+    }
+
+    /** {@inheritDoc} */
+    @Override public boolean removed() {
+        return ch.service(ClientOperation.ATOMIC_LONG_EXISTS, this::writeName, in -> !in.in().readBoolean());
+    }
+
+    /** {@inheritDoc} */
+    @Override public void close() {
+        ch.service(ClientOperation.ATOMIC_LONG_REMOVE, this::writeName, null);
+    }
+
+    /**
+     * Writes the name.
+     *
+     * @param out Output channel.
+     */
+    private void writeName(PayloadOutputChannel out) {
+        try (BinaryRawWriterEx w = new BinaryWriterExImpl(null, out.out(), null, null)) {
+            w.writeString(name);
+            w.writeString(groupName);
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientOperation.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientOperation.java
@@ -23,71 +23,197 @@ import org.jetbrains.annotations.Nullable;
 
 /** Operation codes. */
 public enum ClientOperation {
-    /** Resource close. */RESOURCE_CLOSE(0),
-    /** Heartbeat. */ HEARTBEAT(1),
-    /** Get idle timeout. */ GET_IDLE_TIMEOUT(2),
+    /** Resource close. */
+    RESOURCE_CLOSE(0),
 
-    /** Cache get or create with name. */CACHE_GET_OR_CREATE_WITH_NAME(1052),
-    /** Cache put. */CACHE_PUT(1001),
-    /** Cache get. */CACHE_GET(1000),
-    /** Cache create with configuration. */CACHE_CREATE_WITH_CONFIGURATION(1053),
-    /** Cache get names. */CACHE_GET_NAMES(1050),
-    /** Cache destroy. */CACHE_DESTROY(1056),
-    /** Cache get or create with configuration. */CACHE_GET_OR_CREATE_WITH_CONFIGURATION(1054),
-    /** Cache create with name. */CACHE_CREATE_WITH_NAME(1051),
-    /** Cache contains key. */CACHE_CONTAINS_KEY(1011),
-    /** Cache contains keys. */CACHE_CONTAINS_KEYS(1012),
-    /** Cache get configuration. */CACHE_GET_CONFIGURATION(1055),
-    /** Get size. */CACHE_GET_SIZE(1020),
-    /** Put all. */CACHE_PUT_ALL(1004),
-    /** Get all. */CACHE_GET_ALL(1003),
-    /** Cache replace if equals. */CACHE_REPLACE_IF_EQUALS(1010),
-    /** Cache replace. */CACHE_REPLACE(1009),
-    /** Cache remove key. */CACHE_REMOVE_KEY(1016),
-    /** Cache remove if equals. */CACHE_REMOVE_IF_EQUALS(1017),
-    /** Cache remove keys. */CACHE_REMOVE_KEYS(1018),
-    /** Cache remove all. */CACHE_REMOVE_ALL(1019),
-    /** Cache get and put. */CACHE_GET_AND_PUT(1005),
-    /** Cache get and remove. */CACHE_GET_AND_REMOVE(1007),
-    /** Cache get and replace. */CACHE_GET_AND_REPLACE(1006),
-    /** Cache put if absent. */CACHE_PUT_IF_ABSENT(1002),
-    /** Cache get and put if absent. */CACHE_GET_AND_PUT_IF_ABSENT(1008),
-    /** Cache clear. */CACHE_CLEAR(1013),
-    /** Cache clear key. */CACHE_CLEAR_KEY(1014),
-    /** Cache clear keys. */CACHE_CLEAR_KEYS(1015),
-    /** Cache partitions. */CACHE_PARTITIONS(1101),
+    /** Heartbeat. */
+    HEARTBEAT(1),
 
-    /** Query scan. */QUERY_SCAN(2000),
-    /** Query scan cursor get page. */QUERY_SCAN_CURSOR_GET_PAGE(2001),
-    /** Query sql. */QUERY_SQL(2002),
-    /** Query sql cursor get page. */QUERY_SQL_CURSOR_GET_PAGE(2003),
-    /** Query sql fields. */QUERY_SQL_FIELDS(2004),
-    /** Query sql fields cursor get page. */QUERY_SQL_FIELDS_CURSOR_GET_PAGE(2005),
-    /** Continuous query. */QUERY_CONTINUOUS(2006),
-    /** Continuous query event. */QUERY_CONTINUOUS_EVENT(2007, ClientNotificationType.CONTINUOUS_QUERY_EVENT),
+    /** Get idle timeout. */
+    GET_IDLE_TIMEOUT(2),
 
-    /** Get binary type. */GET_BINARY_TYPE(3002),
-    /** Register binary type name. */REGISTER_BINARY_TYPE_NAME(3001),
-    /** Put binary type. */PUT_BINARY_TYPE(3003),
-    /** Get binary type name. */GET_BINARY_TYPE_NAME(3000),
+    /** Cache get or create with name. */
+    CACHE_GET_OR_CREATE_WITH_NAME(1052),
 
-    /** Start new transaction. */TX_START(4000),
-    /** End the transaction (commit or rollback). */TX_END(4001),
+    /** Cache put. */
+    CACHE_PUT(1001),
 
-    /** Get cluster state. */CLUSTER_GET_STATE(5000),
-    /** Change cluster state. */CLUSTER_CHANGE_STATE(5001),
-    /** Get WAL state. */CLUSTER_GET_WAL_STATE(5003),
-    /** Change WAL state. */CLUSTER_CHANGE_WAL_STATE(5002),
-    /** Get nodes IDs by filter. */CLUSTER_GROUP_GET_NODE_IDS(5100),
-    /** Get nodes info by IDs. */CLUSTER_GROUP_GET_NODE_INFO(5101),
+    /** Cache get. */
+    CACHE_GET(1000),
 
-    /** Execute compute task. */COMPUTE_TASK_EXECUTE(6000),
-    /** Finished compute task notification. */COMPUTE_TASK_FINISHED(6001,
-        ClientNotificationType.COMPUTE_TASK_FINISHED),
+    /** Cache create with configuration. */
+    CACHE_CREATE_WITH_CONFIGURATION(1053),
 
-    /** Invoke service. */SERVICE_INVOKE(7000),
-    /** Get service descriptors. */SERVICE_GET_DESCRIPTORS(7001),
-    /** Get service descriptors. */SERVICE_GET_DESCRIPTOR(7002);
+    /** Cache get names. */
+    CACHE_GET_NAMES(1050),
+
+    /** Cache destroy. */
+    CACHE_DESTROY(1056),
+
+    /** Cache get or create with configuration. */
+    CACHE_GET_OR_CREATE_WITH_CONFIGURATION(1054),
+
+    /** Cache create with name. */
+    CACHE_CREATE_WITH_NAME(1051),
+
+    /** Cache contains key. */
+    CACHE_CONTAINS_KEY(1011),
+
+    /** Cache contains keys. */
+    CACHE_CONTAINS_KEYS(1012),
+
+    /** Cache get configuration. */
+    CACHE_GET_CONFIGURATION(1055),
+
+    /** Get size. */
+    CACHE_GET_SIZE(1020),
+
+    /** Put all. */
+    CACHE_PUT_ALL(1004),
+
+    /** Get all. */
+    CACHE_GET_ALL(1003),
+
+    /** Cache replace if equals. */
+    CACHE_REPLACE_IF_EQUALS(1010),
+
+    /** Cache replace. */
+    CACHE_REPLACE(1009),
+
+    /** Cache remove key. */
+    CACHE_REMOVE_KEY(1016),
+
+    /** Cache remove if equals. */
+    CACHE_REMOVE_IF_EQUALS(1017),
+
+    /** Cache remove keys. */
+    CACHE_REMOVE_KEYS(1018),
+
+    /** Cache remove all. */
+    CACHE_REMOVE_ALL(1019),
+
+    /** Cache get and put. */
+    CACHE_GET_AND_PUT(1005),
+
+    /** Cache get and remove. */
+    CACHE_GET_AND_REMOVE(1007),
+
+    /** Cache get and replace. */
+    CACHE_GET_AND_REPLACE(1006),
+
+    /** Cache put if absent. */
+    CACHE_PUT_IF_ABSENT(1002),
+
+    /** Cache get and put if absent. */
+    CACHE_GET_AND_PUT_IF_ABSENT(1008),
+
+    /** Cache clear. */
+    CACHE_CLEAR(1013),
+
+    /** Cache clear key. */
+    CACHE_CLEAR_KEY(1014),
+
+    /** Cache clear keys. */
+    CACHE_CLEAR_KEYS(1015),
+
+    /** Cache partitions. */
+    CACHE_PARTITIONS(1101),
+
+    /** Query scan. */
+    QUERY_SCAN(2000),
+
+    /** Query scan cursor get page. */
+    QUERY_SCAN_CURSOR_GET_PAGE(2001),
+
+    /** Query sql. */
+    QUERY_SQL(2002),
+
+    /** Query sql cursor get page. */
+    QUERY_SQL_CURSOR_GET_PAGE(2003),
+
+    /** Query sql fields. */
+    QUERY_SQL_FIELDS(2004),
+
+    /** Query sql fields cursor get page. */
+    QUERY_SQL_FIELDS_CURSOR_GET_PAGE(2005),
+
+    /** Continuous query. */
+    QUERY_CONTINUOUS(2006),
+
+    /** Continuous query event. */
+    QUERY_CONTINUOUS_EVENT(2007, ClientNotificationType.CONTINUOUS_QUERY_EVENT),
+
+    /** Get binary type. */
+    GET_BINARY_TYPE(3002),
+
+    /** Register binary type name. */
+    REGISTER_BINARY_TYPE_NAME(3001),
+
+    /** Put binary type. */
+    PUT_BINARY_TYPE(3003),
+
+    /** Get binary type name. */
+    GET_BINARY_TYPE_NAME(3000),
+
+    /** Start new transaction. */
+    TX_START(4000),
+
+    /** End the transaction (commit or rollback). */
+    TX_END(4001),
+
+    /** Get cluster state. */
+    CLUSTER_GET_STATE(5000),
+
+    /** Change cluster state. */
+    CLUSTER_CHANGE_STATE(5001),
+
+    /** Get WAL state. */
+    CLUSTER_GET_WAL_STATE(5003),
+
+    /** Change WAL state. */
+    CLUSTER_CHANGE_WAL_STATE(5002),
+
+    /** Get nodes IDs by filter. */
+    CLUSTER_GROUP_GET_NODE_IDS(5100),
+
+    /** Get nodes info by IDs. */
+    CLUSTER_GROUP_GET_NODE_INFO(5101),
+
+    /** Execute compute task. */
+    COMPUTE_TASK_EXECUTE(6000),
+
+    /** Finished compute task notification. */
+    COMPUTE_TASK_FINISHED(6001, ClientNotificationType.COMPUTE_TASK_FINISHED),
+
+    /** Invoke service. */
+    SERVICE_INVOKE(7000),
+
+    /** Get service descriptors. */
+    SERVICE_GET_DESCRIPTORS(7001),
+
+    /** Get service descriptors. */
+    SERVICE_GET_DESCRIPTOR(7002),
+
+    /** Get or create an AtomicLong by name. */
+    ATOMIC_LONG_CREATE(9000),
+
+    /** Remove an AtomicLong. */
+    ATOMIC_LONG_REMOVE(9001),
+
+    /** Check if AtomicLong exists. */
+    ATOMIC_LONG_EXISTS(9002),
+
+    /** AtomicLong.get. */
+    ATOMIC_LONG_VALUE_GET(9003),
+
+    /** AtomicLong.addAndGet (also covers incrementAndGet, getAndIncrement, getAndAdd, decrementAndGet, getAndDecrement).  */
+    ATOMIC_LONG_VALUE_ADD_AND_GET(9004),
+
+    /** AtomicLong.getAndSet. */
+    ATOMIC_LONG_VALUE_GET_AND_SET(9005),
+
+    /** AtomicLong.compareAndSet. */
+    ATOMIC_LONG_VALUE_COMPARE_AND_SET(9006);
 
     /** Code. */
     private final int code;
@@ -244,6 +370,27 @@ public enum ClientOperation {
 
             case SERVICE_GET_DESCRIPTOR:
                 return ClientOperationType.SERVICE_GET_DESCRIPTOR;
+
+            case ATOMIC_LONG_CREATE:
+                return ClientOperationType.ATOMIC_LONG_CREATE;
+
+            case ATOMIC_LONG_REMOVE:
+                return ClientOperationType.ATOMIC_LONG_REMOVE;
+
+            case ATOMIC_LONG_EXISTS:
+                return ClientOperationType.ATOMIC_LONG_EXISTS;
+
+            case ATOMIC_LONG_VALUE_GET:
+                return ClientOperationType.ATOMIC_LONG_VALUE_GET;
+
+            case ATOMIC_LONG_VALUE_ADD_AND_GET:
+                return ClientOperationType.ATOMIC_LONG_VALUE_ADD_AND_GET;
+
+            case ATOMIC_LONG_VALUE_GET_AND_SET:
+                return ClientOperationType.ATOMIC_LONG_VALUE_GET_AND_SET;
+
+            case ATOMIC_LONG_VALUE_COMPARE_AND_SET:
+                return ClientOperationType.ATOMIC_LONG_VALUE_COMPARE_AND_SET;
 
             default:
                 return null;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpIgniteClient.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpIgniteClient.java
@@ -32,6 +32,8 @@ import org.apache.ignite.binary.BinaryObjectException;
 import org.apache.ignite.binary.BinaryType;
 import org.apache.ignite.cache.query.FieldsQueryCursor;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
+import org.apache.ignite.client.ClientAtomicConfiguration;
+import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.client.ClientCache;
 import org.apache.ignite.client.ClientCacheConfiguration;
 import org.apache.ignite.client.ClientCluster;
@@ -56,6 +58,7 @@ import org.apache.ignite.internal.binary.BinaryWriterExImpl;
 import org.apache.ignite.internal.binary.streams.BinaryInputStream;
 import org.apache.ignite.internal.binary.streams.BinaryOutputStream;
 import org.apache.ignite.internal.client.thin.io.ClientConnectionMultiplexer;
+import org.apache.ignite.internal.util.GridArgumentCheck;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.marshaller.MarshallerContext;
@@ -326,6 +329,44 @@ public class TcpIgniteClient implements IgniteClient {
     /** {@inheritDoc} */
     @Override public ClientServices services(ClientClusterGroup grp) {
         return services.withClusterGroup((ClientClusterGroupImpl)grp);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientAtomicLong atomicLong(String name, long initVal, boolean create) {
+        return atomicLong(name, null, initVal, create);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientAtomicLong atomicLong(String name, ClientAtomicConfiguration cfg, long initVal, boolean create) {
+        GridArgumentCheck.notNull(name, "name");
+
+        if (create) {
+            ch.service(ClientOperation.ATOMIC_LONG_CREATE, out -> {
+                try (BinaryRawWriterEx w = new BinaryWriterExImpl(null, out.out(), null, null)) {
+                    w.writeString(name);
+                    w.writeLong(initVal);
+
+                    if (cfg != null) {
+                        w.writeBoolean(true);
+                        w.writeInt(cfg.getAtomicSequenceReserveSize());
+                        w.writeByte((byte)cfg.getCacheMode().ordinal());
+                        w.writeInt(cfg.getBackups());
+                        w.writeString(cfg.getGroupName());
+                    }
+                    else
+                        w.writeBoolean(false);
+                }
+
+            }, null);
+        }
+
+        ClientAtomicLong res = new ClientAtomicLongImpl(name, cfg != null ? cfg.getGroupName() : null, ch);
+
+        // Return null when specified atomic long does not exist to match IgniteKernal behavior.
+        if (!create && res.removed())
+            return null;
+
+        return res;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -77,6 +77,13 @@ import org.apache.ignite.internal.processors.platform.client.cluster.ClientClust
 import org.apache.ignite.internal.processors.platform.client.cluster.ClientClusterWalChangeStateRequest;
 import org.apache.ignite.internal.processors.platform.client.cluster.ClientClusterWalGetStateRequest;
 import org.apache.ignite.internal.processors.platform.client.compute.ClientExecuteTaskRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongCreateRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongExistsRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongRemoveRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongValueAddAndGetRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongValueCompareAndSetRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongValueGetAndSetRequest;
+import org.apache.ignite.internal.processors.platform.client.datastructures.ClientAtomicLongValueGetRequest;
 import org.apache.ignite.internal.processors.platform.client.service.ClientServiceGetDescriptorRequest;
 import org.apache.ignite.internal.processors.platform.client.service.ClientServiceGetDescriptorsRequest;
 import org.apache.ignite.internal.processors.platform.client.service.ClientServiceInvokeRequest;
@@ -287,6 +294,28 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
     /** */
     private static final short OP_DATA_STREAMER_ADD_DATA = 8001;
+
+    /** Data structures. */
+    /** Create an AtomicLong. */
+    private static final short OP_ATOMIC_LONG_CREATE = 9000;
+
+    /** Remove an AtomicLong. */
+    private static final short OP_ATOMIC_LONG_REMOVE = 9001;
+
+    /** Check if AtomicLong exists. */
+    private static final short OP_ATOMIC_LONG_EXISTS = 9002;
+
+    /** AtomicLong.get. */
+    private static final short OP_ATOMIC_LONG_VALUE_GET = 9003;
+
+    /** AtomicLong.addAndGet (also covers incrementAndGet, getAndIncrement, getAndAdd, decrementAndGet, getAndDecrement).  */
+    private static final short OP_ATOMIC_LONG_VALUE_ADD_AND_GET = 9004;
+
+    /** AtomicLong.getAndSet. */
+    private static final short OP_ATOMIC_LONG_VALUE_GET_AND_SET = 9005;
+
+    /** AtomicLong.compareAndSet. */
+    private static final short OP_ATOMIC_LONG_VALUE_COMPARE_AND_SET = 9006;
 
     /* Custom queries working through processors registry. */
     private static final short OP_CUSTOM_QUERY = 32_000;
@@ -519,6 +548,27 @@ public class ClientMessageParser implements ClientListenerMessageParser {
 
             case OP_DATA_STREAMER_ADD_DATA:
                 return new ClientDataStreamerAddDataRequest(reader);
+
+            case OP_ATOMIC_LONG_CREATE:
+                return new ClientAtomicLongCreateRequest(reader);
+
+            case OP_ATOMIC_LONG_REMOVE:
+                return new ClientAtomicLongRemoveRequest(reader);
+
+            case OP_ATOMIC_LONG_EXISTS:
+                return new ClientAtomicLongExistsRequest(reader);
+
+            case OP_ATOMIC_LONG_VALUE_GET:
+                return new ClientAtomicLongValueGetRequest(reader);
+
+            case OP_ATOMIC_LONG_VALUE_ADD_AND_GET:
+                return new ClientAtomicLongValueAddAndGetRequest(reader);
+
+            case OP_ATOMIC_LONG_VALUE_GET_AND_SET:
+                return new ClientAtomicLongValueGetAndSetRequest(reader);
+
+            case OP_ATOMIC_LONG_VALUE_COMPARE_AND_SET:
+                return new ClientAtomicLongValueCompareAndSetRequest(reader);
 
             case OP_CUSTOM_QUERY:
                 return new ClientCustomQueryRequest(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongCreateRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongCreateRequest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.configuration.AtomicConfiguration;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientRequest;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Gets or creates atomic long by name.
+ */
+public class ClientAtomicLongCreateRequest extends ClientRequest {
+    /** Atomic long name. */
+    private final String name;
+
+    /** Initial value. */
+    private final long initVal;
+
+    /** Configuration. */
+    private final AtomicConfiguration atomicConfiguration;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongCreateRequest(BinaryRawReader reader) {
+        super(reader);
+
+        name = reader.readString();
+        initVal = reader.readLong();
+        atomicConfiguration = readAtomicConfiguration(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        try {
+            ctx.kernalContext().dataStructures().atomicLong(name, atomicConfiguration, initVal, true);
+
+            return new ClientResponse(requestId());
+        }
+        catch (IgniteCheckedException e) {
+            return new ClientResponse(requestId(), e.getMessage());
+        }
+    }
+
+    /**
+     * Reads the atomic configuration.
+     *
+     * @param reader Reader.
+     * @return Config.
+     */
+    @Nullable private static AtomicConfiguration readAtomicConfiguration(BinaryRawReader reader) {
+        if (!reader.readBoolean())
+            return null;
+
+        return new AtomicConfiguration()
+                .setAtomicSequenceReserveSize(reader.readInt())
+                .setCacheMode(CacheMode.fromOrdinal(reader.readByte()))
+                .setBackups(reader.readInt())
+                .setGroupName(reader.readString());
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongExistsRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongExistsRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientBooleanResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long exists request.
+ */
+public class ClientAtomicLongExistsRequest extends ClientAtomicLongRequest {
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongExistsRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        IgniteAtomicLong atomicLong = atomicLong(ctx);
+
+        return new ClientBooleanResponse(requestId(), atomicLong != null);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongRemoveRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongRemoveRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long remove request.
+ */
+public class ClientAtomicLongRemoveRequest extends ClientAtomicLongRequest {
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongRemoveRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        IgniteAtomicLong atomicLong = atomicLong(ctx);
+
+        // Same semantics as IgniteAtomicLong - do nothing when does not exist.
+        if (atomicLong != null)
+            atomicLong.close();
+
+        return new ClientResponse(requestId());
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongRequest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.configuration.AtomicConfiguration;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientRequest;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long value request.
+ */
+public class ClientAtomicLongRequest extends ClientRequest {
+    /** Atomic long name. */
+    private final String name;
+
+    /** Cache group name. */
+    private final String groupName;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongRequest(BinaryRawReader reader) {
+        super(reader);
+
+        name = reader.readString();
+        groupName = reader.readString();
+    }
+
+    /**
+     * Gets the atomic long.
+     *
+     * @param ctx Context.
+     * @return Atomic long or null.
+     */
+    protected IgniteAtomicLong atomicLong(ClientConnectionContext ctx) {
+        AtomicConfiguration cfg = groupName == null ? null : new AtomicConfiguration().setGroupName(groupName);
+
+        try {
+            return ctx.kernalContext().dataStructures().atomicLong(name, cfg, 0, false);
+        }
+        catch (IgniteCheckedException e) {
+            throw new IgniteException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Gets a response for non-existent atomic long.
+     *
+     * @return Response for non-existent atomic long.
+     */
+    protected ClientResponse notFoundResponse() {
+        return new ClientResponse(requestId(), String.format("AtomicLong with name '%s' does not exist.", name));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueAddAndGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueAddAndGetRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientLongResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long add and get request.
+ */
+public class ClientAtomicLongValueAddAndGetRequest extends ClientAtomicLongRequest {
+    /** Operand. */
+    private final long operand;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongValueAddAndGetRequest(BinaryRawReader reader) {
+        super(reader);
+
+        operand = reader.readLong();
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        IgniteAtomicLong atomicLong = atomicLong(ctx);
+
+        if (atomicLong == null)
+            return notFoundResponse();
+
+        return new ClientLongResponse(requestId(), atomicLong.addAndGet(operand));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueCompareAndSetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueCompareAndSetRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientBooleanResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long get and set request.
+ */
+public class ClientAtomicLongValueCompareAndSetRequest extends ClientAtomicLongRequest {
+    /** */
+    private final long expected;
+
+    /** */
+    private final long val;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongValueCompareAndSetRequest(BinaryRawReader reader) {
+        super(reader);
+
+        expected = reader.readLong();
+        val = reader.readLong();
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        IgniteAtomicLong atomicLong = atomicLong(ctx);
+
+        if (atomicLong == null)
+            return notFoundResponse();
+
+        return new ClientBooleanResponse(requestId(), atomicLong.compareAndSet(expected, val));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueGetAndSetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueGetAndSetRequest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientLongResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long get and set request.
+ */
+public class ClientAtomicLongValueGetAndSetRequest extends ClientAtomicLongRequest {
+    /** Operand. */
+    private final long operand;
+
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongValueGetAndSetRequest(BinaryRawReader reader) {
+        super(reader);
+
+        operand = reader.readLong();
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        IgniteAtomicLong atomicLong = atomicLong(ctx);
+
+        if (atomicLong == null)
+            return notFoundResponse();
+
+        return new ClientLongResponse(requestId(), atomicLong.getAndSet(operand));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueGetRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/datastructures/ClientAtomicLongValueGetRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.platform.client.datastructures;
+
+import org.apache.ignite.IgniteAtomicLong;
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.platform.client.ClientLongResponse;
+import org.apache.ignite.internal.processors.platform.client.ClientResponse;
+
+/**
+ * Atomic long value request.
+ */
+public class ClientAtomicLongValueGetRequest extends ClientAtomicLongRequest {
+    /**
+     * Constructor.
+     *
+     * @param reader Reader.
+     */
+    public ClientAtomicLongValueGetRequest(BinaryRawReader reader) {
+        super(reader);
+    }
+
+    /** {@inheritDoc} */
+    @Override public ClientResponse process(ClientConnectionContext ctx) {
+        IgniteAtomicLong atomicLong = atomicLong(ctx);
+
+        if (atomicLong == null)
+            return notFoundResponse();
+
+        return new ClientLongResponse(requestId(), atomicLong.get());
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AtomicLongTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/AtomicLongTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.thin;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.client.ClientAtomicConfiguration;
+import org.apache.ignite.client.ClientAtomicLong;
+import org.apache.ignite.client.ClientException;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
+import org.junit.Test;
+import static org.apache.ignite.testframework.GridTestUtils.assertContains;
+import static org.apache.ignite.testframework.GridTestUtils.assertThrows;
+
+/**
+ * Tests client atomic long.
+ */
+public class AtomicLongTest extends AbstractThinClientTest {
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
+        super.beforeTestsStarted();
+
+        startGrids(1);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
+        stopAllGrids();
+
+        super.afterTestsStopped();
+    }
+
+    /**
+     * Tests initial value setting.
+     */
+    @Test
+    public void testCreateSetsInitialValue() {
+        String name = "testCreateSetsInitialValue";
+
+        try (IgniteClient client = startClient(0)) {
+            ClientAtomicLong atomicLong = client.atomicLong(name, 42, true);
+
+            ClientAtomicLong atomicLongWithGroup = client.atomicLong(
+                    name, new ClientAtomicConfiguration().setGroupName("grp"), 43, true);
+
+            assertEquals(42, atomicLong.get());
+            assertEquals(43, atomicLongWithGroup.get());
+        }
+    }
+
+    /**
+     * Tests that initial value is ignored when atomic long already exists.
+     */
+    @Test
+    public void testCreateIgnoresInitialValueWhenAlreadyExists() {
+        String name = "testCreateIgnoresInitialValueWhenAlreadyExists";
+
+        try (IgniteClient client = startClient(0)) {
+            ClientAtomicLong atomicLong = client.atomicLong(name, 42, true);
+            ClientAtomicLong atomicLong2 = client.atomicLong(name, -42, true);
+
+            assertEquals(42, atomicLong.get());
+            assertEquals(42, atomicLong2.get());
+        }
+    }
+
+    /**
+     * Tests that exception is thrown when atomic long does not exist.
+     */
+    @Test
+    public void testOperationsThrowExceptionWhenAtomicLongDoesNotExist() {
+        try (IgniteClient client = startClient(0)) {
+            String name = "testOperationsThrowExceptionWhenAtomicLongDoesNotExist";
+            ClientAtomicLong atomicLong = client.atomicLong(name, 0, true);
+            atomicLong.close();
+
+            assertDoesNotExistError(name, atomicLong::get);
+
+            assertDoesNotExistError(name, atomicLong::incrementAndGet);
+            assertDoesNotExistError(name, atomicLong::getAndIncrement);
+            assertDoesNotExistError(name, atomicLong::decrementAndGet);
+            assertDoesNotExistError(name, atomicLong::getAndDecrement);
+
+            assertDoesNotExistError(name, () -> atomicLong.addAndGet(1));
+            assertDoesNotExistError(name, () -> atomicLong.getAndAdd(1));
+
+            assertDoesNotExistError(name, () -> atomicLong.getAndSet(1));
+            assertDoesNotExistError(name, () -> atomicLong.compareAndSet(1, 2));
+        }
+    }
+
+    /**
+     * Tests removed property.
+     */
+    @Test
+    public void testRemoved() {
+        String name = "testRemoved";
+
+        try (IgniteClient client = startClient(0)) {
+            ClientAtomicLong atomicLong = client.atomicLong(name, 0, false);
+            assertNull(atomicLong);
+
+            atomicLong = client.atomicLong(name, 1, true);
+            assertFalse(atomicLong.removed());
+            assertEquals(1, atomicLong.get());
+
+            atomicLong.close();
+            assertTrue(atomicLong.removed());
+        }
+    }
+
+    /**
+     * Tests increment, decrement, add.
+     */
+    @Test
+    public void testIncrementDecrementAdd() {
+        String name = "testIncrementDecrementAdd";
+
+        try (IgniteClient client = startClient(0)) {
+            ClientAtomicLong atomicLong = client.atomicLong(name, 1, true);
+
+            assertEquals(2, atomicLong.incrementAndGet());
+            assertEquals(2, atomicLong.getAndIncrement());
+
+            assertEquals(3, atomicLong.get());
+
+            assertEquals(2, atomicLong.decrementAndGet());
+            assertEquals(2, atomicLong.getAndDecrement());
+
+            assertEquals(1, atomicLong.get());
+
+            assertEquals(101, atomicLong.addAndGet(100));
+            assertEquals(101, atomicLong.getAndAdd(-50));
+
+            assertEquals(51, atomicLong.get());
+        }
+    }
+
+    /**
+     * Tests getAndSet.
+     */
+    @Test
+    public void testGetAndSet() {
+        String name = "testGetAndSet";
+
+        try (IgniteClient client = startClient(0)) {
+            ClientAtomicLong atomicLong = client.atomicLong(name, 1, true);
+
+            assertEquals(1, atomicLong.getAndSet(100));
+            assertEquals(100, atomicLong.get());
+        }
+    }
+
+    /**
+     * Tests compareAndSet.
+     */
+    @Test
+    public void testCompareAndSet() {
+        String name = "testCompareAndSet";
+
+        try (IgniteClient client = startClient(0)) {
+            ClientAtomicLong atomicLong = client.atomicLong(name, 1, true);
+
+            assertFalse(atomicLong.compareAndSet(2, 3));
+            assertEquals(1, atomicLong.get());
+
+            assertTrue(atomicLong.compareAndSet(1, 4));
+            assertEquals(4, atomicLong.get());
+        }
+    }
+
+    /**
+     * Tests atomic long with custom configuration.
+     */
+    @Test
+    public void testCustomConfigurationPropagatesToServer() {
+        ClientAtomicConfiguration cfg1 = new ClientAtomicConfiguration()
+                .setAtomicSequenceReserveSize(64)
+                .setBackups(2)
+                .setCacheMode(CacheMode.PARTITIONED)
+                .setGroupName("atomic-long-group-partitioned");
+
+        ClientAtomicConfiguration cfg2 = new ClientAtomicConfiguration()
+                .setAtomicSequenceReserveSize(32)
+                .setBackups(3)
+                .setCacheMode(CacheMode.REPLICATED)
+                .setGroupName("atomic-long-group-replicated");
+
+        String name = "testCustomConfiguration";
+
+        try (IgniteClient client = startClient(0)) {
+            client.atomicLong(name, cfg1, 1, true);
+            client.atomicLong(name, cfg2, 2, true);
+        }
+
+        List<IgniteInternalCache<?, ?>> caches = new ArrayList<>(grid(0).cachesx());
+        assertEquals(3, caches.size());
+
+        IgniteInternalCache<?, ?> partitionedCache = caches.get(1);
+        IgniteInternalCache<?, ?> replicatedCache = caches.get(2);
+
+        assertEquals("ignite-sys-atomic-cache@atomic-long-group-partitioned", partitionedCache.name());
+        assertEquals("ignite-sys-atomic-cache@atomic-long-group-replicated", replicatedCache.name());
+
+        assertEquals(2, partitionedCache.configuration().getBackups());
+        assertEquals(Integer.MAX_VALUE, replicatedCache.configuration().getBackups());
+    }
+
+    /**
+     * Asserts that "does not exist" error is thrown.
+     *
+     * @param name Atomic long name.
+     * @param callable Callable.
+     */
+    private void assertDoesNotExistError(String name, Callable<Object> callable) {
+        ClientException ex = (ClientException)assertThrows(null, callable, ClientException.class, null);
+
+        assertContains(null, ex.getMessage(), "AtomicLong with name '" + name + "' does not exist.");
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/client/ClientTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/client/ClientTestSuite.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.client;
 
+import org.apache.ignite.internal.client.thin.AtomicLongTest;
 import org.apache.ignite.internal.client.thin.CacheAsyncTest;
 import org.apache.ignite.internal.client.thin.CacheEntryListenersTest;
 import org.apache.ignite.internal.client.thin.ClusterApiTest;
@@ -70,6 +71,7 @@ import org.junit.runners.Suite;
     CacheAsyncTest.class,
     TimeoutTest.class,
     OptimizedMarshallerClassesCachedTest.class,
+    AtomicLongTest.class
 })
 public class ClientTestSuite {
     // No-op.


### PR DESCRIPTION
* Add `IgniteClient.atomicLong()` and `ClientAtomicLong` APIs.
* Provides the same functionality as "thick" API, with the only exception of `AtomicConfiguration.affinityFunction`.