### PR TITLE
GG-35484 [IGNITE-17274] Improve service name lookup performance

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/service/IgniteServiceProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/service/IgniteServiceProcessor.java
@@ -135,6 +135,12 @@ public class IgniteServiceProcessor extends ServiceProcessorAdapter implements I
     private final ConcurrentMap<IgniteUuid, ServiceInfo> registeredServices = new ConcurrentHashMap<>();
 
     /**
+     * Map of registered services, kept in-sync with registeredServices above, and keyed by name to improve performance
+     * for lookups.
+     */
+    private final ConcurrentMap<String, ServiceInfo> registeredServicesByName = new ConcurrentHashMap<>();
+
+    /**
      * Collection of services information that were processed by deployment worker. <b>It is updated from deployment
      * worker</b>.
      * <p/>
@@ -279,6 +285,7 @@ public class IgniteServiceProcessor extends ServiceProcessorAdapter implements I
         cancelDeployedServices();
 
         registeredServices.clear();
+        registeredServicesByName.clear();
 
         // If user requests sent to network but not received back to handle in deployment manager.
         Stream.concat(depFuts.values().stream(), undepFuts.values().stream()).forEach(fut -> {
@@ -1659,6 +1666,7 @@ public class IgniteServiceProcessor extends ServiceProcessorAdapter implements I
             }
             else if (req instanceof ServiceUndeploymentRequest) {
                 ServiceInfo rmv = registeredServices.remove(reqSrvcId);
+                registeredServicesByName.remove(oldDesc.name());
 
                 assert oldDesc == rmv : "Concurrent map modification.";
 
@@ -1686,6 +1694,7 @@ public class IgniteServiceProcessor extends ServiceProcessorAdapter implements I
         desc.context(ctx);
 
         registeredServices.put(desc.serviceId(), desc);
+        registeredServicesByName.put(desc.name(), desc);
     }
 
     /**
@@ -1733,6 +1742,9 @@ public class IgniteServiceProcessor extends ServiceProcessorAdapter implements I
             depActions.servicesToUndeploy(toUndeploy);
 
             msg.servicesDeploymentActions(depActions);
+
+            // Remove the names from the service-by-name map as well
+            toUndeploy.values().forEach((desc) -> registeredServicesByName.remove(desc.name()));
         }
     }
 
@@ -1785,12 +1797,7 @@ public class IgniteServiceProcessor extends ServiceProcessorAdapter implements I
      * @return Mapped service descriptor. Possibly {@code null} if not found.
      */
     @Nullable private ServiceInfo lookupInRegisteredServices(String name) {
-        for (ServiceInfo desc : registeredServices.values()) {
-            if (desc.name().equals(name))
-                return desc;
-        }
-
-        return null;
+        return registeredServicesByName.get(name);
     }
 
     /**


### PR DESCRIPTION
Adds a Map of services by service-name in addition to the Map by service-id, and use this map for lookups instead of a linear search of the map by service-name.

This significantly reduces the startup timing of services and changes the growth in timing from exponential to linear.

Co-authored-by: Arthur Naseef <art@artnaseef.com>