### PR TITLE
GG-35685 [IGNITE-17432] Removed MaxPermSize option from ignitevisorcmd to provide compatibility with jdk17

### DIFF
--- a/bin/ignitevisorcmd.bat
+++ b/bin/ignitevisorcmd.bat
@@ -129,7 +129,7 @@ if %ERRORLEVEL% neq 0 (
 ::
 :: ADD YOUR/CHANGE ADDITIONAL OPTIONS HERE
 ::
-if "%JVM_OPTS_VISOR%" == "" set JVM_OPTS_VISOR=-Xms1g -Xmx1g -XX:MaxPermSize=128M
+if "%JVM_OPTS_VISOR%" == "" set JVM_OPTS_VISOR=-Xms1g -Xmx1g
 
 ::
 :: Uncomment to set preference to IPv4 stack.

--- a/bin/ignitevisorcmd.sh
+++ b/bin/ignitevisorcmd.sh
@@ -70,7 +70,7 @@ CP="${IGNITE_HOME}/bin/include/visor-common/*${SEP}${IGNITE_HOME}/bin/include/vi
 #
 # ADD YOUR/CHANGE ADDITIONAL OPTIONS HERE
 #
-JVM_OPTS="-Xms1g -Xmx1g -XX:MaxPermSize=128M -server ${JVM_OPTS}"
+JVM_OPTS="-Xms1g -Xmx1g -server ${JVM_OPTS}"
 
 # Mac OS specific support to display correct name in the dock.
 osname=`uname`


### PR DESCRIPTION
… compatibility with jdk17 (#10173)

Co-authored-by: liyujue <liyujue@ignite-service.cn>
(cherry picked from commit 33fafc4b707f6fac4b4c45ca45fab9aedf559f7a)