### PR TITLE
GG-35810 .NET: Fix PartitionLossTest flakiness

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformWaitForRebalanceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformWaitForRebalanceTask.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobAdapter;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeTaskAdapter;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.IgniteInterruptedCheckedException;
+import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
+import org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtPartitionTopology;
+import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.util.typedef.internal.CU;
+import org.apache.ignite.resources.IgniteInstanceResource;
+import org.apache.ignite.testframework.GridTestUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Task that waits for rebalance to complete.
+ */
+public class PlatformWaitForRebalanceTask extends ComputeTaskAdapter<Object[], Boolean> {
+    /** {@inheritDoc} */
+    @NotNull
+    @Override public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid, Object[] args)
+            throws IgniteException {
+        return Collections.singletonMap(new Job(args), F.first(subgrid));
+    }
+
+    /** {@inheritDoc} */
+    @Nullable @Override public Boolean reduce(List<ComputeJobResult> results) throws IgniteException {
+        return results.get(0).getData();
+    }
+
+    /**
+     * Job.
+     */
+    private static class Job extends ComputeJobAdapter {
+        /** Expected version. */
+        private final AffinityTopologyVersion topVer;
+
+        private final String cacheName;
+
+        private final long timeout;
+
+        /** Ignite. */
+        @IgniteInstanceResource
+        private Ignite ignite;
+
+        /**
+         * Ctor.
+         *
+         * @param args Args.
+         */
+        private Job(Object[] args) {
+            topVer = (AffinityTopologyVersion) args[0];
+            cacheName = (String) args[1];
+            timeout = (Long) args[2];
+        }
+
+        /** {@inheritDoc} */
+        @Override public Boolean execute() throws IgniteException {
+            final GridDhtPartitionTopology top =
+                    ((IgniteEx) ignite).context().cache().context().cacheContext(CU.cacheId(cacheName)).topology();
+
+            try {
+                return GridTestUtils.waitForCondition(() -> top.rebalanceFinished(topVer), timeout);
+            } catch (IgniteInterruptedCheckedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformWaitForRebalanceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformWaitForRebalanceTask.java
@@ -75,9 +75,9 @@ public class PlatformWaitForRebalanceTask extends ComputeTaskAdapter<Object[], B
          * @param args Args.
          */
         private Job(Object[] args) {
-            topVer = (AffinityTopologyVersion) args[0];
-            cacheName = (String) args[1];
-            timeout = (Long) args[2];
+            cacheName = (String) args[0];
+            topVer = new AffinityTopologyVersion((Long) args[1], (Integer) args[2]);
+            timeout = (Long) args[3];
         }
 
         /** {@inheritDoc} */
@@ -86,7 +86,13 @@ public class PlatformWaitForRebalanceTask extends ComputeTaskAdapter<Object[], B
                     ((IgniteEx) ignite).context().cache().context().cacheContext(CU.cacheId(cacheName)).topology();
 
             try {
-                return GridTestUtils.waitForCondition(() -> top.rebalanceFinished(topVer), timeout);
+
+                return GridTestUtils.waitForCondition(() -> {
+                    System.out.println("PlatformWaitForRebalanceTask.Job: Waiting for rebalance to complete [expectedTopVer="
+                            + topVer + ", readyTopVer=" + top.readyTopologyVersion() + ']');
+
+                    return top.rebalanceFinished(topVer);
+                }, timeout);
             } catch (IgniteInterruptedCheckedException e) {
                 throw new RuntimeException(e);
             }

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformWaitForRebalanceTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformWaitForRebalanceTask.java
@@ -88,7 +88,7 @@ public class PlatformWaitForRebalanceTask extends ComputeTaskAdapter<Object[], B
             try {
 
                 return GridTestUtils.waitForCondition(() -> {
-                    System.out.println("PlatformWaitForRebalanceTask.Job: Waiting for rebalance to complete [expectedTopVer="
+                    ignite.log().info("PlatformWaitForRebalanceTask.Job: Waiting for rebalance to complete [expectedTopVer="
                             + topVer + ", readyTopVer=" + top.readyTopologyVersion() + ']');
 
                     return top.rebalanceFinished(topVer);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -126,7 +126,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 Console.WriteLine("Cache size in WaitForTrueCondition: " + cache.GetSize());
 
                 return cache.GetLostPartitions().Any();
-            }, 45000);
+            }, 245000);
             var lostParts = cache.GetLostPartitions();
             Assert.IsTrue(lostParts.Contains(lostPart));
 
@@ -144,13 +144,6 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Reset and verify.
             ignite.ResetLostPartitions(CacheName);
-            Assert.IsEmpty(cache.GetLostPartitions());
-
-            // Check another ResetLostPartitions overload.
-            PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 45000);
-            Assert.IsNotEmpty(cache.GetLostPartitions());
-            ignite.ResetLostPartitions(new List<string> {CacheName, "foo"});
             Assert.IsEmpty(cache.GetLostPartitions());
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -21,6 +21,7 @@ namespace Apache.Ignite.Core.Tests.Cache
     using System.Linq;
     using System.Threading;
     using Apache.Ignite.Core.Cache;
+    using Apache.Ignite.Core.Cache.Affinity;
     using Apache.Ignite.Core.Cache.Affinity.Rendezvous;
     using Apache.Ignite.Core.Cache.Configuration;
     using NUnit.Framework;
@@ -34,6 +35,9 @@ namespace Apache.Ignite.Core.Tests.Cache
     {
         /** */
         private const string CacheName = "lossTestCache";
+
+        /** */
+        public const string WaitForRebalanceTask = "org.apache.ignite.platform.PlatformWaitForRebalanceTask";
 
         /// <summary>
         /// Fixture set up.
@@ -249,7 +253,9 @@ namespace Apache.Ignite.Core.Tests.Cache
             Console.WriteLine("]]] Cache size before one node stop: " + cache.GetSize());
 
             // TODO: This delay works. Which means we don't wait for rebalance properly. See how Java does it.
-            Thread.Sleep(10000);
+            // Thread.Sleep(10000);
+            ignite.GetCompute().ExecuteJavaTask<bool>(WaitForRebalanceTask,
+                new object[] { CacheName, 2L, 1, 9000L });
 
             Console.WriteLine("]]] Cache size before one node stop 2: " + cache.GetSize());
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -121,6 +121,12 @@ namespace Apache.Ignite.Core.Tests.Cache
             var lostPart = PrepareTopology();
             Console.WriteLine("Cache size after PrepareTopology: " + cache.GetSize());
 
+            // TODO: How does the following happen? Not all partitions are moved?
+            // ]]] Cache size before one node stop: 32
+            // Cache size after PrepareTopology: 13
+            // Cache size in WaitForTrueCondition: 13
+            // Cache size in WaitForTrueCondition: 32
+            // Cache size in WaitForTrueCondition: 32
             TestUtils.WaitForTrueCondition(() =>
             {
                 Console.WriteLine("Cache size in WaitForTrueCondition: " + cache.GetSize());

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -126,7 +126,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 Console.WriteLine("Cache size in WaitForTrueCondition: " + cache.GetSize());
 
                 return cache.GetLostPartitions().Any();
-            }, 245000);
+            }, 45000);
             var lostParts = cache.GetLostPartitions();
             Assert.IsTrue(lostParts.Contains(lostPart));
 
@@ -241,6 +241,10 @@ namespace Apache.Ignite.Core.Tests.Cache
             var res = cache.GetLocalEntries(CachePeekMode.Primary).Select(x => x.Key).First();
 
             Console.WriteLine("]]] Cache size before one node stop: " + cache.GetSize());
+
+            Thread.Sleep(10000);
+
+            Console.WriteLine("]]] Cache size before one node stop 2: " + cache.GetSize());
 
             Ignition.Stop(ignite.Name, true);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -248,6 +248,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             Console.WriteLine("]]] Cache size before one node stop: " + cache.GetSize());
 
+            // TODO: This delay works. Which means we don't wait for rebalance properly. See how Java does it.
             Thread.Sleep(10000);
 
             Console.WriteLine("]]] Cache size before one node stop 2: " + cache.GetSize());

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -129,7 +129,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Loose data and verify lost partition.
             var lostPart = PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 15000);
