### PR TITLE
GG-35817 [IGNITE-17796] .NET: Support default interface methods in Services

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Services/ServiceProxyInvoker.cs
@@ -67,6 +67,11 @@ namespace Apache.Ignite.Core.Impl.Services
 
         /// <summary>
         /// Finds suitable method in the specified type, or throws an exception.
+        /// <para />
+        /// We do not try to cover all kinds of intricate use cases with complex class hierarchies,
+        /// explicit interface implementations, and so on.
+        /// It is not possible given only the type, name, and arguments - the call can come from other languages too.
+        /// So we do our best or throw an error.
         /// </summary>
         private static Func<object, object[], object> GetMethodOrThrow(Type svcType, string methodName,
             object[] arguments)
@@ -84,9 +89,20 @@ namespace Apache.Ignite.Core.Impl.Services
                 return res;
 
             // 1) Find methods by name
-            var methods = svcType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+            var bindingFlags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance;
+
+            var methods = svcType.GetMethods(bindingFlags)
                 .Where(m => CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
                 .ToArray();
+
+            if (methods.Length == 0)
+            {
+                // Check default interface implementations.
+                // This does not cover exotic use cases when methods with same signature come from multiple interfaces.
+                methods = svcType.GetInterfaces().SelectMany(x => x.GetMethods(bindingFlags))
+                    .Where(m => !m.IsAbstract && CleanupMethodName(m) == methodName && m.GetParameters().Length == argsLength)
+                    .ToArray();
+            }
 
             if (methods.Length == 1)
             {
@@ -97,7 +113,7 @@ namespace Apache.Ignite.Core.Impl.Services
             if (methods.Length == 0)
                 throw new InvalidOperationException(
                     string.Format(CultureInfo.InvariantCulture,
-                        "Failed to invoke proxy: there is no method '{0}' in type '{1}' with {2} arguments", 
+                        "Failed to invoke proxy: there is no method '{0}' in type '{1}' with {2} arguments",
                         methodName, svcType, argsLength));
 
             // 2) There is more than 1 method with specified name - resolve with argument types.


### PR DESCRIPTION
When resolving service method in `ServiceProxyInvoker`, also check default interface methods.