### PR TITLE
GG-35751ClientConnectionView should use SecuritySubject instead of AuthorizationContext which is null for thin clients.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/spi/systemview/view/ClientConnectionView.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/systemview/view/ClientConnectionView.java
@@ -17,13 +17,13 @@
 package org.apache.ignite.spi.systemview.view;
 
 import java.net.InetSocketAddress;
-import org.apache.ignite.internal.processors.authentication.AuthorizationContext;
 import org.apache.ignite.internal.processors.odbc.ClientListenerConnectionContext;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProtocolVersion;
 import org.apache.ignite.internal.processors.odbc.ClientListenerRequestHandler;
 import org.apache.ignite.internal.processors.odbc.jdbc.JdbcConnectionContext;
 import org.apache.ignite.internal.processors.odbc.odbc.OdbcConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
+import org.apache.ignite.internal.processors.security.SecurityContext;
 import org.apache.ignite.internal.util.nio.GridNioSession;
 import org.jetbrains.annotations.Nullable;
 
@@ -80,12 +80,12 @@ public class ClientConnectionView {
 
     /** @return User name. */
     public String user() {
-        if (ctx == null)
+        SecurityContext secCtx = ctx == null ? null : ctx.securityContext();
+
+        if (secCtx == null)
             return null;
 
-        AuthorizationContext authCtx = ctx.authorizationContext();
-
-        return authCtx == null ? null : authCtx.userName();
+        return (String)secCtx.subject().login();
     }
 
     /** @return Protocol version. */


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35751