+            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 45000);
             var lostParts = cache.GetLostPartitions();
             Assert.IsTrue(lostParts.Contains(lostPart));
 
@@ -151,7 +151,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Check another ResetLostPartitions overload.
             PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 15000);
+            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 45000);
             Assert.IsNotEmpty(cache.GetLostPartitions());
             ignite.ResetLostPartitions(new List<string> {CacheName, "foo"});
             Assert.IsEmpty(cache.GetLostPartitions());
@@ -247,7 +247,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 cache.Rebalance();
 
                 // Wait for rebalance to complete.
-                TestUtils.WaitForTrueCondition(() => cache.GetLocalEntries(CachePeekMode.Primary).Any(), 3000);
+                TestUtils.WaitForTrueCondition(() => cache.GetLocalSize(CachePeekMode.Primary) == 19, 3000);
 
                 return cache.GetLocalEntries(CachePeekMode.Primary).Select(x => x.Key).First();
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -38,8 +38,8 @@ namespace Apache.Ignite.Core.Tests.Cache
         /// <summary>
         /// Fixture set up.
         /// </summary>
-        [TestFixtureSetUp]
-        public void FixtureSetUp()
+        [SetUp]
+        public void SetUp()
         {
             Ignition.Start(TestUtils.GetTestConfiguration());
         }
@@ -47,21 +47,10 @@ namespace Apache.Ignite.Core.Tests.Cache
         /// <summary>
         /// Fixture tear down.
         /// </summary>
