### PR TITLE
GG-35343 [IGNITE-16582] Improve behavior of speed-based throttling when dirty pages ratio is low

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointProgressImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointProgressImpl.java
@@ -245,11 +245,11 @@ public class CheckpointProgressImpl implements CheckpointProgress {
     }
 
     /** {@inheritDoc} */
-    @Override public void updateEvictedPages(int deltha) {
-        A.ensure(deltha > 0, "param must be positive");
+    @Override public void updateEvictedPages(int delta) {
+        A.ensure(delta > 0, "param must be positive");
 
         if (evictedPagesCounter() != null)
-            evictedPagesCounter().addAndGet(deltha);
+            evictedPagesCounter().addAndGet(delta);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteSpeedBasedThrottle.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteSpeedBasedThrottle.java
@@ -26,6 +26,7 @@ import org.apache.ignite.internal.processors.cache.persistence.checkpoint.Checkp
 import org.apache.ignite.internal.util.GridConcurrentHashSet;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteOutClosure;
+import org.jetbrains.annotations.TestOnly;
 
 /**
  * Throttles threads that generate dirty pages during ongoing checkpoint.
@@ -103,7 +104,7 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
         this.log = log;
 
         cleanPagesProtector = new SpeedBasedMemoryConsumptionThrottlingStrategy(pageMemory, cpProgress,
-                markSpeedAndAvgParkTime);
+            markSpeedAndAvgParkTime);
         cpBufferWatchdog = new CheckpointBufferOverflowWatchdog(pageMemory);
     }
 
@@ -185,7 +186,7 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
 
         if (prevWarnTime.compareAndSet(prevWarningNs, curNs) && log.isInfoEnabled()) {
             String msg = String.format("Throttling is applied to page modifications " +
-                    "[percentOfPartTime=%.2f, markDirty=%d pages/sec, checkpointWrite=%d pages/sec, " +
+                    "[fractionOfParkTime=%.2f, markDirty=%d pages/sec, checkpointWrite=%d pages/sec, " +
                     "estIdealMarkDirty=%d pages/sec, curDirty=%.2f, maxDirty=%.2f, avgParkTime=%d ns, " +
                     "pages: (total=%d, evicted=%d, written=%d, synced=%d, cpBufUsed=%d, cpBufTotal=%d)]",
                 weight, getMarkDirtySpeed(), getCpWriteSpeed(),
@@ -209,6 +210,7 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
      * @param curCpWriteSpeed average checkpoint write speed, pages/sec.
      * @return time in nanoseconds to part or 0 if throttling is not required.
      */
+    @TestOnly
     long getCleanPagesProtectionParkTime(
             double dirtyPagesRatio,
             long fullyCompletedPages,
@@ -292,7 +294,7 @@ public class PagesWriteSpeedBasedThrottle implements PagesWriteThrottlePolicy {
         if (speed <= 0)
             return 0;
 
-        long timeForOnePage = cleanPagesProtector.calcDelayTime(speed);
+        long timeForOnePage = cleanPagesProtector.nsPerOperation(speed);
 
         if (timeForOnePage == 0)
             return 0;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedMemoryConsumptionThrottlingStrategy.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/SpeedBasedMemoryConsumptionThrottlingStrategy.java
@@ -56,7 +56,7 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
     /**
      * Total pages possible to store in page memory.
      */
-    private final long totalPages;
+    private volatile long pageMemTotalPages;
 
     /**
      * Last estimated speed for marking all clear pages as dirty till the end of checkpoint.
@@ -110,8 +110,6 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
         this.pageMemory = pageMemory;
         this.cpProgress = cpProgress;
         this.markSpeedAndAvgParkTime = markSpeedAndAvgParkTime;
-
-        totalPages = pageMemory.totalPages();
     }
 
     /**
@@ -148,7 +146,7 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
         final int cpWrittenPages = writtenPagesCounter.get();
         final long donePages = cpDonePagesEstimation(cpWrittenPages);
 
-        final long markDirtySpeed = markSpeedAndAvgParkTime.getSpeedOpsPerSec(curNanoTime);
+        final long instantaneousMarkDirtySpeed = markSpeedAndAvgParkTime.getSpeedOpsPerSec(curNanoTime);
         // NB: we update progress for speed calculation only in this (clean pages protection) scenario, because
         // we only use the computed speed in this same scenario and for reporting in logs (where it's not super
         // important to display an ideally accurate speed), but not in the CP Buffer protection scenario.
@@ -156,7 +154,8 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
         // The progress is set to 0 at the beginning of a checkpoint, so we can be sure that the start time remembered
         // in cpWriteSpeed is pretty accurate even without writing to cpWriteSpeed from this method.
         cpWriteSpeed.setProgress(donePages, curNanoTime);
-        final long curCpWriteSpeed = cpWriteSpeed.getOpsPerSecond(curNanoTime);
+        // TODO: IGNITE-16878 use exponential moving average so that we react to changes faster?
+        final long avgCpWriteSpeed = cpWriteSpeed.getOpsPerSecond(curNanoTime);
 
         final int cpTotalPages = cpTotalPages();
 
@@ -165,11 +164,11 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
             // CheckpointProgressImpl.clearCounters() is invoked at the end of a checkpoint (by falling through
             // between two volatile assignments). When we get here, we don't have any information about the total
             // number of pages in the current CP, so we calculate park time by only using information we have.
-            return parkTimeToThrottleByJustCPSpeed(markDirtySpeed, curCpWriteSpeed);
+            return parkTimeToThrottleByJustCPSpeed(instantaneousMarkDirtySpeed, avgCpWriteSpeed);
         }
         else {
-            return speedBasedParkTime(cpWrittenPages, donePages, markDirtySpeed,
-                    curCpWriteSpeed, cpTotalPages);
+            return speedBasedParkTime(cpWrittenPages, donePages, cpTotalPages, instantaneousMarkDirtySpeed,
+                    avgCpWriteSpeed);
         }
     }
 
@@ -182,6 +181,9 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
      * @return estimation of work done (in pages)
      */
     private int cpDonePagesEstimation(int cpWrittenPages) {
+        // TODO: IGNITE-16879 - this only works correctly if time-to-write a page is close to time-to-sync a page.
+        // In reality, this does not seem to hold, which produces wrong estimations. We could measure the real times
+        // in Checkpointer and make this estimation a lot more precise.
         return (cpWrittenPages + cpSyncedPages()) / 2;
     }
 
@@ -197,15 +199,15 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
         boolean throttleByCpSpeed = curCpWriteSpeed > 0 && markDirtySpeed > curCpWriteSpeed;
 
         if (throttleByCpSpeed) {
-            return calcDelayTime(curCpWriteSpeed);
+            return nsPerOperation(curCpWriteSpeed);
         }
 
         return 0;
     }
 
     /***/
-    private long speedBasedParkTime(int cpWrittenPages, long donePages, long markDirtySpeed,
-                                    long curCpWriteSpeed, int cpTotalPages) {
+    private long speedBasedParkTime(int cpWrittenPages, long donePages, int cpTotalPages,
+                                    long instantaneousMarkDirtySpeed, long avgCpWriteSpeed) {
         final double dirtyPagesRatio = pageMemory.getDirtyPagesRatio();
 
         currDirtyRatio = dirtyPagesRatio;
@@ -219,8 +221,8 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
                     donePages,
                     notEvictedPagesTotal(cpTotalPages),
                     threadIdsCount(),
-                    markDirtySpeed,
-                    curCpWriteSpeed);
+                    instantaneousMarkDirtySpeed,
+                    avgCpWriteSpeed);
         }
     }
 
@@ -236,8 +238,8 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
      * @param donePages           roughly, written & fsynced pages count.
      * @param cpTotalPages        total checkpoint scope.
      * @param nThreads            number of threads providing data during current checkpoint.
-     * @param markDirtySpeed      registered mark dirty speed, pages/sec.
-     * @param curCpWriteSpeed     average checkpoint write speed, pages/sec.
+     * @param instantaneousMarkDirtySpeed registered (during approx last second) mark dirty speed, pages/sec.
+     * @param avgCpWriteSpeed     average checkpoint write speed, pages/sec.
      * @return time in nanoseconds to part or 0 if throttling is not required.
      */
     long getParkTime(
@@ -245,84 +247,40 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
             long donePages,
             int cpTotalPages,
             int nThreads,
-            long markDirtySpeed,
-            long curCpWriteSpeed) {
+            long instantaneousMarkDirtySpeed,
+            long avgCpWriteSpeed) {
 
         final long targetSpeedToMarkAll = calcSpeedToMarkAllSpaceTillEndOfCp(dirtyPagesRatio, donePages,
-                curCpWriteSpeed, cpTotalPages);
+            avgCpWriteSpeed, cpTotalPages);
         final double targetCurrentDirtyRatio = targetCurrentDirtyRatio(donePages, cpTotalPages);
 
-        updateSpeedAndRatio(targetSpeedToMarkAll, targetCurrentDirtyRatio);
+        publishSpeedAndRatioForMetrics(targetSpeedToMarkAll, targetCurrentDirtyRatio);
 
-        long delayByCpWrite = delayIfMarkingFasterThanCPWriteSpeedAllows(markDirtySpeed, curCpWriteSpeed,
-                dirtyPagesRatio, nThreads, targetSpeedToMarkAll, targetCurrentDirtyRatio);
-        long delayByMarkAllWrite = delayIfMarkingFasterThanTargetSpeedAllows(markDirtySpeed, dirtyPagesRatio, nThreads,
-                targetSpeedToMarkAll, targetCurrentDirtyRatio);
-
-        return Math.max(delayByCpWrite, delayByMarkAllWrite);
+        return delayIfMarkingFasterThanTargetSpeedAllows(instantaneousMarkDirtySpeed,
+            dirtyPagesRatio, nThreads, targetSpeedToMarkAll, targetCurrentDirtyRatio);
     }
 
     /***/
