### PR TITLE
GG-35944 [IGNITE-18191] .NET: Fix startup on Java 15+

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformProcessUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformProcessUtils.java
@@ -18,6 +18,7 @@ package org.apache.ignite.platform;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -48,6 +49,8 @@ public class PlatformProcessUtils {
             throws Exception {
         if (process != null)
             throw new Exception("PlatformProcessUtils can't start more than one process at a time.");
+
+        Thread.sleep(5000);
 
         ProcessBuilder pb = new ProcessBuilder(file, arg1, arg2);
         pb.directory(new File(workDir));
@@ -80,8 +83,10 @@ public class PlatformProcessUtils {
                             if (line.contains(waitForOutput))
                                 return;
                         }
-                    } catch (Exception ignored) {
-                        // No-op.
+
+                        throw new RuntimeException("Expected output not found: " + waitForOutput);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
                     }
                 });
 

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformTestUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import org.apache.ignite.internal.util.typedef.internal.U;
+
+/**
+ * Test utils.
+ */
+public class PlatformTestUtils {
+    /**
+     * Gets major version of the current JVM.
+     *
+     * @return Major version.
+     */
+    public static int majorJavaVersion() {
+        return U.majorJavaVersion(System.getProperty("java.version"));
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformTestUtils.java
@@ -1,12 +1,11 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.Core.Tests.Client.Compatibility
 {
     using System;
+    using System.Collections;
     using System.Threading;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Cache.Expiry;
@@ -34,15 +35,7 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
     /// Differs from <see cref="ClientProtocolCompatibilityTest"/>:
     /// here we actually download and run old Ignite versions instead of changing the protocol version in handshake.
     /// </summary>
-    [TestFixture(JavaServer.GroupIdIgnite, "2.4.0", 0)]
-    [TestFixture(JavaServer.GroupIdIgnite, "2.5.0", 1)]
-    [TestFixture(JavaServer.GroupIdIgnite, "2.6.0", 1)]
-    [TestFixture(JavaServer.GroupIdIgnite, "2.7.6", 2)]
-    [TestFixture(JavaServer.GroupIdIgnite, "2.8.0", 6)]
-    [TestFixture(JavaServer.GroupIdGridGain, "8.7.6", 2)]
-    [TestFixture(JavaServer.GroupIdGridGain, "8.7.7", 2)]
-    [TestFixture(JavaServer.GroupIdGridGain, "8.7.8", 4)]
-    [TestFixture(JavaServer.GroupIdGridGain, "8.7.9", 4)]
+    [TestFixtureSource(typeof(FixtureSource))]
     [Category(TestUtils.CategoryIntensive)]
     public class ClientServerCompatibilityTest
     {
@@ -288,6 +281,28 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
             public IExpiryPolicy CreateInstance()
             {
                 return new ExpiryPolicy(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(3));
+            }
+        }
+
+        private class FixtureSource : IEnumerable
+        {
+            public IEnumerator GetEnumerator()
+            {
+                TestUtils.EnsureJvmCreated();
+
+                if (TestUtilsJni.GetJavaMajorVersion() <= 11)
+                {
+                    // Old Ignite versions can't start on new JDKs (support was not yet added).
+                    yield return new object[] { JavaServer.GroupIdIgnite, "2.4.0", 0 };
+                    yield return new object[] { JavaServer.GroupIdIgnite, "2.6.0", 1 };
+                }
+
+                yield return new object[] { JavaServer.GroupIdIgnite, "2.7.6", 2 };
+                yield return new object[] { JavaServer.GroupIdIgnite, "2.8.0", 6 };
+
+                yield return new object[] { JavaServer.GroupIdGridGain, "8.7.6", 2 };
+                yield return new object[] { JavaServer.GroupIdGridGain, "8.7.8", 4 };
+                yield return new object[] { JavaServer.GroupIdGridGain, "8.8.3", 6 };
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientServerCompatibilityTest.cs
@@ -302,7 +302,6 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
 
                 yield return new object[] { JavaServer.GroupIdGridGain, "8.7.6", 2 };
                 yield return new object[] { JavaServer.GroupIdGridGain, "8.7.8", 4 };
-                yield return new object[] { JavaServer.GroupIdGridGain, "8.8.3", 6 };
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/JavaServer.cs
@@ -64,10 +64,13 @@ namespace Apache.Ignite.Core.Tests
         {
             IgniteArgumentCheck.NotNullOrEmpty(version, "version");
 
+            Console.WriteLine("Using maven at: " + MavenPath);
+            Console.WriteLine("JAVA_HOME: " + Environment.GetEnvironmentVariable("JAVA_HOME"));
+
             var pomWrapper =
                 ReplaceIgniteVersionInPomFile(groupId, version, Path.Combine(JavaServerSourcePath, "pom.xml"));
 
-            EnsureJvmCreated();
+            TestUtils.EnsureJvmCreated();
 
             var time = DateTime.Now;
 
@@ -98,19 +101,6 @@ namespace Apache.Ignite.Core.Tests
                 TestUtilsJni.DestroyProcess();
                 pomWrapper.Dispose();
             });
-        }
-
-        /// <summary>
-        /// Ensures that JVM is created.
-        /// When corresponding test runs individually we have to start/stop Ignite node to create the JVM,
-        /// otherwise it already exists.
-        /// </summary>
-        private static void EnsureJvmCreated()
-        {
-            if (Jvm.Get(ignoreMissing: true) == null)
-            {
-                Ignition.Start(TestUtils.GetTestConfiguration()).Dispose();
-            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
@@ -33,6 +33,9 @@ namespace Apache.Ignite.Core.Tests
         /** */
         private const string ClassPlatformStartIgniteUtils = "org/apache/ignite/platform/PlatformStartIgniteUtils";
 
+        /** */
+        private const string ClassPlatformTestUtils = "org/apache/ignite/platform/PlatformTestUtils";
+
         /// <summary>
         /// Suspend Ignite threads for the given grid.
         /// </summary>
@@ -119,6 +122,11 @@ namespace Apache.Ignite.Core.Tests
             CallStringMethod(ClassPlatformStartIgniteUtils, "stop", "(Ljava/lang/String;)V", name);
         }
 
+        public static int GetJavaMajorVersion()
+        {
+            return CallIntMethod(ClassPlatformTestUtils, "majorJavaVersion", "()I");
+        }
+
         /** */
         private static unsafe void CallStringMethod(string className, string methodName, string methodSig, string arg)
         {
@@ -156,6 +164,17 @@ namespace Apache.Ignite.Core.Tests
                 var methodId = env.GetStaticMethodId(cls, methodName, methodSig);
                 var res = env.CallStaticObjectMethod(cls, methodId);
                 return env.JStringToString(res.Target);
+            }
+        }
+
+        /** */
+        private static unsafe int CallIntMethod(string className, string methodName, string methodSig)
+        {
+            var env = Jvm.Get().AttachCurrentThread();
+            using (var cls = env.FindClass(className))
+            {
+                var methodId = env.GetStaticMethodId(cls, methodName, methodSig);
+                return env.CallStaticIntMethod(cls, methodId);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Env.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Env.cs
@@ -41,6 +41,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private readonly EnvDelegates.CallStaticBooleanMethod _callStaticBoolMethod;
 
         /** */
+        private readonly EnvDelegates.CallStaticIntMethod _callStaticIntMethod;
+
+        /** */
         private readonly EnvDelegates.FindClass _findClass;
 
         /** */
@@ -126,6 +129,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
 
             GetDelegate(func.CallStaticVoidMethod, out _callStaticVoidMethod);
             GetDelegate(func.CallStaticBooleanMethod, out _callStaticBoolMethod);
+            GetDelegate(func.CallStaticIntMethod, out _callStaticIntMethod);
             GetDelegate(func.FindClass, out _findClass);
             GetDelegate(func.GetMethodID, out _getMethodId);
             GetDelegate(func.GetStaticMethodID, out _getStaticMethodId);
@@ -190,6 +194,18 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             ExceptionCheck();
 
             return res > 0;
+        }
+
+        /// <summary>
+        /// Calls a static int method.
+        /// </summary>
+        public int CallStaticIntMethod(GlobalRef cls, IntPtr methodId, long* argsPtr = null)
+        {
+            var res = _callStaticIntMethod(_envPtr, cls.Target, methodId, argsPtr);
+
+            ExceptionCheck();
+
+            return res;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/EnvDelegates.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/EnvDelegates.cs
@@ -33,6 +33,10 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             IntPtr env, IntPtr clazz, IntPtr methodId, long* argsPtr);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        internal delegate int CallStaticIntMethod(
+            IntPtr env, IntPtr clazz, IntPtr methodId, long* argsPtr);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate IntPtr NewGlobalRef(IntPtr env, IntPtr lobj);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Jvm.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Jvm.cs
@@ -41,7 +41,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         // ReSharper disable once InconsistentNaming
         private const int JNI_VERSION_9 = 0x00090000;
 
-        /** Options to enable startup on Java 9. */
+        /** Options to enable startup on Java 9+. */
         public static readonly string[] Java9Options =
         {
             "--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED",
@@ -49,7 +49,23 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             "--add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED",
             "--add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
             "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
-            "--illegal-access=permit"
+            "--illegal-access=permit",
+
+            "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+            "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+            "--add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED",
+            "--add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
+            "--add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=ALL-UNNAMED",
+            "--add-opens=java.base/java.nio=ALL-UNNAMED",
+            "--add-opens=java.base/java.util=ALL-UNNAMED",
+            "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+            "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+            "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang=ALL-UNNAMED",
+            "--add-opens=java.base/java.lang.invoke=ALL-UNNAMED",
+            "--add-opens=java.base/java.math=ALL-UNNAMED",
+            "--add-opens=java.sql/java.sql=ALL-UNNAMED"
         };
 
         /** */


### PR DESCRIPTION
* Add JVM arguments for Java 15+
* Fix `ClientServerCompatibilityTest`
  * Skip old Ignite versions when new JDK is detected.
  * Fix error handling in `PlatformProcessUtils.startProcess`

NOTE: The following warning may appear on startup with JDK 17+: `OpenJDK 64-Bit Server VM warning: Ignoring option --illegal-access=permit; support was removed in 17.0`. It is harmless.

Unfortunately, with JNI there is no way to tell apart Java versions above 10: https://docs.oracle.com/en/java/javase/17/docs/specs/jni/functions.html#getversion. So we have to use a universal set of JVM args for everything Java 9+, which may produce warnings.