### PR TITLE
GG-35573 Fix NodeSslConnectionMetricTest

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -73,7 +73,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
     private static final String UNSUPPORTED_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_GCM_SHA256";
 
     /** Metric timeout. */
-    private static final long TIMEOUT = 3_000;
+    private static final long TIMEOUT = 7_000;
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -227,6 +227,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         // Tests untrusted certificate.
         checkNodeJoinFails(2, true, "thinClient", "trusttwo", CIPHER_SUITE, "TLSv1.2");
         checkNodeJoinFails(2, false, "thinClient", "trusttwo", CIPHER_SUITE, "TLSv1.2");
+
         // Tests untrusted cipher suites.
         checkNodeJoinFails(2, true, "client", "trustone", UNSUPPORTED_CIPHER_SUITE, "TLSv1.2");
         checkNodeJoinFails(2, false, "node01", "trustone", UNSUPPORTED_CIPHER_SUITE, "TLSv1.2");
@@ -236,7 +237,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         checkNodeJoinFails(2, false, "node01", "trustone", null, "TLSv1.1");
 
         // In case of an SSL error, the client and server nodes make 2 additional connection attempts.
-        waitForMetric("RejectedSslConnectionsCount", 13,
+        waitForMetric("RejectedSslConnectionsCount", 12,
                 () -> reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value());
     }
 

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -209,7 +209,8 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
             // GridClient makes 2 additional  silent connection attempts if an SSL error occurs.
         }
 
-        checkSslCommunicationMetrics(reg, 10, 0, 9);
+        // Not rejected by server, but by client, so rejectedSesCnt is the same.
+        checkSslCommunicationMetrics(reg, 10, 0, 6);
     }
 
     /** Tests SSL discovery metrics produced by node connection. */

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -430,7 +430,6 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         waitForMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME, handshakeCnt, () -> (int) Arrays.stream(
                 mreg.<HistogramMetric>findMetric(SSL_HANDSHAKE_DURATION_HISTOGRAM_METRIC_NAME).value()).sum());
 
-
         waitForMetric(SSL_REJECTED_SESSIONS_CNT_METRIC_NAME, rejectedSesCnt,
                 () -> mreg.<IntMetric>findMetric(SSL_REJECTED_SESSIONS_CNT_METRIC_NAME).value());
     }

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -73,7 +73,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
     private static final String UNSUPPORTED_CIPHER_SUITE = "TLS_RSA_WITH_AES_128_GCM_SHA256";
 
     /** Metric timeout. */
-    private static final long TIMEOUT = 5_000;
+    private static final long TIMEOUT = 3_000;
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -165,7 +165,8 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
             getConnection(jdbcConfiguration("thinClient", "trusttwo", null, "TLSv1.1")),
             SQLException.class);
 
-        checkSslCommunicationMetrics(reg, 4, 0, 3);
+        // Not rejected by server, but by client, so rejectedSesCnt is the same.
+        checkSslCommunicationMetrics(reg, 4, 0, 2);
     }
 
     /** Tests SSL metrics produced by REST TCP client connection. */
@@ -235,9 +236,8 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         checkNodeJoinFails(2, false, "node01", "trustone", null, "TLSv1.1");
 
         // In case of an SSL error, the client and server nodes make 2 additional connection attempts.
-        assertTrue(waitForCondition(() ->
-            18 == reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value(),
-            TIMEOUT));
+        waitForMetric("RejectedSslConnectionsCount", 13,
+                () -> reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value());
     }
 
     /** Tests SSL communication metrics produced by node connection. */
@@ -315,7 +315,8 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
             ClientConnectionException.class
         );
 
-        checkSslCommunicationMetrics(reg, 4, 0, 3);
+        // Not rejected by server, but by client, so rejectedSesCnt is the same.
+        checkSslCommunicationMetrics(reg, 4, 0, 2);
     }
 
     /** Starts node that imitates a cluster server node to which connections will be performed. */

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -165,8 +165,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
             getConnection(jdbcConfiguration("thinClient", "trusttwo", null, "TLSv1.1")),
             SQLException.class);
 
-        // Not rejected by server, but by client, so rejectedSesCnt is the same.
-        checkSslCommunicationMetrics(reg, 4, 0, 2);
+        checkSslCommunicationMetrics(reg, 4, 0, 3);
     }
 
     /** Tests SSL metrics produced by REST TCP client connection. */
