### PR TITLE
GG-35774 CacheExchangeMergeTest.testConcurrentStartServers sometimes hangs forever

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheExchangeMergeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheExchangeMergeTest.java
@@ -201,7 +201,7 @@ public class CacheExchangeMergeTest extends GridCommonAbstractTest {
     @Override protected void afterTest() throws Exception {
         listeningLog.clearListeners();
 
-        stopAllGrids();
+        stopAllGridsNoWait();
 
         super.afterTest();
     }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/junits/GridAbstractTest.java
@@ -1615,6 +1615,15 @@ public abstract class GridAbstractTest extends JUnitAssertAware {
     }
 
     /**
+     * Stops all grids (even those grids that have not been started successfully are tried to be stopped).
+     * This differs from {@link #stopAllGrids()} in one aspect: {@code stopAllGrids()} waits for all grids
+     * to be started, and, if any of them hangs during startup, it hangs as well.
+     */
+    protected void stopAllGridsNoWait() {
+        stopAllGrids(true, false);
+    }
+
+    /**
      * @param cancel Cancel flag.
      */
     protected void stopAllClients(boolean cancel) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35774

The problem is that, if a grid fails to start (for instance, due to PME), then the test times out, then afterTest() is called which calls stopAllGrids(), which, in turn, waits for all grids to be started, so it hangs as well, this time forever (as the timeout is not applied to afterTest()).

We try to solve the problem by using the variation of stopAllGrids() that does not wait for the grids to start and tries to stop them regargless of their state.