### PR TITLE
GG-35349 [IGNITE-17063] .NET: Improve Java detection on Linux

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ShellTests.cs
@@ -16,38 +16,82 @@
 
 namespace Apache.Ignite.Core.Tests
 {
+    using System;
+    using System.Linq;
     using Apache.Ignite.Core.Impl;
-    using Apache.Ignite.Core.Impl.Unmanaged;
+    using Apache.Ignite.Core.Log;
+    using Apache.Ignite.Core.Tests.Client.Cache;
     using NUnit.Framework;
 
     /// <summary>
     /// Tests for <see cref="Shell"/> class.
     /// </summary>
+    [Platform("Linux")]
+    [Order(1)] // Execute first to avoid zombie processes (see https://issues.apache.org/jira/browse/IGNITE-13536).
     public class ShellTests
     {
         /// <summary>
         /// Tests <see cref="Shell.ExecuteSafe"/> method.
         /// </summary>
         [Test]
-        public void TestExecuteSafe()
+        public void TestExecuteSafeReturnsStdout()
         {
-            if (Os.IsWindows)
+            var log = GetLogger();
+
+            var uname = Shell.ExecuteSafe("uname", string.Empty, log: log);
+            Assert.AreEqual("Linux", uname.Trim(), string.Join(", ", log.Entries.Select(e => e.ToString())));
+            Assert.IsEmpty(log.Entries);
+
+            var readlink = Shell.ExecuteSafe("readlink", "-f /usr/bin/java", log: log);
+            Assert.IsNotEmpty(readlink, readlink, string.Join(", ", log.Entries.Select(e => e.ToString())));
+            Assert.IsEmpty(log.Entries);
+        }
+
+        /// <summary>
+        /// Tests that non-zero error code and stderr are logged.
+        /// </summary>
+        [Test]
+        public void TestExecuteSafeLogsNonZeroExitCodeAndStderr()
+        {
+            var log = GetLogger();
+            var res = Shell.ExecuteSafe("uname", "--badarg", log: log);
+
+            var entries = log.Entries;
+            var entriesString = string.Join(", ", entries.Select(e => e.ToString()));
+
+            Assert.IsEmpty(res, entriesString);
+            Assert.AreEqual(2, entries.Count, entriesString);
+
+            Assert.AreEqual(LogLevel.Warn, entries[0].Level);
+            StringAssert.StartsWith("Shell command 'uname' stderr: 'uname: unrecognized option", entries[0].Message);
+
+            Assert.AreEqual(LogLevel.Warn, entries[1].Level);
+            Assert.AreEqual("Shell command 'uname' exit code: 1", entries[1].Message);
+        }
+
+        /// <summary>
+        /// Tests that failure to execute a command is logged.
+        /// </summary>
+        [Test]
+        public void TestExecuteSafeLogsException()
+        {
+            var log = GetLogger();
+            var res = Shell.ExecuteSafe("foo_bar", "abc", log: log);
+            var entries = log.Entries;
+
+            Assert.IsEmpty(res);
+            Assert.AreEqual(1, entries.Count);
+
+            Assert.AreEqual(LogLevel.Warn, entries[0].Level);
+            Assert.AreEqual("Shell command 'foo_bar' failed: 'No such file or directory'", entries[0].Message);
+        }
+
+        private static ListLogger GetLogger()
+        {
+            return new ListLogger
             {
-                return;
-            }
-
-            var uname = Shell.ExecuteSafe("uname", string.Empty);
-            Assert.IsNotEmpty(uname, uname);
-
-            var readlink = Shell.ExecuteSafe("readlink", "-f /usr/bin/java");
-            Assert.IsNotEmpty(readlink, readlink);
-
-            if (Os.IsLinux)
-            {
-                Assert.AreEqual("Linux", uname.Trim());
-            }
-
-            Assert.IsEmpty(Shell.ExecuteSafe("foo_bar", "abc"));
+                EnabledLevels = Enum.GetValues(typeof(LogLevel)).Cast<LogLevel>().ToArray()
+            };
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Shell.cs
@@ -19,6 +19,8 @@ namespace Apache.Ignite.Core.Impl
     using System;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using System.Text;
+    using System.Threading;
     using Apache.Ignite.Core.Log;
 
     /// <summary>
@@ -41,13 +43,48 @@ namespace Apache.Ignite.Core.Impl
                     FileName = file,
                     Arguments = args,
                     RedirectStandardOutput = true,
+                    RedirectStandardError = true,
                     UseShellExecute = false,
                     CreateNoWindow = true
                 };
 
+                var stdOut = new StringBuilder();
+                var stdErr = new StringBuilder();
+
+                using (var stdOutEvt = new ManualResetEventSlim())
+                using (var stdErrEvt = new ManualResetEventSlim())
                 using (var process = new Process {StartInfo = processStartInfo})
                 {
+                    process.OutputDataReceived += (_, e) =>
+                    {
+                        if (e.Data == null)
+                        {
+                            // ReSharper disable once AccessToDisposedClosure
+                            stdOutEvt.Set();
+                        }
+                        else
+                        {
+                            stdOut.AppendLine(e.Data);
+                        }
+                    };
+
+                    process.ErrorDataReceived += (_, e) =>
+                    {
+                        if (e.Data == null)
+                        {
+                            // ReSharper disable once AccessToDisposedClosure
+                            stdErrEvt.Set();
+                        }
+                        else
+                        {
+                            stdErr.AppendLine(e.Data);
+                        }
+                    };
+
                     process.Start();
+
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
 
                     if (!process.WaitForExit(timeoutMs))
                     {
@@ -56,12 +93,27 @@ namespace Apache.Ignite.Core.Impl
                         process.Kill();
                     }
 
-                    return process.StandardOutput.ReadToEnd();
+                    if (!stdOutEvt.Wait(timeoutMs) || !stdErrEvt.Wait(timeoutMs))
+                    {
+                        log?.Warn("Shell command '{0}' timed out when waiting for stdout/stderr.", file);
+                    }
+
+                    if (stdErr.Length > 0)
+                    {
+                        log?.Warn("Shell command '{0}' stderr: '{1}'", file, stdErr);
+                    }
+
+                    if (process.ExitCode != 0)
+                    {
+                        log?.Warn("Shell command '{0}' exit code: {1}", file, process.ExitCode);
+                    }
+
+                    return stdOut.ToString();
                 }
             }
             catch (Exception e)
             {
-                log?.Warn("Shell command '{0}' failed: {1}", file, e.Message, e);
+                log?.Warn("Shell command '{0}' failed: '{1}'", file, e.Message, e);
 
                 return string.Empty;
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/JvmDll.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/JvmDll.cs
@@ -366,8 +366,13 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
                 yield break;
             }
 
-            var file = Shell.ExecuteSafe("readlink", "-f /usr/bin/java", log: log);
+            var file = Shell.ExecuteSafe("/usr/bin/readlink", "-f /usr/bin/java", log: log);
             // /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+            if (string.IsNullOrWhiteSpace(file))
+            {
+                file = Shell.ExecuteSafe("readlink", "-f /usr/bin/java", log: log);
+            }
 
             if (string.IsNullOrWhiteSpace(file))
             {


### PR DESCRIPTION
* Try `/usr/bin/readlink` as well as `readlink` - it is not in PATH in some rare scenarios.
* Improve logging when commands fail.