### PR TITLE
GG-35607 WAL segment reservation can be forcibly released while the segment is required for the checkpoint

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/WalDeletionArchiveAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/wal/WalDeletionArchiveAbstractTest.java
@@ -38,6 +38,7 @@ import org.apache.ignite.internal.processors.cache.persistence.checkpoint.Checkp
 import org.apache.ignite.internal.processors.cache.persistence.wal.FileDescriptor;
 import org.apache.ignite.internal.processors.cache.persistence.wal.FileWALPointer;
 import org.apache.ignite.internal.processors.cache.persistence.wal.FileWriteAheadLogManager;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.testframework.ListeningTestLogger;
 import org.apache.ignite.testframework.junits.WithSystemProperty;
@@ -51,6 +52,10 @@ import static org.apache.ignite.internal.util.IgniteUtils.KB;
 import static org.apache.ignite.internal.util.IgniteUtils.MB;
 import static org.apache.ignite.testframework.GridTestUtils.getFieldValueHierarchy;
 import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  *
@@ -307,6 +312,95 @@ public abstract class WalDeletionArchiveAbstractTest extends GridCommonAbstractT
         assertTrue(waitForCondition(() -> walArchiveSize(n) < maxWalArchiveSize, getTestTimeout()));
 
         assertEquals(logStrs.toString(), 1, logStrs.size());
+    }
+
+    /**
+     * Check that if the maximum archive size is equal to one WAL segment size, then when the archive is overflowing,
+     * segments that are needed for binary recovery will not be deleted from the archive until the checkpoint occurs
+     * and finishes.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testMaxWalArchiveSizeEqualsOneWalSegmentSize() throws Exception {
+        int walSegmentSize = (int)MB;
+
+        IgniteConfiguration cfg = getConfiguration(getTestIgniteInstanceName(0))
+            .setCacheConfiguration(cacheConfiguration())
+            .setDataStorageConfiguration(
+                new DataStorageConfiguration()
+                    .setCheckpointFrequency(Long.MAX_VALUE)
+                    .setMaxWalArchiveSize(walSegmentSize)
+                    .setWalSegmentSize(walSegmentSize)
+                    .setWalSegments(2)
+                    .setDefaultDataRegionConfiguration(
+                        new DataRegionConfiguration()
+                            .setPersistenceEnabled(true)
+                            .setMaxSize(GB)
+                            .setCheckpointPageBufferSize(GB)
+                    )
+            );
+
+        IgniteEx n = startGrid(cfg);
+
+        n.cluster().state(ClusterState.ACTIVE);
+
+        // Let's not let a checkpoint happen.
+        gridDatabase(n).checkpointReadLock();
+
+        try {
+            // Let's reserve the very first segment that will definitely be needed for the checkpoint.
+            assertTrue(wal(n).reserve(new FileWALPointer(0, 0, 0)));
+
+            for (int i = 0; wal(n).lastArchivedSegment() < 20L; i++)
+                n.cache(DEFAULT_CACHE_NAME).put(i, new byte[(int)(512 * KB)]);
+
+            // Make sure nothing has been deleted from the archive.
+            assertThat(walArchiveSize(n), greaterThanOrEqualTo(20L * walSegmentSize));
+            assertThat(wal(n).lastTruncatedSegment(), equalTo(-1L));
+
+            // Let's try to reserve all the segments and then immediately release them.
+            long lastWalSegmentIndex = ((FileWALPointer)wal(n).lastWritePointer()).index();
+
+            for (int i = 0; i < lastWalSegmentIndex; i++) {
+                FileWALPointer pointer = new FileWALPointer(i, 0, 0);
+
+                // Unable to reserve because the archive is full.
+                assertFalse(String.valueOf(i), wal(n).reserve(pointer));
+
+                wal(n).release(pointer);
+            }
+
+            assertTrue(
+                String.valueOf(lastWalSegmentIndex),
+                wal(n).reserve(new FileWALPointer(lastWalSegmentIndex, 0, 0))
+            );
+
+            wal(n).release(new FileWALPointer(lastWalSegmentIndex, 0, 0));
+
+            // Let's wait a bit, suddenly there will be a deletion from the archive?
+            assertFalse(waitForCondition(() -> wal(n).lastTruncatedSegment() >= 0, 1_000, 100));
+
+            // Make sure nothing has been deleted from the archive.
+            assertThat(walArchiveSize(n), greaterThanOrEqualTo(20L * walSegmentSize));
+            assertThat(wal(n).lastTruncatedSegment(), equalTo(-1L));
+        }
+        finally {
+            gridDatabase(n).checkpointReadUnlock();
+        }
+
+        // Now let's run a checkpoint and make sure that only one segment remains in the archive.
+        forceCheckpoint(n);
+
+        assertTrue(
+            IgniteUtils.humanReadableByteCount(walArchiveSize(n)),
+            waitForCondition(() -> walArchiveSize(n) <= walSegmentSize, 1_000, 100)
+        );
+
+        assertThat(
+            wal(n).lastTruncatedSegment(),
+            lessThan(((FileWALPointer)getFieldValueHierarchy(wal(n), "lastCheckpointPtr")).index())
+        );
     }
 
     /**


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35607