### PR TITLE
GG-35445 [IGNITE-17217] Java thin: reload addresses from ClientAddressFinder on connection loss

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
@@ -504,8 +504,19 @@ final class ReliableChannel implements AutoCloseable {
         rollCurrentChannel(hld);
 
         // For partiton awareness it's already initializing asynchronously in #onTopologyChanged.
-        if (scheduledChannelsReinit.get() && !affinityAwarenessEnabled)
+        if (addressFinderAddressesChanged() || (scheduledChannelsReinit.get() && !affinityAwarenessEnabled))
             channelsInit();
+    }
+
+    /**
+     * Checks whether addressFinder returns a different set of addresses.
+     */
+    private boolean addressFinderAddressesChanged() {
+        if (clientCfg.getAddressesFinder() == null)
+            return false;
+
+        String[] hostAddrs = clientCfg.getAddressesFinder().getAddresses();
+        return !Arrays.equals(hostAddrs, prevHostAddrs);
     }
 
     /**

--- a/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestClusterClientConnection.java
+++ b/modules/kubernetes/src/test/java/org/apache/ignite/kubernetes/discovery/TestClusterClientConnection.java
@@ -21,11 +21,13 @@ import org.apache.ignite.client.ClientCache;
 import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.client.ThinClientKubernetesAddressFinder;
 import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.configuration.ClientConnectorConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.junit.Test;
 
 /** Test that thin client connects to cluster with {@link ThinClientKubernetesAddressFinder}. */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class TestClusterClientConnection extends KubernetesDiscoveryAbstractTest {
     /** */
     @Test
@@ -47,5 +49,50 @@ public class TestClusterClientConnection extends KubernetesDiscoveryAbstractTest
         ClientCache cache = client.createCache("cache");
         cache.put(1, 2);
         assertEquals(2, cache.get(1));
+    }
+
+    /**
+     * Tests that client updates addresses from address finder and can connect to the cluster after pod restart.
+     */
+    @Test
+    public void testClientReConnectsToClusterAfterPodIpChange() throws Exception {
+        mockServerResponse();
+
+        IgniteConfiguration cfg = getConfiguration(getTestIgniteInstanceName(), false);
+
+        IgniteEx crd = startGrid(cfg);
+        String crdAddr = crd.localNode().addresses().iterator().next();
+
+        mockServerResponse(crdAddr);
+
+        ClientConfiguration ccfg = new ClientConfiguration();
+        ccfg.setAddressesFinder(new ThinClientKubernetesAddressFinder(prepareConfiguration()));
+        IgniteClient client = Ignition.startClient(ccfg);
+
+        ClientCache cache = client.createCache("cache");
+        cache.put(1, 2);
+        assertEquals(2, cache.get(1));
+
+        // Stop node and change port => still can connect.
+        Ignition.stop(crd.name(), true);
+        int newPort = 10801;
+        ccfg.setAddressesFinder(new ThinClientKubernetesAddressFinder(prepareConfiguration(), newPort));
+        mockServerResponse(5, crdAddr);
+
+        cfg = getConfiguration(getTestIgniteInstanceName(), false);
+        cfg.setClientConnectorConfiguration(new ClientConnectorConfiguration().setPort(newPort));
+        startGrid(cfg);
+
+        try {
+            cache = client.getOrCreateCache("cache");
+            cache.put(1, 3);
+        }
+        catch (Exception ignored) {
+            // No-op.
+        }
+
+        cache = client.getOrCreateCache("cache");
+        cache.put(1, 3);
+        assertEquals(3, cache.get(1));
     }
 }


### PR DESCRIPTION
Server address can change after restart (applies to Kubernetes, among other things). Refresh addresses from AddressFinder on connection loss.