### PR TITLE
GG-35454 [IGNITE-17247] Fix race condition on close in GridNioClientConnectionMultiplexer

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -22,6 +22,8 @@ import java.nio.ByteOrder;
 import java.nio.channels.SocketChannel;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.net.ssl.SSLContext;
 
 import org.apache.ignite.IgniteCheckedException;
@@ -58,6 +60,9 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
 
     /** */
     private final SSLContext sslCtx;
+
+    /** */
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
 
     /**
      * Constructor.
@@ -106,12 +111,26 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
 
     /** {@inheritDoc} */
     @Override public void start() {
-        srv.start();
+        rwLock.writeLock().lock();
+
+        try {
+            srv.start();
+        }
+        finally {
+            rwLock.writeLock().unlock();
+        }
     }
 
     /** {@inheritDoc} */
-    @Override public void stop() {
-        srv.stop();
+    @Override public synchronized void stop() {
+        rwLock.writeLock().lock();
+
+        try {
+            srv.stop();
+        }
+        finally {
+            rwLock.writeLock().unlock();
+        }
     }
 
     /** {@inheritDoc} */
@@ -119,6 +138,8 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
                                            ClientMessageHandler msgHnd,
                                            ClientConnectionStateHandler stateHnd)
             throws ClientConnectionException {
+        rwLock.readLock().lock();
+
         try {
             SocketChannel ch = SocketChannel.open();
             ch.socket().connect(new InetSocketAddress(addr.getHostName(), addr.getPort()), Integer.MAX_VALUE);
@@ -141,6 +162,9 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
         }
         catch (Exception e) {
             throw new ClientConnectionException(e.getMessage(), e);
+        }
+        finally {
+            rwLock.readLock().unlock();
         }
     }
 }


### PR DESCRIPTION
When `GridNioServer.createSession` is called concurrently with `GridNioServer.stop`, it is possible that `GridNioFuture` returned by `createSession` will never complete. Add RW lock in `GridNioClientConnectionMultiplexer` to fix this.