### PR TITLE
GG-35262 [IGNITE-16983] Java thin: Add AtomicLong partition awareness

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientAtomicLongImpl.java
@@ -20,6 +20,7 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.internal.binary.BinaryRawWriterEx;
 import org.apache.ignite.internal.binary.BinaryWriterExImpl;
+import org.apache.ignite.internal.processors.datastructures.DataStructuresProcessor;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -35,6 +36,9 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
     /** */
     private final ReliableChannel ch;
 
+    /** Cache id. */
+    private final int cacheId;
+
     /**
      * Constructor.
      *
@@ -47,6 +51,9 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
         this.name = name;
         this.groupName = groupName;
         this.ch = ch;
+
+        String groupNameInternal = groupName == null ? DataStructuresProcessor.DEFAULT_DS_GROUP_NAME : groupName;
+        cacheId = ClientUtils.cacheId(DataStructuresProcessor.ATOMICS_CACHE_NAME + "@" + groupNameInternal);
     }
 
     /** {@inheritDoc} */
@@ -56,7 +63,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long get() throws IgniteException {
-        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_GET, this::writeName, in -> in.in().readLong());
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_GET, this::writeName, in -> in.in().readLong());
     }
 
     /** {@inheritDoc} */
@@ -71,7 +78,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long addAndGet(long l) throws IgniteException {
-        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_ADD_AND_GET, out -> {
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_ADD_AND_GET, out -> {
             writeName(out);
             out.out().writeLong(l);
         }, in -> in.in().readLong());
@@ -94,7 +101,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public long getAndSet(long l) throws IgniteException {
-        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_GET_AND_SET, out -> {
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_GET_AND_SET, out -> {
             writeName(out);
             out.out().writeLong(l);
         }, in -> in.in().readLong());
@@ -102,7 +109,7 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public boolean compareAndSet(long expVal, long newVal) throws IgniteException {
-        return ch.service(ClientOperation.ATOMIC_LONG_VALUE_COMPARE_AND_SET, out -> {
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_VALUE_COMPARE_AND_SET, out -> {
             writeName(out);
             out.out().writeLong(expVal);
             out.out().writeLong(newVal);
@@ -111,12 +118,13 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
 
     /** {@inheritDoc} */
     @Override public boolean removed() {
-        return ch.service(ClientOperation.ATOMIC_LONG_EXISTS, this::writeName, in -> !in.in().readBoolean());
+        return ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_EXISTS, this::writeName,
+                in -> !in.in().readBoolean());
     }
 
     /** {@inheritDoc} */
     @Override public void close() {
-        ch.service(ClientOperation.ATOMIC_LONG_REMOVE, this::writeName, null);
+        ch.affinityService(cacheId, affinityKey(), ClientOperation.ATOMIC_LONG_REMOVE, this::writeName, null);
     }
 
     /**
@@ -129,5 +137,15 @@ public class ClientAtomicLongImpl implements ClientAtomicLong {
             w.writeString(name);
             w.writeString(groupName);
         }
+    }
+
+    /**
+     * Gets the affinity key for this data structure.
+     * 
+     * @return Affinity key.
+     */
+    private String affinityKey() {
+        // GridCacheInternalKeyImpl uses name as AffinityKeyMapped.
+        return name;
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractAffinityAwarenessTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAbstractAffinityAwarenessTest.java
@@ -145,11 +145,11 @@ public abstract class ThinClientAbstractAffinityAwarenessTest extends GridCommon
 
         assertNotNull("Unexpected (null) next operation [expCh=" + expCh + ", expOp=" + expOp + ']', nextChOp);
 
-        assertEquals("Unexpected channel for opertation [expCh=" + expCh + ", expOp=" + expOp +
-            ", nextOpCh=" + nextChOp + ']', expCh, nextChOp.get1());
-
         assertEquals("Unexpected operation on channel [expCh=" + expCh + ", expOp=" + expOp +
-            ", nextOpCh=" + nextChOp + ']', expOp, nextChOp.get2());
+                ", nextOpCh=" + nextChOp + ']', expOp, nextChOp.get2());
+
+        assertEquals("Unexpected channel for operation [expCh=" + expCh + ", expOp=" + expOp +
+            ", nextOpCh=" + nextChOp + ']', expCh, nextChOp.get1());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessStableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessStableTopologyTest.java
@@ -19,8 +19,13 @@ package org.apache.ignite.internal.client.thin;
 
 import java.util.function.Function;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.cache.CacheMode;
+import org.apache.ignite.client.ClientAtomicConfiguration;
+import org.apache.ignite.client.ClientAtomicLong;
 import org.apache.ignite.client.ClientCache;
+import org.apache.ignite.configuration.AtomicConfiguration;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
+import org.apache.ignite.internal.processors.datastructures.GridCacheAtomicLongEx;
 import org.junit.Test;
 
 /**
@@ -135,6 +140,43 @@ public class ThinClientAffinityAwarenessStableTopologyTest extends ThinClientAbs
     @Test
     public void testPartitionedCache3Backups() throws Exception {
         testApplicableCache(PART_CACHE_3_BACKUPS_NAME, i -> i);
+    }
+
+    /**
+     * Test atomic long.
+     */
+    @Test
+    public void testAtomicLong() {
+        testAtomicLong("default-grp-partitioned", null, CacheMode.PARTITIONED);
+        testAtomicLong("default-grp-replicated", null, CacheMode.REPLICATED);
+        testAtomicLong("custom-grp-partitioned", "testAtomicLong", CacheMode.PARTITIONED);
+        testAtomicLong("custom-grp-replicated", "testAtomicLong", CacheMode.REPLICATED);
+    }
+
+    /**
+     * Test atomic long.
+     */
+    private void testAtomicLong(String name, String grpName, CacheMode cacheMode) {
+        ClientAtomicConfiguration cfg = new ClientAtomicConfiguration()
+                .setGroupName(grpName)
+                .setCacheMode(cacheMode);
+
+        ClientAtomicLong clientAtomicLong = client.atomicLong(name, cfg, 1, true);
+        GridCacheAtomicLongEx serverAtomicLong = (GridCacheAtomicLongEx)grid(0).atomicLong(
+                name, new AtomicConfiguration().setGroupName(grpName), 0, false);
+
+        String cacheName = "ignite-sys-atomic-cache@" + (grpName == null ? "default-ds-group" : grpName);
+        IgniteInternalCache<Object, Object> cache = grid(0).context().cache().cache(cacheName);
+
+        // Warm up.
+        clientAtomicLong.get();
+        opsQueue.clear();
+
+        // Test.
+        clientAtomicLong.get();
+        TestTcpClientChannel opCh = affinityChannel(serverAtomicLong.key(), cache);
+
+        assertOpOnChannel(opCh, ClientOperation.ATOMIC_LONG_VALUE_GET);
     }
 
     /**


### PR DESCRIPTION
`AtomicLong` is just a cache entry underneath, where `GridCacheInternalKeyImpl` is the key. Use partition awareness to send requests to the primary node and improve performance.