-        [TestFixtureTearDown]
-        public void FixtureTearDown()
-        {
-            Ignition.StopAll(true);
-        }
-
-        /// <summary>
-        /// Test teardown.
-        /// </summary>
         [TearDown]
         public void TearDown()
         {
-            var ignite = Ignition.GetIgnite();
-
-            ignite.GetCacheNames().ToList().ForEach(ignite.DestroyCache);
+            Ignition.StopAll(true);
         }
 
         /// <summary>
@@ -252,9 +241,6 @@ namespace Apache.Ignite.Core.Tests.Cache
             var res = cache.GetLocalEntries(CachePeekMode.Primary).Select(x => x.Key).First();
 
             Ignition.Stop(ignite.Name, true);
-
-            // TODO: Remove me.
-            Thread.Sleep(20_000);
 
             return res;
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -129,7 +129,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Loose data and verify lost partition.
             var lostPart = PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 3000);
+            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 9000);
             var lostParts = cache.GetLostPartitions();
             Assert.IsTrue(lostParts.Contains(lostPart));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -254,8 +254,9 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // TODO: This delay works. Which means we don't wait for rebalance properly. See how Java does it.
             // Thread.Sleep(10000);
-            ignite.GetCompute().ExecuteJavaTask<bool>(WaitForRebalanceTask,
-                new object[] { CacheName, 2L, 1, 9000L });
+            Assert.IsTrue(
+                ignite.GetCompute().ExecuteJavaTask<bool>(WaitForRebalanceTask,
+                    new object[] { CacheName, 2L, 1, 9000L }));
 
             Console.WriteLine("]]] Cache size before one node stop 2: " + cache.GetSize());
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -151,7 +151,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Check another ResetLostPartitions overload.
             PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 3000);
+            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 9000);
             Assert.IsNotEmpty(cache.GetLostPartitions());
             ignite.ResetLostPartitions(new List<string> {CacheName, "foo"});
             Assert.IsEmpty(cache.GetLostPartitions());

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -141,8 +141,16 @@ namespace Apache.Ignite.Core.Tests.Cache
                 Assert.IsFalse(recoverCache.TryGet(part, out unused));
             }
 
-            // Reset and verify.
-            ignite.ResetLostPartitions(CacheName);
+            // Reset and verify. Test different ResetLostPartitions overloads.
+            if (canWrite)
+            {
+                ignite.ResetLostPartitions(CacheName);
+            }
+            else
+            {
+                ignite.ResetLostPartitions(new List<string> {CacheName, "foo"});
+            }
+
             Assert.IsEmpty(cache.GetLostPartitions());
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -119,7 +119,14 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Loose data and verify lost partition.
             var lostPart = PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 45000);
+            Console.WriteLine("Cache size after PrepareTopology: " + cache.GetSize());
+
+            TestUtils.WaitForTrueCondition(() =>
+            {
+                Console.WriteLine("Cache size in WaitForTrueCondition: " + cache.GetSize());
+
+                return cache.GetLostPartitions().Any();
+            }, 45000);
             var lostParts = cache.GetLostPartitions();
             Assert.IsTrue(lostParts.Contains(lostPart));
 
@@ -239,6 +246,8 @@ namespace Apache.Ignite.Core.Tests.Cache
             TestUtils.WaitForTrueCondition(() => cache.GetLocalSize(CachePeekMode.Primary) == 19, 3000);
 
             var res = cache.GetLocalEntries(CachePeekMode.Primary).Select(x => x.Key).First();
+
+            Console.WriteLine("]]] Cache size before one node stop: " + cache.GetSize());
 
             Ignition.Stop(ignite.Name, true);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -129,7 +129,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Loose data and verify lost partition.
             var lostPart = PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 9000);
+            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 15000);
             var lostParts = cache.GetLostPartitions();
             Assert.IsTrue(lostParts.Contains(lostPart));
 
@@ -151,7 +151,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
             // Check another ResetLostPartitions overload.
             PrepareTopology();
-            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 9000);
+            TestUtils.WaitForTrueCondition(() => cache.GetLostPartitions().Any(), 15000);
             Assert.IsNotEmpty(cache.GetLostPartitions());
             ignite.ResetLostPartitions(new List<string> {CacheName, "foo"});
             Assert.IsEmpty(cache.GetLostPartitions());
@@ -247,11 +247,9 @@ namespace Apache.Ignite.Core.Tests.Cache
                 cache.Rebalance();
 
                 // Wait for rebalance to complete.
-                var node = ignite.GetCluster().GetLocalNode();
-                Func<int, bool> isPrimary = x => affinity.IsPrimary(node, x);
-                TestUtils.WaitForTrueCondition(() => keys.Any(isPrimary));
+                TestUtils.WaitForTrueCondition(() => cache.GetLocalEntries(CachePeekMode.Primary).Any(), 3000);
 
-                return keys.First(isPrimary);
+                return cache.GetLocalEntries(CachePeekMode.Primary).Select(x => x.Key).First();
             }
         }
     }


### PR DESCRIPTION
Add `PlatformWaitForRebalanceTask` to wait for rebalance reliably.