### PR TITLE
GG-35236 Log validation errors with DEBUG when processing snapshot-utility commands

### DIFF
--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -231,13 +231,6 @@
             <version>${commons.lang3.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest</artifactId>
-            <version>${hamcrest.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteFeatures.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteFeatures.java
@@ -242,9 +242,12 @@ public enum IgniteFeatures {
 
     /** Snapshot operations with ZSTD, LZ4, SNAPPY algorithms. */
     SNAPSHOT_COMPRESSION_EXTENDED_OPTION(63),
-    
+
     /** Whether the absent PK parts should be filled with defaults or not. */
-    FILLS_ABSENT_PKS_WITH_DEFAULTS(64);
+    FILLS_ABSENT_PKS_WITH_DEFAULTS(64),
+
+    /** Whether there is {@link InvalidUserCommandException} class. */
+    HAS_INVALID_USER_COMMAND_EXCEPTION(65);
 
     /**
      * Unique feature identifier.

--- a/modules/core/src/main/java/org/apache/ignite/internal/InvalidUserCommandCheckedException.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/InvalidUserCommandCheckedException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import org.apache.ignite.IgniteCheckedException;
+
+/**
+ * Thrown to indicate that the requested operation cannot be executed NOT due to some system problem (like a disk
+ * failure or internal storage state being corrupted), but because the operation logic forbids the execution.
+ * Such exceptions should not be logged by the 'system' loggers with ERROR level (or above).
+ * For example, such exception might be thrown if a user command has invalid parameters, or if it's invalid for the
+ * current system state.
+ */
+public class InvalidUserCommandCheckedException extends IgniteCheckedException {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param msg Error message.
+     */
+    public InvalidUserCommandCheckedException(String msg) {
+        super(msg);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/InvalidUserCommandException.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/InvalidUserCommandException.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import org.apache.ignite.IgniteException;
+
+/**
+ * Thrown to indicate that the requested operation cannot be executed NOT due to some system problem (like a disk
+ * failure or internal storage state being corrupted), but because the operation logic forbids the execution.
+ * Such exceptions should not be logged by the 'system' loggers with ERROR level (or above).
+ * For example, such exception might be thrown if a user command has invalid parameters, or if it's invalid for the
+ * current system state.
+ */
+public class InvalidUserCommandException extends IgniteException {
+    /** */
+    private static final long serialVersionUID = 0L;
+
+    /**
+     * Creates a new instance.
+     *
+     * @param msg Error message.
+     */
+    public InvalidUserCommandException(String msg) {
+        super(msg);
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/UserCommandExceptions.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/UserCommandExceptions.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.internal.util.typedef.X;
+import org.apache.ignite.spi.discovery.DiscoverySpi;
+
+import static org.apache.ignite.internal.IgniteFeatures.HAS_INVALID_USER_COMMAND_EXCEPTION;
+
+/**
+ * Utils to work with exceptions related to user-supplied commands.
+ */
+public class UserCommandExceptions {
+    /**
+     * Returns either {@link InvalidUserCommandException} (if every node in the cluster has this exception class) or
+     * {@link IgniteException} (otherwise) with the given message.
+     *
+     * @param message Exception message.
+     * @param discoverySpi SPI to use to determine whether the exception class is supported.
+     * @return Created exception.
+     */
+    public static IgniteException invalidUserCommandException(String message, DiscoverySpi discoverySpi) {
+        if (IgniteFeatures.allNodesSupport(null, discoverySpi, HAS_INVALID_USER_COMMAND_EXCEPTION))
+            return new InvalidUserCommandException(message);
+        else
+            return new IgniteException(message);
+    }
+
+    /**
+     * Returns either {@link InvalidUserCommandException} (if every node in the cluster has this exception class) or
+     * {@link IgniteException} (otherwise) with the given message.
+     *
+     * @param message Exception message.
+     * @param ctx     Context to use to determine whether the exception class is supported.
+     * @return Created exception.
+     */
+    public static IgniteException invalidUserCommandException(String message, GridKernalContext ctx) {
+        return invalidUserCommandException(message, ctx.config().getDiscoverySpi());
+    }
+
+    /**
+     * Returns either {@link InvalidUserCommandCheckedException} (if every node in the cluster has this exception class)
+     * or {@link IgniteCheckedException} (otherwise) with the given message.
+     *
+     * @param message Exception message.
+     * @param discoverySpi SPI to use to determine whether the exception class is supported.
+     * @return Created exception.
+     */
+    public static IgniteCheckedException invalidUserCommandCheckedException(String message, DiscoverySpi discoverySpi) {
+        if (IgniteFeatures.allNodesSupport(null, discoverySpi, HAS_INVALID_USER_COMMAND_EXCEPTION))
+            return new InvalidUserCommandCheckedException(message);
+        else
+            return new IgniteCheckedException(message);
+    }
+
+    /**
+     * Returns either {@link InvalidUserCommandCheckedException} (if every node in the cluster has this exception class)
+     * or {@link IgniteCheckedException} (otherwise) with the given message.
+     *
+     * @param message Exception message.
+     * @param ctx     Context to use to determine whether the exception class is supported.
+     * @return Created exception.
+     */
+    public static IgniteCheckedException invalidUserCommandCheckedException(String message, GridKernalContext ctx) {
+        return invalidUserCommandCheckedException(message, ctx.config().getDiscoverySpi());
+    }
+
+    /**
+     * Returns {@code true} if the given exception is caused by {@link InvalidUserCommandException} or
+     * {@link InvalidUserCommandCheckedException}.
+     *
+     * @param ex The exception to check.
+     * @return {@code true} if the given exception is an instance of {@link InvalidUserCommandException} or
+     *     {@link InvalidUserCommandCheckedException}.
+     */
+    public static boolean causedByUserCommandException(Throwable ex) {
+        return X.hasCause(ex, InvalidUserCommandException.class)
+                || X.hasCause(ex, InvalidUserCommandCheckedException.class);
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/UserCommandExceptionsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/UserCommandExceptionsTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.managers.discovery.IgniteDiscoverySpi;
+import org.apache.ignite.spi.discovery.DiscoverySpi;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link UserCommandExceptions}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class UserCommandExceptionsTest {
+    /** Config. */
+    private final IgniteConfiguration config = new IgniteConfiguration();
+
+    /** Mock SPI. */
+    @Mock
+    private IgniteDiscoverySpi discoverySpi;
+
+    /**
+     * Tests that, if all nodes support the corresponding feature,
+     * {@link UserCommandExceptions#invalidUserCommandException(String, DiscoverySpi)} creates an
+     * {@link InvalidEnvironmentException}.
+     */
+    @Test
+    public void createsInvalidUserCommandExceptionWhenFeatureIsSupported() {
+        config.setDiscoverySpi(discoverySpi);
+        when(discoverySpi.allNodesSupport(any(), any())).thenReturn(true);
+
+        Exception ex = UserCommandExceptions.invalidUserCommandException("Hello", discoverySpi);
+
+        assertThat(ex, isA(InvalidUserCommandException.class));
+        assertThat(ex.getMessage(), is("Hello"));
+    }
+
+    /**
+     * Tests that, if not all nodes support the corresponding feature,
+     * {@link UserCommandExceptions#invalidUserCommandException(String, DiscoverySpi)} creates an
+     * {@link IgniteException}.
+     */
+    @Test
+    public void createsIgniteExceptionWhenInvalidUserCommandExceptionFeatureIsNotSupported() {
+        config.setDiscoverySpi(discoverySpi);
+        when(discoverySpi.allNodesSupport(any(), any())).thenReturn(false);
+
+        Exception ex = UserCommandExceptions.invalidUserCommandException("Hello", discoverySpi);
+
+        assertThat(ex, isA(IgniteException.class));
+        assertThat(ex.getMessage(), is("Hello"));
+    }
+
+    /**
+     * Tests that, if all nodes support the corresponding feature,
+     * {@link UserCommandExceptions#invalidUserCommandException(String, DiscoverySpi)} creates an
+     * {@link InvalidEnvironmentException}.
+     */
+    @Test
+    public void createsInvalidUserCommandCheckedExceptionWhenFeatureIsSupported() {
+        config.setDiscoverySpi(discoverySpi);
+        when(discoverySpi.allNodesSupport(any(), any())).thenReturn(true);
+
+        Exception ex = UserCommandExceptions.invalidUserCommandCheckedException("Hello", discoverySpi);
+
+        assertThat(ex, isA(InvalidUserCommandCheckedException.class));
+        assertThat(ex.getMessage(), is("Hello"));
+    }
+
+    /**
+     * Tests that, if not all nodes support the corresponding feature,
+     * {@link UserCommandExceptions#invalidUserCommandCheckedException(String, DiscoverySpi)} creates an
+     * {@link IgniteCheckedException}.
+     */
+    @Test
+    public void createsIgniteExceptionWhenInvalidUserCommandCheckedExceptionFeatureIsNotSupported() {
+        config.setDiscoverySpi(discoverySpi);
+        when(discoverySpi.allNodesSupport(any(), any())).thenReturn(false);
+
+        Exception ex = UserCommandExceptions.invalidUserCommandCheckedException("Hello", discoverySpi);
+
+        assertThat(ex, isA(IgniteCheckedException.class));
+        assertThat(ex.getMessage(), is("Hello"));
+    }
+
+    /**
+     * Tests that {@link UserCommandExceptions#causedByUserCommandException(Throwable)} returns {@code true} for
+     * an instance of {@link InvalidUserCommandException}.
+     */
+    @Test
+    public void causedByUserCommandExceptionRecognizesInvalidUserCommandException() {
+        assertTrue(UserCommandExceptions.causedByUserCommandException(new InvalidUserCommandException("Oops")));
+    }
+
+    /**
+     * Tests that {@link UserCommandExceptions#causedByUserCommandException(Throwable)} returns {@code true} for
+     * an instance of {@link InvalidUserCommandCheckedException}.
+     */
+    @Test
+    public void causedByUserCommandExceptionRecognizesInvalidUserCommandCheckedException() {
+        assertTrue(UserCommandExceptions.causedByUserCommandException(new InvalidUserCommandCheckedException("Oops")));
+    }
+
+    /**
+     * Tests that {@link UserCommandExceptions#causedByUserCommandException(Throwable)} returns {@code false} for
+     * non-related exceptions.
+     */
+    @Test
+    public void causedByUserCommandExceptionReturnsFalseForUnrelatedExceptions() {
+        assertFalse(UserCommandExceptions.causedByUserCommandException(new Exception("Oops")));
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/IgniteBasicTestSuite.java
@@ -36,6 +36,7 @@ import org.apache.ignite.internal.GridStopWithCollisionSpiTest;
 import org.apache.ignite.internal.IgniteLocalNodeMapBeforeStartTest;
 import org.apache.ignite.internal.IgniteSlowClientDetectionSelfTest;
 import org.apache.ignite.internal.TransactionsMXBeanImplTest;
+import org.apache.ignite.internal.UserCommandExceptionsTest;
 import org.apache.ignite.internal.processors.affinity.GridAffinityAssignmentV2Test;
 import org.apache.ignite.internal.processors.affinity.GridAffinityAssignmentV2TestNoOptimizations;
 import org.apache.ignite.internal.processors.affinity.GridAffinityProcessorMemoryLeakTest;
@@ -147,6 +148,7 @@ import org.junit.runners.Suite;
     OdbcConfigurationValidationSelfTest.class,
     OdbcEscapeSequenceSelfTest.class,
     SqlListenerUtilsTest.class,
+    UserCommandExceptionsTest.class,
 })
 public class IgniteBasicTestSuite {
 }

--- a/modules/extdata/p2p/pom.xml
+++ b/modules/extdata/p2p/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
         </dependency>
     </dependencies>
 

--- a/modules/indexing/pom.xml
+++ b/modules/indexing/pom.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/modules/mesos/pom.xml
+++ b/modules/mesos/pom.xml
@@ -57,13 +57,6 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.gridgain</groupId>
             <artifactId>ignite-tools</artifactId>
             <version>${project.version}</version>

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -115,7 +115,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>compile</scope>
         </dependency>
 

--- a/modules/yarn/pom.xml
+++ b/modules/yarn/pom.xml
@@ -104,13 +104,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -293,6 +293,19 @@
                 <artifactId>snappy-java</artifactId>
                 <version>${snappy.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.12</version>
+                <exclusions>
+                    <!-- We use hamcrest 2.x, so we don't need a conflicting hamcrest 1.x coming with junit 4 -->
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -300,7 +313,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35236

Some exceptions are thrown to indicate that something is wrong with a user command, but they do not indicate that the system is in trouble. Such exceptions should not be logged with high levels in the core system. To distinguish them from other exceptions, we add special exception types.