-    private long delayIfMarkingFasterThanCPWriteSpeedAllows(long markDirtySpeed, long curCpWriteSpeed,
-                                                            double dirtyPagesRatio, int nThreads,
-                                                            long targetSpeedToMarkAll, double targetCurrentDirtyRatio) {
-        final double allowedCpWriteSpeedExcessMultiplier = allowedCpWriteSpeedExcessMultiplier(markDirtySpeed,
-                dirtyPagesRatio, targetSpeedToMarkAll, targetCurrentDirtyRatio);
-        final boolean throttleByCpSpeed = curCpWriteSpeed > 0
-                && markDirtySpeed > (allowedCpWriteSpeedExcessMultiplier * curCpWriteSpeed);
-
-        if (!throttleByCpSpeed) {
-            return 0;
-        }
-
-        int slowdown = slowdownIfLowSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
-        long nanosecsToMarkOnePage = TimeUnit.SECONDS.toNanos(1) * nThreads / markDirtySpeed;
-        long nanosecsToWriteOneCPPage = calcDelayTime(curCpWriteSpeed, nThreads, slowdown);
-        return nanosecsToWriteOneCPPage - nanosecsToMarkOnePage;
-    }
-
-    /***/
-    private double allowedCpWriteSpeedExcessMultiplier(long markDirtySpeed, double dirtyPagesRatio,
-                                                       long targetSpeedToMarkAll, double targetCurrentDirtyRatio) {
-        final boolean lowSpaceLeft = lowCleanSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
-
-        // for case of speedForMarkAll >> markDirtySpeed, allow write little bit faster than CP average
-        final double allowWriteFasterThanCp;
-        if (markDirtySpeed > 0 && markDirtySpeed < targetSpeedToMarkAll)
-            allowWriteFasterThanCp = 0.1 * targetSpeedToMarkAll / markDirtySpeed;
-        else if (dirtyPagesRatio > targetCurrentDirtyRatio)
-            allowWriteFasterThanCp = 0.0;
-        else
-            allowWriteFasterThanCp = 0.1;
-
-        return lowSpaceLeft
-                ? 1.0
-                : 1.0 + allowWriteFasterThanCp;
-    }
-
-    /***/
-    private int slowdownIfLowSpaceLeft(double dirtyPagesRatio, double targetCurrentDirtyRatio) {
-        boolean lowSpaceLeft = lowCleanSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
-        return slowdownIfLowSpaceLeft(lowSpaceLeft);
-    }
-
-    /***/
-    private int slowdownIfLowSpaceLeft(boolean lowSpaceLeft) {
-        return lowSpaceLeft ? 3 : 1;
-    }
-
-    /***/
-    private long delayIfMarkingFasterThanTargetSpeedAllows(long markDirtySpeed, double dirtyPagesRatio, int nThreads,
+    private long delayIfMarkingFasterThanTargetSpeedAllows(long instantaneousMarkDirtySpeed, double dirtyPagesRatio,
+                                                           int nThreads,
                                                            long targetSpeedToMarkAll, double targetCurrentDirtyRatio) {
         final boolean lowSpaceLeft = lowCleanSpaceLeft(dirtyPagesRatio, targetCurrentDirtyRatio);
         final int slowdown = slowdownIfLowSpaceLeft(lowSpaceLeft);
 
         double multiplierForSpeedToMarkAll = lowSpaceLeft ? 0.8 : 1.0;
         boolean markingTooFastNow = targetSpeedToMarkAll > 0
-                && markDirtySpeed > multiplierForSpeedToMarkAll * targetSpeedToMarkAll;
+                && instantaneousMarkDirtySpeed > multiplierForSpeedToMarkAll * targetSpeedToMarkAll;
         boolean markedTooFastSinceCPStart = dirtyPagesRatio > targetCurrentDirtyRatio;
         boolean markingTooFast = markedTooFastSinceCPStart && markingTooFastNow;
-        return markingTooFast ? calcDelayTime(targetSpeedToMarkAll, nThreads, slowdown) : 0;
+
+        // We must NOT subtract nsPerOperation(instantaneousMarkDirtySpeed, nThreads)! If we do, the actual speed
+        // converges to a value that is 1-2 times higher than the target speed.
+        return markingTooFast ? nsPerOperation(targetSpeedToMarkAll, nThreads, slowdown) : 0;
+    }
+
+    /***/
+    private int slowdownIfLowSpaceLeft(boolean lowSpaceLeft) {
+        return lowSpaceLeft ? 3 : 1;
     }
 
     /**
@@ -337,9 +295,9 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
     }
 
     /***/
-    private void updateSpeedAndRatio(long speedForMarkAll, double targetDirtyRatio) {
-        this.speedForMarkAll = speedForMarkAll; //publish for metrics
-        this.targetDirtyRatio = targetDirtyRatio; //publish for metrics
+    private void publishSpeedAndRatioForMetrics(long speedForMarkAll, double targetDirtyRatio) {
+        this.speedForMarkAll = speedForMarkAll;
+        this.targetDirtyRatio = targetDirtyRatio;
     }
 
     /**
@@ -350,14 +308,14 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
      *
      * @param dirtyPagesRatio     current percent of dirty pages.
      * @param donePages           roughly, count of written and sync'ed pages
-     * @param curCpWriteSpeed     pages/second checkpoint write speed. 0 speed means 'no data'.
+     * @param avgCpWriteSpeed     pages/second checkpoint write speed. 0 speed means 'no data'.
      * @param cpTotalPages        total pages in checkpoint.
      * @return pages/second to mark to mark all clean pages as dirty till the end of checkpoint. 0 speed means 'no
      * data', or when we are not going to throttle due to the current dirty pages ratio being too high
      */
     private long calcSpeedToMarkAllSpaceTillEndOfCp(double dirtyPagesRatio, long donePages,
-                                                    long curCpWriteSpeed, int cpTotalPages) {
-        if (curCpWriteSpeed == 0)
+                                                    long avgCpWriteSpeed, int cpTotalPages) {
+        if (avgCpWriteSpeed == 0)
             return 0;
 
         if (cpTotalPages <= 0)
@@ -366,11 +324,30 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
         if (dirtyPagesRatio >= MAX_DIRTY_PAGES)
             return 0;
 
-        double remainedClearPages = (MAX_DIRTY_PAGES - dirtyPagesRatio) * totalPages;
+        // IDEA: here, when calculating the count of clean pages, it includes the pages under checkpoint. It is kinda
+        // legal because they can be written (using the Checkpoint Buffer to make a copy of the value to be
+        // checkpointed), but the CP Buffer is usually not too big, and if it gets nearly filled, writes become
+        // throttled really hard by exponential throttler. Maybe we should subtract the number of not-yet-written-by-CP
+        // pages from the count of clean pages? In such a case, we would lessen the risk of CP Buffer-caused throttling.
+        double remainedCleanPages = (MAX_DIRTY_PAGES - dirtyPagesRatio) * pageMemTotalPages();
 
-        double secondsTillCPEnd = 1.0 * (cpTotalPages - donePages) / curCpWriteSpeed;
+        double secondsTillCPEnd = 1.0 * (cpTotalPages - donePages) / avgCpWriteSpeed;
 
-        return (long) (remainedClearPages / secondsTillCPEnd);
+        return (long)(remainedCleanPages / secondsTillCPEnd);
+    }
+
+    /** Returns total number of pages storable in page memory. */
+    private long pageMemTotalPages() {
+        long currentTotalPages = pageMemTotalPages;
+
+        if (currentTotalPages == 0) {
+            currentTotalPages = pageMemory.totalPages();
+            pageMemTotalPages = currentTotalPages;
+        }
+
+        assert currentTotalPages > 0 : "PageMemory.totalPages() is still 0";
+
+        return currentTotalPages;
     }
 
     /**
@@ -456,24 +433,33 @@ class SpeedBasedMemoryConsumptionThrottlingStrategy {
      * @param baseSpeed   speed to slow down.
      * @return sleep time in nanoseconds.
      */
-    long calcDelayTime(long baseSpeed) {
-        return calcDelayTime(baseSpeed, threadIdsCount(), 1);
+    long nsPerOperation(long baseSpeed) {
+        return nsPerOperation(baseSpeed, threadIdsCount());
     }
 
     /**
-     * @param baseSpeed   speed to slow down.
+     * @param speedPagesPerSec   speed to slow down.
+     * @param nThreads    operating threads.
+     * @return sleep time in nanoseconds.
+     */
+    private long nsPerOperation(long speedPagesPerSec, int nThreads) {
+        return nsPerOperation(speedPagesPerSec, nThreads, 1);
+    }
+
+    /**
+     * @param speedPagesPerSec   speed to slow down.
      * @param nThreads    operating threads.
      * @param factor      how much it is needed to slowdown base speed. 1 means delay to get exact base speed.
      * @return sleep time in nanoseconds.
      */
-    private long calcDelayTime(long baseSpeed, int nThreads, int factor) {
+    private long nsPerOperation(long speedPagesPerSec, int nThreads, int factor) {
         if (factor <= 0)
             throw new IllegalStateException("Coefficient should be positive");
 
-        if (baseSpeed <= 0)
+        if (speedPagesPerSec <= 0)
             return 0;
 
-        long updTimeNsForOnePage = TimeUnit.SECONDS.toNanos(1) * nThreads / (baseSpeed);
+        long updTimeNsForOnePage = TimeUnit.SECONDS.toNanos(1) * nThreads / (speedPagesPerSec);
 
         return factor * updTimeNsForOnePage;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/AbstractSlowCheckpointFileIOFactory.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/AbstractSlowCheckpointFileIOFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.db;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.file.OpenOption;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+import org.apache.ignite.internal.processors.cache.persistence.file.FileIO;
+import org.apache.ignite.internal.processors.cache.persistence.file.FileIODecorator;
+import org.apache.ignite.internal.processors.cache.persistence.file.FileIOFactory;
+import org.apache.ignite.internal.processors.cache.persistence.file.RandomAccessFileIOFactory;
+
+/**
+ * File I/O that emulates poor checkpoint write speed.
+ */
+public abstract class AbstractSlowCheckpointFileIOFactory implements FileIOFactory {
+    /** Serial version uid. */
+    private static final long serialVersionUID = 0L;
+
+    /** Delegate factory. */
+    private final FileIOFactory delegateFactory = new RandomAccessFileIOFactory();
+
+    /** Slow checkpoint enabled. */
+    private final AtomicBoolean slowCheckpointEnabled;
+
+    /** Checkpoint park nanos. */
+    private final long checkpointParkNanos;
+
+    /**
+     * @param slowCheckpointEnabled Slow checkpoint enabled.
+     * @param checkpointParkNanos Checkpoint park nanos.
+     */
+    protected AbstractSlowCheckpointFileIOFactory(AtomicBoolean slowCheckpointEnabled, long checkpointParkNanos) {
+        this.slowCheckpointEnabled = slowCheckpointEnabled;
+        this.checkpointParkNanos = checkpointParkNanos;
+    }
+
+    /** {@inheritDoc} */
+    @Override public FileIO create(File file, OpenOption... openOption) throws IOException {
+        final FileIO delegate = delegateFactory.create(file, openOption);
+
+        return new FileIODecorator(delegate) {
+            @Override public int write(ByteBuffer srcBuf) throws IOException {
+                parkIfNeeded();
+
+                return delegate.write(srcBuf);
+            }
+
+            @Override public int write(ByteBuffer srcBuf, long position) throws IOException {
+                parkIfNeeded();
+
+                return delegate.write(srcBuf, position);
+            }
+
+            @Override public int write(byte[] buf, int off, int len) throws IOException {
+                parkIfNeeded();
+
+                return delegate.write(buf, off, len);
+            }
+
+            /** Parks current checkpoint thread if slow mode is enabled. */
+            private void parkIfNeeded() {
+                if (slowCheckpointEnabled.get() && shouldSlowDownCurrentThread())
+                    LockSupport.parkNanos(checkpointParkNanos);
+            }
+        };
+    }
+
+    /**
+     * Returns {@code true} if the current thread should be slowed down.
+     *
+     * @return {@code true} if the current thread should be slowed down
+     */
+    protected abstract boolean shouldSlowDownCurrentThread();
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/SlowCheckpointMetadataFileIOFactory.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/SlowCheckpointMetadataFileIOFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.db;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * File I/O that emulates poor checkpoint metadata write speed.
+ */
+public class SlowCheckpointMetadataFileIOFactory extends AbstractSlowCheckpointFileIOFactory {
+    /** Serial version uid. */
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * @param slowCheckpointEnabled Slow checkpoint enabled.
+     * @param checkpointParkNanos Checkpoint park nanos.
+     */
+    public SlowCheckpointMetadataFileIOFactory(AtomicBoolean slowCheckpointEnabled, long checkpointParkNanos) {
+        super(slowCheckpointEnabled, checkpointParkNanos);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected boolean shouldSlowDownCurrentThread() {
+        return Thread.currentThread().getName().contains("db-checkpoint-thread");
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/SlowCheckpointPagesFileIOFactory.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/SlowCheckpointPagesFileIOFactory.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.persistence.db;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * File I/O that emulates poor checkpoint pages write speed.
+ */
+public class SlowCheckpointPagesFileIOFactory extends AbstractSlowCheckpointFileIOFactory {
+    /** Serial version uid. */
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * @param slowCheckpointEnabled Slow checkpoint enabled.
+     * @param checkpointParkNanos Checkpoint park nanos.
+     */
+    public SlowCheckpointPagesFileIOFactory(AtomicBoolean slowCheckpointEnabled, long checkpointParkNanos) {
+        super(slowCheckpointEnabled, checkpointParkNanos);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected boolean shouldSlowDownCurrentThread() {
+        return Thread.currentThread().getName().contains("checkpoint-runner-");
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgniteThrottlingUnitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgniteThrottlingUnitTest.java
@@ -91,37 +91,56 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
     }
 
     /**
-     *
+     * Tests that the speed-based throttler throttles when writing faster than target speed, AND the dirty ratio
+     * is above the target ratio.
      */
     @Test
-    public void breakInCaseTooFast() {
+    public void shouldThrottleWhenWritingTooFast() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
-        long time = throttle.getCleanPagesProtectionParkTime(0.67,
+        long parkTime = throttle.getCleanPagesProtectionParkTime(0.67,
             (362584 + 67064) / 2,
             328787,
             1,
             60184,
             23103);
 
-        assertTrue(time > 0);
+        assertTrue(parkTime > 0);
     }
 
     /**
      *
      */
     @Test
-    public void noBreakIfNotFastWrite() {
+    public void shouldNotThrottleWhenWritingSlowly() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
-        long time = throttle.getCleanPagesProtectionParkTime(0.47,
+        long parkTime = throttle.getCleanPagesProtectionParkTime(0.47,
             ((362584 + 67064) / 2),
             328787,
             1,
             20103,
             23103);
 
-        assertEquals(0, time);
+        assertEquals(0, parkTime);
+    }
+
+    /**
+     * Tests that the speed-based throttler does NOT throttle when there are plenty clean pages, even if writing
+     * faster than the current checkpoint speed.
+     */
+    @Test
+    public void shouldNotThrottleWhenThereArePlentyCleanPages() {
+        PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
+
+        long parkTime = throttle.getCleanPagesProtectionParkTime(0.0,
+            (362584 + 67064) / 2,
+            328787,
+            1,
+            60184,
+            23103);
+
+        assertEquals(0, parkTime);
     }
 
     /**
@@ -134,17 +153,14 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
 
         int markDirtySpeed = 34422;
         int cpWriteSpeed = 19416;
-        long time = throttle.getCleanPagesProtectionParkTime(0.04,
+        long time = throttle.getCleanPagesProtectionParkTime(0.67,
             ((903150 + 227217) / 2),
             903150,
             1,
             markDirtySpeed,
             cpWriteSpeed);
 
-        long mdSpeed = TimeUnit.SECONDS.toNanos(1) / markDirtySpeed;
-        long cpSpeed = TimeUnit.SECONDS.toNanos(1) / cpWriteSpeed;
-
-        assertEquals((cpSpeed - mdSpeed), time);
+        assertEquals(415110, time);
     }
 
     /**
@@ -266,7 +282,7 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
      *
      */
     @Test
-    public void tooMuchPagesMarkedDirty() {
+    public void doNotThrottleWhenDirtyPagesRatioIsTooHigh() {
         PagesWriteSpeedBasedThrottle throttle = new PagesWriteSpeedBasedThrottle(pageMemory2g, null, stateChecker, log);
 
         // 363308 350004 348976 10604
@@ -276,8 +292,6 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
             4,
             279,
             23933);
-
-        System.err.println(time);
 
         assertEquals(0, time);
     }
@@ -446,8 +460,6 @@ public class IgniteThrottlingUnitTest extends GridCommonAbstractTest {
             if (warnings.get() > 0)
                 break;
         }
-
-        System.out.println(throttle.throttleWeight());
 
         assertTrue(warnings.get() > 0);
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteThrottleSandboxTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PagesWriteThrottleSandboxTest.java
@@ -18,8 +18,11 @@ package org.apache.ignite.internal.processors.cache.persistence.pagemem;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import com.google.common.util.concurrent.AtomicDouble;
 import org.apache.ignite.DataRegionMetrics;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCheckedException;
@@ -32,7 +35,10 @@ import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.configuration.WALMode;
+import org.apache.ignite.failure.FailureHandler;
+import org.apache.ignite.failure.StopNodeOrHaltFailureHandler;
 import org.apache.ignite.internal.processors.cache.persistence.GridCacheDatabaseSharedManager;
+import org.apache.ignite.internal.processors.cache.persistence.checkpoint.Checkpointer;
 import org.apache.ignite.internal.processors.metric.impl.HitRateMetric;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -54,7 +60,7 @@ public class PagesWriteThrottleSandboxTest extends GridCommonAbstractTest {
 
         DataStorageConfiguration dbCfg = new DataStorageConfiguration()
             .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
-                .setMaxSize(4000L * 1024 * 1024)
+                .setMaxSize(1000L * 1024 * 1024)
                 .setCheckpointPageBufferSize(1000L * 1000 * 1000)
                 .setName("dfltDataRegion")
                 .setMetricsEnabled(true)
@@ -131,6 +137,9 @@ public class PagesWriteThrottleSandboxTest extends GridCommonAbstractTest {
             }, 2, "read-loader");
 
             final HitRateMetric putRate = new HitRateMetric("putRate", "", 1000, 5);
+            final AtomicLong putCount = new AtomicLong();
+            final AtomicDouble maxDirtyRatio = new AtomicDouble();
+            long startNanos = System.nanoTime();
 
             GridTestUtils.runAsync(new Runnable() {
                 @Override public void run() {
@@ -141,24 +150,38 @@ public class PagesWriteThrottleSandboxTest extends GridCommonAbstractTest {
                             if (m.getName().equals("dfltDataRegion"))
                                 dirtyPages = m.getDirtyPages();
 
-                        long cpBufPages = 0;
+                        long cpBufPages;
 
                         long cpWrittenPages;
 
-                        AtomicInteger cntr = ((GridCacheDatabaseSharedManager)((ignite(0))
-                            .context().cache().context().database())).getCheckpointer().currentProgress().writtenPagesCounter();
+                        Checkpointer checkpointer = ((GridCacheDatabaseSharedManager)((ignite(0))
+                            .context().cache().context().database())).getCheckpointer();
+                        AtomicInteger cntr = checkpointer.currentProgress().writtenPagesCounter();
 
                         cpWrittenPages = cntr == null ? 0 : cntr.get();
 
                         try {
-                            cpBufPages = ((ignite(0)).context().cache().context().database()
-                                .dataRegion("dfltDataRegion").pageMemory()).checkpointBufferPagesCount();
+                            PageMemoryEx pageMemory = (PageMemoryEx)(ignite(0)).context().cache().context().database()
+                                .dataRegion("dfltDataRegion").pageMemory();
+                            cpBufPages = pageMemory.checkpointBufferPagesCount();
+
+                            if (System.nanoTime() - startNanos > TimeUnit.SECONDS.toNanos(10)) {
+                                double currentDirtyRatio = (double)dirtyPages / pageMemory.totalPages();
+                                double newMaxDirtyRatio = Math.max(maxDirtyRatio.get(), currentDirtyRatio);
+                                maxDirtyRatio.set(newMaxDirtyRatio);
+                            }
                         }
                         catch (IgniteCheckedException e) {
                             e.printStackTrace();
+                            throw new RuntimeException("Something went wrong", e);
                         }
 
-                        System.out.println("@@@ putsPerSec=," + (putRate.value()) + ", getsPerSec=," + (getRate.value()) + ", dirtyPages=," + dirtyPages + ", cpWrittenPages=," + cpWrittenPages + ", cpBufPages=," + cpBufPages);
+                        System.out.println("@@@ globalPutsPerSec="
+                            + String.format("%.2f", globalPutsPerSec(putCount, startNanos))
+                            + ", putsPerSec=" + (putRate.value()) + ", getsPerSec=" + (getRate.value()) + ", dirtyPages="
+                            + dirtyPages + ", cpWrittenPages=" + cpWrittenPages + ", cpBufPages=" + cpBufPages
+                            + ", maxDirtyRatio=" + String.format("%.2f", maxDirtyRatio.get())
+                        );
 
                         try {
                             Thread.sleep(1000);
@@ -170,14 +193,27 @@ public class PagesWriteThrottleSandboxTest extends GridCommonAbstractTest {
                 }
             }, "metrics-view");
 
+            final boolean intermittentPutsMode = false;
+
             try (IgniteDataStreamer<Object, Object> ds = ig.dataStreamer(CACHE_NAME)) {
                 ds.allowOverwrite(true);
 
-                for (int i = 0; i < keyCnt * 10; i++) {
-                    ds.addData(ThreadLocalRandom.current().nextInt(keyCnt), new TestValue(ThreadLocalRandom.current().nextInt(),
-                        ThreadLocalRandom.current().nextInt()));
+                while (true) {
+                    long tensOfSecondsPassed = TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startNanos) / 10;
+                    if (intermittentPutsMode && tensOfSecondsPassed % 2 == 1) {
+                        System.out.println("... sleeping ...");
+                        Thread.sleep(1000);
+                    }
+                    else {
+                        ds.addData(ThreadLocalRandom.current().nextInt(keyCnt), new TestValue(ThreadLocalRandom.current().nextInt(),
+                            ThreadLocalRandom.current().nextInt()));
 
-                    putRate.increment();
+                        putRate.increment();
+                        putCount.incrementAndGet();
+                    }
+
+                    if (System.nanoTime() - startNanos > TimeUnit.MINUTES.toNanos(10))
+                        break;
                 }
             }
 
@@ -186,6 +222,11 @@ public class PagesWriteThrottleSandboxTest extends GridCommonAbstractTest {
         finally {
             stopAllGrids();
         }
+    }
+
+    /***/
+    private double globalPutsPerSec(AtomicLong putCount, long startNanos) {
+        return (double)putCount.get() * TimeUnit.SECONDS.toNanos(1) / (System.nanoTime() - startNanos);
     }
 
     /**
@@ -244,5 +285,10 @@ public class PagesWriteThrottleSandboxTest extends GridCommonAbstractTest {
     private void deleteWorkFiles() throws Exception {
         cleanPersistenceDir();
         U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), "snapshot", false));
+    }
+
+    /** {@inheritDoc} */
+    @Override protected FailureHandler getFailureHandler(String igniteInstanceName) {
+        return new StopNodeOrHaltFailureHandler();
     }
 }


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35343

Speed-based throttle contained 2 algorithms (it took max of the values they were returning):

* Simpler that throttled when current marking speed was higher than average CP speed
* More complex one that first computed max acceptable marking speed (taking into account clean pages ratio and average CP speed) and then throttled if current marking speed was higher than the acceptable speed AND the current dirty ratio was higher than the acceptable dirty ratio

There was a bug that prevented the second algorithm from ever kicking in.

The first one did not take into account the clean pages that we still had, so it throttled bursts even in situations when the buffering power of the clean pages was still enough to smooth the bursts. Also, the second algorithm seems to be more general than the first one, but more adaptive.

That's why this commit removes the first algorithm and enables the second one.

(cherry-picked from commit 4b58545534a49a39b8fd60bb560d1bec4ae235fc)