### PR TITLE
GG-35724 [IGNITE-17710] .NET: Fix CancellationTest.TestTask

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/CancellationTest.cs
@@ -42,8 +42,23 @@ namespace Apache.Ignite.Core.Tests.Compute
         public void TestTask()
         {
             TestTask((c, t) => c.ExecuteAsync(new Task(), t));
+        }
+
+        [Test]
+        public void TestTaskWithArg()
+        {
             TestTask((c, t) => c.ExecuteAsync(new Task(), 1, t));
+        }
+
+        [Test]
+        public void TestTaskByType()
+        {
             TestTask((c, t) => c.ExecuteAsync<int, IList<IComputeJobResult<int>>>(typeof(Task), t));
+        }
+
+        [Test]
+        public void TestTaskByTypeWithArg()
+        {
             TestTask((c, t) => c.ExecuteAsync<object, int, IList<IComputeJobResult<int>>>(typeof(Task), 1, t));
         }
 
@@ -92,11 +107,25 @@ namespace Apache.Ignite.Core.Tests.Compute
 
         private void TestTask(Func<ICompute, CancellationToken, System.Threading.Tasks.Task> runner)
         {
-            Job.CancelCount = 0;
+            Job.Cancelled = false;
+            Job.StartEvent.Reset();
+            Job.CancelEvent.Reset();
 
-            TestClosure(runner, MillisecondsTimeout * 2);
+            using (var cts = new CancellationTokenSource())
+            {
+                var task = runner(Compute, cts.Token);
+                Assert.IsFalse(task.IsCanceled);
 
-            Assert.IsTrue(TestUtils.WaitForCondition(() => Job.CancelCount > 0, 5000));
+                Job.StartEvent.Wait();
+
+                cts.Cancel();
+                TestUtils.WaitForTrueCondition(() => task.IsCanceled);
+
+                // Pass cancelled token
+                Assert.IsTrue(runner(Compute, cts.Token).IsCanceled);
+            }
+
+            Assert.IsTrue(TestUtils.WaitForCondition(() => Job.Cancelled, 5000));
         }
 
         private void TestClosure(Func<ICompute, CancellationToken, System.Threading.Tasks.Task> runner, int delay = 0)
@@ -122,9 +151,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             public IDictionary<IComputeJob<int>, IClusterNode> Map(IList<IClusterNode> subgrid, object arg)
             {
-                return Enumerable.Range(1, 100)
-                    .SelectMany(x => subgrid)
-                    .ToDictionary(x => (IComputeJob<int>)new Job(), x => x);
+                return subgrid.Where(x => !x.IsLocal).Take(1).ToDictionary(x => (IComputeJob<int>)new Job(), x => x);
             }
 
             public ComputeJobResultPolicy OnResult(IComputeJobResult<int> res, IList<IComputeJobResult<int>> rcvd)
@@ -142,23 +169,24 @@ namespace Apache.Ignite.Core.Tests.Compute
         [Serializable]
         private class Job : IComputeJob<int>
         {
-            private static int _cancelCount;
+            public static readonly ManualResetEventSlim StartEvent = new ManualResetEventSlim(false);
 
-            public static int CancelCount
-            {
-                get { return Thread.VolatileRead(ref _cancelCount); }
-                set { Thread.VolatileWrite(ref _cancelCount, value); }
-            }
+            public static readonly ManualResetEventSlim CancelEvent = new ManualResetEventSlim(false);
+
+            public static volatile bool Cancelled;
 
             public int Execute()
             {
-                Thread.Sleep(MillisecondsTimeout);
+                StartEvent.Set();
+                CancelEvent.Wait();
+
                 return 1;
             }
 
             public void Cancel()
             {
-                Interlocked.Increment(ref _cancelCount);
+                CancelEvent.Set();
+                Cancelled = true;
             }
         }
 


### PR DESCRIPTION
Use synchronization primitives instead of relying on `Thread.Sleep`.