### PR TITLE
GG-35243 [IGNITE-16958] .NET: Fix net461 release build

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite/App.config
+++ b/modules/platforms/dotnet/Apache.Ignite/App.config
@@ -26,10 +26,6 @@
         <section name="igniteConfiguration" type="Apache.Ignite.Core.IgniteConfigurationSection, Apache.Ignite.Core" />
     </configSections>
     
-    <startup>
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.0"/>
-    </startup>
-
     <runtime>
         <gcServer enabled="true" />
     </runtime>

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -180,6 +180,9 @@ cd $PSScriptRoot
 # 2) Build .NET
 if (!$skipDotNet) {
     Build-Solution ".\Apache.Ignite.sln" "bin\net461"
+    
+    # Overwrite dlls to ensure that net461 versions are used instead of netstandard2. 
+    Copy-Item -Force -Recurse ".\Apache.Ignite\bin\$configuration\net461\*" "bin\net461"
 }
 
 if(!$skipDotNetCore) {


### PR DESCRIPTION
Fix "IgniteConfigurationSection does not inherit from IConfigurationSectionHandler" exception due to a wrong `System.Configuration.ConfigurationManager.dll` binary being copied to release directory.