### PR TITLE
GG-35764 [IGNITE-17815] Java thin: Fix RetryPolicy exception handling, propagate exceptions to API caller

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
@@ -825,7 +825,13 @@ final class ReliableChannel implements AutoCloseable {
 
         ClientRetryPolicyContext ctx = new ClientRetryPolicyContextImpl(clientCfg, opType, iteration, exception);
 
-        return plc.shouldRetry(ctx);
+        try {
+            return plc.shouldRetry(ctx);
+        }
+        catch (Throwable t) {
+            exception.addSuppressed(t);
+            return false;
+        }
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/client/ExceptionRetryPolicy.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ExceptionRetryPolicy.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+/**
+ * Retry policy that throws an exception.
+ */
+public class ExceptionRetryPolicy implements ClientRetryPolicy {
+    /** {@inheritDoc} */
+    @Override public boolean shouldRetry(ClientRetryPolicyContext context) {
+        throw new RuntimeException("Error in policy.");
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/client/ExceptionRetryPolicy.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ExceptionRetryPolicy.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/ReliabilityTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -218,6 +219,38 @@ public class ReliabilityTest extends AbstractThinClientTest {
 
             // Reuse second address without fail.
             cache.get(0);
+        }
+    }
+
+    /**
+     * Tests retry policy exception handling.
+     */
+    @Test
+    public void testExceptionInRetryPolicyPropagatesToCaller() {
+        if (isPartitionAware())
+            return;
+
+        try (LocalIgniteCluster cluster = LocalIgniteCluster.start(1);
+             IgniteClient client = Ignition.startClient(getClientConfiguration()
+                 .setRetryPolicy(new ExceptionRetryPolicy())
+                 .setAddresses(
+                     cluster.clientAddresses().iterator().next(),
+                     cluster.clientAddresses().iterator().next()))
+        ) {
+            ClientCache<Integer, Integer> cache = client.createCache("cache");
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            Throwable asyncEx = GridTestUtils.assertThrows(null, () -> cache.getAsync(0).get(),
+                    ExecutionException.class, "Channel is closed");
+
+            dropAllThinClientConnections(Ignition.allGrids().get(0));
+
+            Throwable syncEx = GridTestUtils.assertThrows(null, () -> cache.get(0),
+                    ClientConnectionException.class, "Channel is closed");
+
+            for (Throwable t : new Throwable[] {asyncEx.getCause(), syncEx}) {
+                assertEquals("Error in policy.", t.getSuppressed()[0].getMessage());
+            }
         }
     }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientConnectionTest.cs
@@ -854,6 +854,35 @@ namespace Apache.Ignite.Core.Tests.Client
         }
 
         /// <summary>
+        /// Test retry policy exception handling.
+        /// </summary>
+        [Test]
+        public void TestExceptionInRetryPolicyPropagatesToCaller([Values(true, false)] bool async)
+        {
+            Ignition.Start(TestUtils.GetTestConfiguration());
+
+            var cfg = new IgniteClientConfiguration
+            {
+                Endpoints = new[] { "127.0.0.1" },
+                RetryPolicy = new TestRetryPolicy { ShouldThrow = true },
+                RetryLimit = 2
+            };
+
+            using (var client = Ignition.StartClient(cfg))
+            {
+                var cache = client.GetOrCreateCache<int, int>("c");
+
+                Ignition.StopAll(true);
+
+                var ex = async
+                    ? Assert.CatchAsync(() => cache.GetAsync(0))
+                    : Assert.Catch(() => cache.Get(0));
+
+                Assert.AreEqual("Error in policy.", ex.Message);
+            }
+        }
+
+        /// <summary>
         /// Tests that client stops it's receiver thread upon disposal.
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/TestRetryPolicy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/TestRetryPolicy.cs
@@ -16,6 +16,7 @@
 
 namespace Apache.Ignite.Core.Tests.Client
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Apache.Ignite.Core.Client;
@@ -45,10 +46,20 @@ namespace Apache.Ignite.Core.Tests.Client
         /// </summary>
         public IReadOnlyList<IClientRetryPolicyContext> Invocations => _invocations;
 
+        /// <summary>
+        /// Gets or sets a value indicating whether this policy should throw an exception.
+        /// </summary>
+        public bool ShouldThrow { get; set; }
+
         /** <inheritDoc /> */
         public bool ShouldRetry(IClientRetryPolicyContext context)
         {
             _invocations.Add(context);
+
+            if (ShouldThrow)
+            {
+                throw new Exception("Error in policy.");
+            }
 
             return _allowedOperations.Contains(context.Operation);
         }


### PR DESCRIPTION
Fix API call hang when there is an exception in `RetryPolicy` implementation. Catch exceptions and propagate to the caller.