### PR TITLE
GG-35422 Java thin: Fix hang on deprecated SSL protocols

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/ClientSslParametersTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/ClientSslParametersTest.java
@@ -268,7 +268,7 @@ public class ClientSslParametersTest extends GridCommonAbstractTest {
         checkSuccessfulClientStart(
             null,
             new String[] {
-                "TLSv1.1",
+                "TLSv1.2",
                 "SSLv3"
             }
         );

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -153,10 +153,12 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
                 meta.put(GridNioSslFilter.HANDSHAKE_FUT_META_KEY, sslHandshakeFut);
             }
 
-            GridNioSession ses = srv.createSession(ch, meta, false, null).get();
+            GridNioFuture<GridNioSession> sesFut = srv.createSession(ch, meta, false, null);
 
             if (sslHandshakeFut != null)
                 sslHandshakeFut.get();
+
+            GridNioSession ses = sesFut.get();
 
             return new GridNioClientConnection(ses, msgHnd, stateHnd);
         }

--- a/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
@@ -27,6 +27,7 @@ import org.apache.ignite.ssl.SslContextFactory;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -223,6 +224,29 @@ public class SslParametersTest extends GridCommonAbstractTest {
      * @throws Exception If failed.
      */
     @Test
+    @Ignore("Outdated machines do not consider TLS 1.1 deprecated.")
+    public void testDeprecatedProtocolThrows() throws Exception {
+        protocols = new String[] {
+            "TLSv1.1",
+            "TLSv1.2"
+        };
+
+        startGrid();
+
+        checkClientStartFailure(
+            null,
+            new String[] {
+                "TLSv1.1",
+            },
+            ClientConnectionException.class,
+            "SSL handshake failed (connection closed)"
+        );
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
     public void testSameProtocols() throws Exception {
         protocols = new String[] {
             "TLSv1.1",
@@ -233,7 +257,8 @@ public class SslParametersTest extends GridCommonAbstractTest {
 
         checkSuccessfulClientStart(null,
             new String[] {
-                "TLSv1.1"
+                "TLSv1.1",
+                "TLSv1.2"
             }
         );
     }

--- a/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.client;
 
 import java.util.concurrent.Callable;
+import javax.net.ssl.SSLHandshakeException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.ClientConfiguration;
@@ -238,8 +239,8 @@ public class SslParametersTest extends GridCommonAbstractTest {
             new String[] {
                 "TLSv1.1",
             },
-            ClientConnectionException.class,
-            "SSL handshake failed (connection closed)"
+            SSLHandshakeException.class,
+            "No appropriate protocol (protocol is disabled or cipher suites are inappropriate)"
         );
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
@@ -254,7 +254,7 @@ public class SslParametersTest extends GridCommonAbstractTest {
 
         checkSuccessfulClientStart(null,
             new String[] {
-                "TLSv1.1",
+                "TLSv1.2",
                 "SSLv3"
             }
         );

--- a/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
@@ -233,8 +233,7 @@ public class SslParametersTest extends GridCommonAbstractTest {
 
         checkSuccessfulClientStart(null,
             new String[] {
-                "TLSv1.1",
-                "TLSv1.2"
+                "TLSv1.1"
             }
         );
     }


### PR DESCRIPTION
TLSv1.1 is deprecated. It causes an exception in `GridNioSslFilter.onSessionOpened`. However, `GridNioClientConnectionMultiplexer` waits on `sesFut` first, which never completes in this case.

* Fix `GridNioClientConnectionMultiplexer` to wait on `sslHandshakeFut` first and fail on SSL exceptions instead of hanging.
* Fix `GridNioSslFilter` to propagate exception details correctly.
* Fix tests to use TLSv1.2 where needed.