### PR TITLE
GG-35189 DiscoveryClientSocketTest.sslSocketTest fails regularly on TC and locally

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/DiscoveryClientSocketTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/DiscoveryClientSocketTest.java
@@ -83,7 +83,7 @@ public class DiscoveryClientSocketTest extends GridCommonAbstractTest {
 
                 connection.getOutputStream().write(U.IGNITE_HEADER);
 
-                clientFut.get(10_000);
+                clientFut.get(20_000);
             }
             catch (IgniteFutureTimeoutCheckedException e) {
                 U.dumpThreads(log);
@@ -106,7 +106,7 @@ public class DiscoveryClientSocketTest extends GridCommonAbstractTest {
      * @param connection Socket connection.
      * @throws IOException If have some issue happens in time read from socket.
      */
-    public void readHandshake(Socket connection) throws IOException {
+    private void readHandshake(Socket connection) throws IOException {
         byte[] buf = new byte[4];
         int read = 0;
 
@@ -160,7 +160,7 @@ public class DiscoveryClientSocketTest extends GridCommonAbstractTest {
                         }
                     });
 
-                    writeFut.get(10 * handshakeInterval);
+                    writeFut.get(Math.min(10 * handshakeInterval, 3_000));
                 }
             }
             catch (IgniteFutureTimeoutCheckedException e) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35189

This is caused by two problems:

1. Some JDK versions (including 1.8.0_261) contain a bug https://bugs.openjdk.java.net/browse/JDK-8241239 due to which close() on a socket is blocked when a write() is blocked on its output stream. This causes the test to always fail on such JDKs. The test models a situation which may be faced by our customers, so there is no point in working this around just in our test.
2. If the original 'handshake' takes long time (I saw it around 1 second), then the test may block on a write attempt for a long time (handshake time multiplied by 10), in my case 10 seconds, which makes the test fail.

This commit can't do anything with item 1, but it alleviates item 2: write wait time is bounded.