### PR TITLE
GG-35168 Thin: Fix server-side message parsing for big messages

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientMessage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientMessage.java
@@ -167,7 +167,7 @@ public class ClientMessage implements Message, Externalizable {
             if (missing > 0) {
                 int len = Math.min(missing, remaining);
 
-                if (isFirstMessage) {
+                if (isFirstMessage && data == null) {
                     // Sanity check: first 3 bytes in handshake are always 1 1 0 (handshake = 1, major version = 1).
                     // Do not allocate the buffer before validating the header to protect us from garbage data sent by unrelated application
                     // connecting on our port by accident.

--- a/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ConnectionTest.java
@@ -89,6 +89,15 @@ public class ConnectionTest {
 
     /** */
     @Test
+    public void testValidBigHandshakeMessage() throws Exception {
+        char[] data = new char[1024 * 65];
+        String userName = new String(data);
+
+        testConnectionWithUsername(userName, Config.SERVER);
+    }
+
+    /** */
+    @Test
     public void testHandshakeTooLargeServerDropsConnection() throws Exception {
         try (LocalIgniteCluster ignored = LocalIgniteCluster.start(1, IPv4_HOST)) {
             Socket clientSocket = new Socket(IPv4_HOST, 10800);


### PR DESCRIPTION
When the first message is bigger than socket buffer size (64KB in case of Java thin client) a handshake request is split in several parts which causes error during sanity check.