### PR TITLE
GG-36079 .NET: Fix ComputeApiTestFullFooter.TestAffinityRun flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/PartitionLossTest.cs
@@ -36,9 +36,6 @@ namespace Apache.Ignite.Core.Tests.Cache
         private const string CacheName = "lossTestCache";
 
         /** */
-        private const string WaitForRebalanceTask = "org.apache.ignite.platform.PlatformWaitForRebalanceTask";
-
-        /** */
         private const int TimeoutMs = 7000;
 
         /// <summary>
@@ -249,10 +246,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 TestUtils.WaitForTrueCondition(() => keys.Any(isPrimary), TimeoutMs);
 
                 var expectedTopVer = new AffinityTopologyVersion(2, 1);
-
-                Assert.IsTrue(ignite.GetCompute().ExecuteJavaTask<bool>(
-                    WaitForRebalanceTask,
-                    new object[] { CacheName, expectedTopVer.Version, expectedTopVer.MinorVersion, (long)TimeoutMs }));
+                Assert.IsTrue(ignite.WaitForRebalance(CacheName, expectedTopVer, TimeoutMs));
 
                 return keys.First(isPrimary);
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -754,6 +754,9 @@ namespace Apache.Ignite.Core.Tests.Compute
             var nodes = new[] {_grid1, _grid2}.Select(x => x.GetCluster().GetLocalNode());
 
             var aff = _grid1.GetAffinity(cacheName);
+            
+            // TODO remove me.
+            Thread.Sleep(6000);
 
             foreach (var node in nodes)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -1155,7 +1155,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
         public static ConcurrentBag<Guid> Invokes = new ConcurrentBag<Guid>();
 
-        public static Guid LastNodeId;
+        public static volatile object LastNodeId;
 
         public Guid Id { get; set; }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -72,7 +72,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             _grid2 = Ignition.Start(Configuration(configs.Item2));
             _grid3 = Ignition.Start(Configuration(configs.Item3));
 
-            var waitingTop = new AffinityTopologyVersion(3, 3);
+            var waitingTop = new AffinityTopologyVersion(3, 0);
             Assert.True(_grid1.WaitTopology(waitingTop), "Failed to wait topology " + waitingTop);
 
             // Start thin client.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -777,10 +777,10 @@ namespace Apache.Ignite.Core.Tests.Compute
                     };
 
                     _grid1.GetCompute().AffinityRun(cacheName, affinityKey, computeAction);
-                    Assert.AreEqual(node.Id, ComputeAction.LastNodeId[computeAction.Id], $"Run {i} failed");
+                    Assert.AreEqual(node.Id, ComputeAction.ActionIdToNodeId[computeAction.Id], $"Run {i} failed");
 
                     _grid1.GetCompute().AffinityRunAsync(cacheName, affinityKey, computeAction).Wait();
-                    Assert.AreEqual(node.Id, ComputeAction.LastNodeId[computeAction.Id], $"Async run {i} failed");
+                    Assert.AreEqual(node.Id, ComputeAction.ActionIdToNodeId[computeAction.Id], $"Async run {i} failed");
                 }
             }
         }
@@ -897,7 +897,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             // Good case.
             action();
-            Assert.AreEqual(node.Id, ComputeAction.LastNodeId[computeAction.Id]);
+            Assert.AreEqual(node.Id, ComputeAction.ActionIdToNodeId[computeAction.Id]);
 
             // Exception in user code.
             computeAction.ShouldThrow = true;
@@ -1163,7 +1163,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
         public static ConcurrentBag<Guid> Invokes = new ConcurrentBag<Guid>();
 
-        public static ConcurrentDictionary<Guid, Guid> LastNodeId = new ConcurrentDictionary<Guid, Guid>();
+        public static ConcurrentDictionary<Guid, Guid> ActionIdToNodeId = new ConcurrentDictionary<Guid, Guid>();
 
         public Guid Id { get; set; }
 
