### PR TITLE
Patch "close fileIO" to release FD #2634

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/filehandle/FileWriteHandleImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/filehandle/FileWriteHandleImpl.java
@@ -515,7 +515,10 @@ class FileWriteHandleImpl extends AbstractFileHandle implements FileWriteHandle 
                     lastFsyncPos = written;
                 }
 
-                walWriter.close();
+                if (mmap)
+                    U.closeQuiet(fileIO);
+                else
+                    walWriter.close();
 
                 if (!mmap && !rollOver)
                     buf.free();


### PR DESCRIPTION
Hi

This code is patch related to #2634.
I think you missed some code from Ignite in [FileWriteHandleImpl.java](https://github.com/apache/ignite/blob/6ad49608f0a88c73c45dd78121ad937673935988/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/filehandle/FileWriteHandleImpl.java#L516)

For reference, the wal problem occurred from v8.8.18.

## Before patch
```bash
$ lsof -p $(ps -ef             \
            | grep java        \
            | grep ignite      \
            | grep -v grep     \
            | awk '{print $2}' \
            | head -n 1)       \
  | grep wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1129    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000001.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1131    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1132    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000001.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1133    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1134    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000001.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1135    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1136    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000001.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1137    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1138    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000001.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1139    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1146    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   1152    /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000001.wal
```

## After patch
```bash
$ lsof -p $(ps -ef             \
            | grep java        \
            | grep ignite      \
            | grep -v grep     \
            | awk '{print $2}' \
            | head -n 1)       \
  | grep wal
1       /usr/lib/jvm/java-11-openjdk/bin/java   104     /storage/wal/node00-5aa21f7e-c075-4bd2-b73b-d93a3aa10aa9/0000000000000000.wal
```

Due to this problem, it seems that serious problems may occur with **disk space issues** or **performance problems** in write-heavy services.

Best regards,
Chan.