@@ -210,8 +209,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
             // GridClient makes 2 additional  silent connection attempts if an SSL error occurs.
         }
 
-        // Not rejected by server, but by client, so rejectedSesCnt is the same.
-        checkSslCommunicationMetrics(reg, 10, 0, 6);
+        checkSslCommunicationMetrics(reg, 10, 0, 9);
     }
 
     /** Tests SSL discovery metrics produced by node connection. */
@@ -316,8 +314,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
             ClientConnectionException.class
         );
 
-        // Not rejected by server, but by client, so rejectedSesCnt is the same.
-        checkSslCommunicationMetrics(reg, 4, 0, 2);
+        checkSslCommunicationMetrics(reg, 4, 0, 3);
     }
 
     /** Starts node that imitates a cluster server node to which connections will be performed. */

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -235,7 +235,7 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         checkNodeJoinFails(2, false, "node01", "trustone", null, "TLSv1.1");
 
         // In case of an SSL error, the client and server nodes make 2 additional connection attempts.
-        waitForMetric("RejectedSslConnectionsCount", 12,
+        waitForMetricGreaterOrEqual("RejectedSslConnectionsCount", 12,
                 () -> reg.<IntMetric>findMetric("RejectedSslConnectionsCount").value());
     }
 
@@ -439,6 +439,13 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         assertTrue(
             "Metric " + name + " expected " + expected + " but was " + supplier.get(),
                 waitForCondition(() -> expected == supplier.get(), TIMEOUT));
+    }
+
+    /** Wait for metric value. */
+    private void waitForMetricGreaterOrEqual(String name, int expected, Supplier<Integer> supplier) throws Exception {
+        assertTrue(
+            "Metric " + name + " expected greater or equal than " + expected + " but was " + supplier.get(),
+                waitForCondition(() -> expected <= supplier.get(), TIMEOUT));
     }
 
     /** Creates {@link SslContextFactory} with specified options. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientNioTcpConnection.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientNioTcpConnection.java
@@ -244,10 +244,12 @@ public class GridClientNioTcpConnection extends GridClientConnection {
                 meta.put(GridNioSslFilter.HANDSHAKE_FUT_META_KEY, sslHandshakeFut);
             }
 
-            ses = (GridNioSession)srv.createSession(ch, meta, false, null).get();
+            GridNioFuture<GridNioSession> sesFut = srv.createSession(ch, meta, false, null);
 
             if (sslHandshakeFut != null)
                 sslHandshakeFut.get();
+
+            ses = sesFut.get();
 
             GridClientHandshakeRequest req = new GridClientHandshakeRequest();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/ssl/GridNioSslFilter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/ssl/GridNioSslFilter.java
@@ -204,9 +204,6 @@ public class GridNioSslFilter extends GridNioFilterAdapter {
             onSessionOpenedException = e;
             U.error(log, "Failed to start SSL handshake (will close inbound connection): " + ses, e);
 
-            if (rejectedSesCnt != null)
-                rejectedSesCnt.increment();
-
             ses.close();
         }
     }
@@ -216,8 +213,12 @@ public class GridNioSslFilter extends GridNioFilterAdapter {
         try {
             GridNioFutureImpl<?> fut = ses.removeMeta(HANDSHAKE_FUT_META_KEY);
 
-            if (fut != null)
+            if (fut != null) {
+                if (rejectedSesCnt != null)
+                    rejectedSesCnt.increment();
+
                 fut.onDone(new IgniteCheckedException("SSL handshake failed (connection closed).", onSessionOpenedException));
+            }
 
             if (ses.meta(SSL_META.ordinal()) == null)
                 return;
@@ -354,9 +355,6 @@ public class GridNioSslFilter extends GridNioFilterAdapter {
             }
         }
         catch (SSLException e) {
-            if (rejectedSesCnt != null)
-                rejectedSesCnt.increment();
-
             throw new GridNioException("Failed to decode SSL data: " + ses, e);
         }
         finally {


### PR DESCRIPTION
* Fix `GridClientNioTcpConnection` hang on invalid SSL protocol (same fix as GG-35422 Java thin: Fix hang on deprecated SSL protocols).
* Fix `rejectedSesCnt` in `GridNioSslFilter`.
* Improve assertions to show expected and actual.