@@ -1187,7 +1187,7 @@ namespace Apache.Ignite.Core.Tests.Compute
         {
             Thread.Sleep(10);
             Invokes.Add(Id);
-            LastNodeId[Id] = _grid.GetCluster().GetLocalNode().Id;
+            ActionIdToNodeId[Id] = _grid.GetCluster().GetLocalNode().Id;
 
             if (ReservedPartition != null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -1201,7 +1201,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
                 foreach (var cacheName in CacheNames)
                 {
-                    Assert.IsFalse(TestUtils.IsPartitionReserved(_grid, cacheName, ReservedPartition.Value));
+                    Assert.IsTrue(TestUtils.IsPartitionReserved(_grid, cacheName, ReservedPartition.Value));
                 }
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -72,8 +72,12 @@ namespace Apache.Ignite.Core.Tests.Compute
             _grid2 = Ignition.Start(Configuration(configs.Item2));
             _grid3 = Ignition.Start(Configuration(configs.Item3));
 
-            var waitingTop = new AffinityTopologyVersion(3, 0);
-            Assert.True(_grid1.WaitTopology(waitingTop), "Failed to wait topology " + waitingTop);
+            var ver = new AffinityTopologyVersion(3, 0);
+
+            foreach (var cacheName in new[] { DefaultCacheName, CacheName2 })
+            {
+                Assert.True(_grid1.WaitForRebalance(cacheName, ver), "Failed to wait for rebalance on " + cacheName);
+            }
 
             // Start thin client.
             _igniteClient = Ignition.StartClient(GetThinClientConfiguration());
@@ -1189,11 +1193,8 @@ namespace Apache.Ignite.Core.Tests.Compute
         public void Invoke()
         {
             Thread.Sleep(10);
-
             Invokes.Add(Id);
             LastNodeId = _grid.GetCluster().GetLocalNode().Id;
-
-            Console.WriteLine($">>> ComputeAction.Invoke: Id = {Id}, NodeId = {LastNodeId}, NodeName = {_grid.Name}");
 
             if (ReservedPartition != null)
             {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -768,7 +768,8 @@ namespace Apache.Ignite.Core.Tests.Compute
                     var computeAction = new ComputeAction
                     {
                         ReservedPartition = partition,
-                        CacheNames = new[] { cacheName }
+                        CacheNames = new[] { cacheName },
+                        Id = Guid.NewGuid()
                     };
 
                     _grid1.GetCompute().AffinityRun(cacheName, affinityKey, computeAction);
@@ -777,7 +778,8 @@ namespace Apache.Ignite.Core.Tests.Compute
 
                     Console.WriteLine(
                         $">>> Test iteration {i}, node {grid.Name} ({node.Id}), key {primaryKey}, affinity key {affinityKey}, " +
-                        $"partition {partition}, actual node {ComputeAction.LastNodeId}, primary node {primaryNodeForPartition}");
+                        $"partition {partition}, actual node {ComputeAction.LastNodeId}, primary node {primaryNodeForPartition}," +
+                        $"actionId {computeAction.Id}");
 
                     Assert.AreEqual(node.Id, ComputeAction.LastNodeId);
 
@@ -1187,8 +1189,11 @@ namespace Apache.Ignite.Core.Tests.Compute
         public void Invoke()
         {
             Thread.Sleep(10);
+
             Invokes.Add(Id);
             LastNodeId = _grid.GetCluster().GetLocalNode().Id;
+
+            Console.WriteLine($">>> ComputeAction.Invoke: Id = {Id}, NodeId = {LastNodeId}, NodeName = {_grid.Name}");
 
             if (ReservedPartition != null)
             {
@@ -1196,7 +1201,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
                 foreach (var cacheName in CacheNames)
                 {
-                    Assert.IsTrue(TestUtils.IsPartitionReserved(_grid, cacheName, ReservedPartition.Value));
+                    Assert.IsFalse(TestUtils.IsPartitionReserved(_grid, cacheName, ReservedPartition.Value));
                 }
             }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -43,7 +43,10 @@ namespace Apache.Ignite.Core.Tests.Compute
         private const string JavaBinaryCls = "PlatformComputeJavaBinarizable";
 
         /** */
-        public const string DefaultCacheName = "default";
+        private const string DefaultCacheName = "default";
+
+        /** */
+        private const string CacheName2 = "cache1";
 
         /** First node. */
         private IIgnite _grid1;
@@ -67,12 +70,10 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             _grid1 = Ignition.Start(Configuration(configs.Item1));
             _grid2 = Ignition.Start(Configuration(configs.Item2));
-
-            AffinityTopologyVersion waitingTop = new AffinityTopologyVersion(2, 1);
-
-            Assert.True(_grid1.WaitTopology(waitingTop), "Failed to wait topology " + waitingTop);
-
             _grid3 = Ignition.Start(Configuration(configs.Item3));
+
+            var waitingTop = new AffinityTopologyVersion(3, 3);
+            Assert.True(_grid1.WaitTopology(waitingTop), "Failed to wait topology " + waitingTop);
 
             // Start thin client.
             _igniteClient = Ignition.StartClient(GetThinClientConfiguration());
@@ -755,9 +756,6 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             var aff = _grid1.GetAffinity(cacheName);
             
-            // TODO remove me.
-            Thread.Sleep(6000);
-
             foreach (var node in nodes)
             {
                 var primaryKey = TestUtils.GetPrimaryKey(_grid1, cacheName, node);
@@ -837,9 +835,7 @@ namespace Apache.Ignite.Core.Tests.Compute
             Assert.AreEqual(localNode.Id, ComputeFunc.LastNodeId);
 
             // Two caches.
-            var cache = _grid1.CreateCache<int, int>(TestUtils.TestName);
-
-            res = action(new[] {cacheName, cache.Name});
+            res = action(new[] {cacheName, CacheName2});
 
             Assert.AreEqual(res, ComputeFunc.InvokeCount);
             Assert.AreEqual(localNode.Id, ComputeFunc.LastNodeId);
@@ -866,8 +862,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             if (multiCache)
             {
-                var cache2 = _grid1.CreateCache<int, int>(TestUtils.TestName);
-                cacheNames.Add(cache2.Name);
+                cacheNames.Add(CacheName2);
             }
 
             var node = local

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -778,8 +778,8 @@ namespace Apache.Ignite.Core.Tests.Compute
 
                     Console.WriteLine(
                         $">>> Test iteration {i}, node {grid.Name} ({node.Id}), key {primaryKey}, affinity key {affinityKey}, " +
-                        $"partition {partition}, actual node {ComputeAction.LastNodeId}, primary node {primaryNodeForPartition}," +
-                        $"actionId {computeAction.Id}");
+                        $"partition {partition}, actual node {ComputeAction.LastNodeId}, primary node {primaryNodeForPartition}, " +
+                        $"actionId {computeAction.Id}, invocationCount {ComputeAction.Invokes.Count}");
 
                     Assert.AreEqual(node.Id, ComputeAction.LastNodeId);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Compute/ComputeApiTest.cs
@@ -887,7 +887,8 @@ namespace Apache.Ignite.Core.Tests.Compute
             var computeAction = new ComputeAction
             {
                 ReservedPartition = part,
-                CacheNames = cacheNames
+                CacheNames = cacheNames,
+                Id = Guid.NewGuid()
             };
 
             var action = async
@@ -896,7 +897,7 @@ namespace Apache.Ignite.Core.Tests.Compute
 
             // Good case.
             action();
-            Assert.AreEqual(node.Id, ComputeAction.LastNodeId);
+            Assert.AreEqual(node.Id, ComputeAction.LastNodeId[computeAction.Id]);
 
             // Exception in user code.
             computeAction.ShouldThrow = true;

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -304,7 +304,7 @@ namespace Apache.Ignite.Core.Tests
         /// <param name="cacheName">Cache name.</param>
         /// <param name="expectedTopVer">Expected topology version.</param>
         /// <param name="timeoutMs">Timeout.</param>
-        /// <returns></returns>
+        /// <returns>True when expected topology version was reached; false otherwise.</returns>
         public static bool WaitForRebalance(
             this IIgnite ignite,
             string cacheName,

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtils.cs
@@ -64,6 +64,9 @@ namespace Apache.Ignite.Core.Tests
         /** System cache name. */
         public const string UtilityCacheName = "ignite-sys-cache";
 
+        /** */
+        private const string WaitForRebalanceTask = "org.apache.ignite.platform.PlatformWaitForRebalanceTask";
+
         /** Work dir. */
         private static readonly string WorkDir =
             // ReSharper disable once AssignNullToNotNullAttribute
@@ -292,6 +295,25 @@ namespace Apache.Ignite.Core.Tests
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Waits for rebalance to complete.
+        /// </summary>
+        /// <param name="ignite">Ignite.</param>
+        /// <param name="cacheName">Cache name.</param>
+        /// <param name="expectedTopVer">Expected topology version.</param>
+        /// <param name="timeoutMs">Timeout.</param>
+        /// <returns></returns>
+        public static bool WaitForRebalance(
+            this IIgnite ignite,
+            string cacheName,
+            AffinityTopologyVersion expectedTopVer,
+            long timeoutMs = 1000)
+        {
+            return ignite.GetCompute().ExecuteJavaTask<bool>(
+                WaitForRebalanceTask,
+                new object[] { cacheName, expectedTopVer.Version, expectedTopVer.MinorVersion, timeoutMs });
         }
 
         /// <summary>


### PR DESCRIPTION
* Do not create new caches in `ComputeApiTest` tests to avoid rebalance and unstable partition distribution. Use existing caches that are created on node start.
* Move `WaitForRebalance` from `PartitionLossTest` to `TestUtils` for reuse.
* Call `WaitForRebalance` before starting tests.