### PR TITLE
GG-36059 [IGNITE-18417] .NET: Reduce memory usage in tests

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -60,7 +60,7 @@ namespace Apache.Ignite.Core.Tests
 
         /** */
         public const int DfltBusywaitSleepInterval = 200;
-        
+
         /** System cache name. */
         public const string UtilityCacheName = "ignite-sys-cache";
 
@@ -69,29 +69,21 @@ namespace Apache.Ignite.Core.Tests
             // ReSharper disable once AssignNullToNotNullAttribute
             Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), "ignite_work");
 
+        private static readonly IList<string> TestJvmOptsCommon = new List<string>
+        {
+            "-XX:+HeapDumpOnOutOfMemoryError",
+            "-ea",
+            "-DIGNITE_QUIET=true",
+            "-Duser.timezone=UTC",
+            "-DIGNITE_UPDATE_NOTIFIER=false",
+            "-DIGNITE_SENSITIVE_DATA_LOGGING=plain"
+        };
+
         /** */
-        private static readonly IList<string> TestJvmOpts = Environment.Is64BitProcess
-            ? new List<string>
-            {
-                "-XX:+HeapDumpOnOutOfMemoryError",
-                "-Xms2g",
-                "-Xmx4g",
-                "-ea",
-                "-DIGNITE_QUIET=true",
-                "-Duser.timezone=UTC",
-                "-DIGNITE_SENSITIVE_DATA_LOGGING=plain"
-            }
-            : new List<string>
-            {
-                "-XX:+HeapDumpOnOutOfMemoryError",
-                "-Xms64m",
-                "-Xmx99m",
-                "-ea",
-                "-DIGNITE_ATOMIC_CACHE_DELETE_HISTORY_SIZE=1000",
-                "-DIGNITE_QUIET=true",
-                "-Duser.timezone=UTC",
-                "-DIGNITE_SENSITIVE_DATA_LOGGING=plain"
-            };
+        private static readonly IList<string> TestJvmOpts = (Environment.Is64BitProcess
+                ? new[] { "-Xms2g", "-Xmx2g" }
+                : new[] { "-Xms64m", "-Xmx99m", "-DIGNITE_ATOMIC_CACHE_DELETE_HISTORY_SIZE=1000" })
+            .Concat(TestJvmOptsCommon).ToList();
 
         /** */
         private static readonly IList<string> JvmDebugOpts =
@@ -262,7 +254,7 @@ namespace Apache.Ignite.Core.Tests
 
             return false;
         }
-        
+
         /// <summary>
         /// Waits for particular topology on specific cache (system cache by default).
         /// </summary>

--- a/modules/platforms/dotnet/examples/Shared/Utils.cs
+++ b/modules/platforms/dotnet/examples/Shared/Utils.cs
@@ -67,7 +67,8 @@ namespace Apache.Ignite.Examples.Shared
                 JvmOptions = new[]
                 {
                     "-DIGNITE_QUIET=true",
-                    "-DIGNITE_PERFORMANCE_SUGGESTIONS_DISABLED=true"
+                    "-DIGNITE_PERFORMANCE_SUGGESTIONS_DISABLED=true",
+                    "-DIGNITE_UPDATE_NOTIFIER=false"
                 },
                 Logger = new ConsoleLogger
                 {


### PR DESCRIPTION
* Disable update notifier (`DIGNITE_UPDATE_NOTIFIER`): timer thread is a GC root and keeps terminated Ignite instances in memory longer that needed.
* Set both `Xms` and `Xmx` to 2G to avoid OOM Killer on TC.