### PR TITLE
GG-35708 Fix startup process of cp marker storage if cpMapSnapshot.bin is empty. Also most likely fixed the situation when it occurs.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointMarkersStorage.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointMarkersStorage.java
@@ -687,6 +687,9 @@ public class CheckpointMarkersStorage {
                     }
 
                     try {
+                        // Use DSYNC so write to file is fsync'ed or else we can move empty file.
+                        // CREATE_NEW is needed here, because we need to create a new temporary file.
+                        // It's not needed by default, but needed to be passed explicitly in case of DSYNC.
                         Files.write(tmpFile.toPath(), bytes, StandardOpenOption.CREATE_NEW, StandardOpenOption.DSYNC);
                     }
                     catch (IOException e) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-35708