### PR TITLE
GG-35372 [IGN-19067] - Failed to activate cluster with control.sh

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/ClusterStateChangeCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/ClusterStateChangeCommand.java
@@ -70,13 +70,19 @@ public class ClusterStateChangeCommand extends AbstractCommand<ClusterState> {
     /** {@inheritDoc} */
     @Override public void prepareConfirmation(GridClientConfiguration clientCfg) throws Exception {
         try (GridClient client = Command.startClient(clientCfg)) {
-            clusterName = client.state().clusterName();
+            GridClientClusterState clientState = client.state();
+
+            if (isFeatureEnabled(IGNITE_CLUSTER_ID_AND_TAG_FEATURE)) {
+                UUID id = clientState.id();
+                String tag = clientState.tag();
+                clusterName = "[id="+id.toString()+", tag="+tag+"]";
+            }
         }
     }
 
     /** {@inheritDoc} */
     @Override public String confirmationPrompt() {
-        return "Warning: the command will change state of cluster with name \"" + clusterName + "\" to " + state + ".";
+        return "Warning: the command will change state of cluster " + clusterName + " to " + state + ".";
     }
 
     /** {@inheritDoc} */

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/DeactivateCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/DeactivateCommand.java
@@ -43,13 +43,19 @@ public class DeactivateCommand extends AbstractCommand<Void> {
     /** {@inheritDoc} */
     @Override public void prepareConfirmation(GridClientConfiguration clientCfg) throws Exception {
         try (GridClient client = Command.startClient(clientCfg)) {
-            clusterName = client.state().clusterName();
+            GridClientClusterState clientState = client.state();
+
+            if (isFeatureEnabled(IGNITE_CLUSTER_ID_AND_TAG_FEATURE)) {
+                UUID id = clientState.id();
+                String tag = clientState.tag();
+                clusterName = "[id="+id.toString()+", tag="+tag+"]";
+            }
         }
     }
 
     /** {@inheritDoc} */
     @Override public String confirmationPrompt() {
-        return "Warning: the command will deactivate a cluster \"" + clusterName + "\".";
+        return "Warning: The command will deactivate a cluster " + clusterName + ".";
     }
 
     /**


### PR DESCRIPTION
GridClient.state().clusterName() throwing GridClientException when cluster is inactive. 
Modified to use cluster Id and cluster tag in confirmation prompt.