### PR TITLE
GG-36301 [IGNITE-18826] Java thin client: fixed the pending requests race on close

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpClientChannel.java
@@ -134,6 +134,9 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     /** Pending requests. */
     private final Map<Long, ClientRequestFuture> pendingReqs = new ConcurrentHashMap<>();
 
+    /** Lock to safely close pending requests. */
+    private final ReadWriteLock pendingReqsLock = new ReentrantReadWriteLock();
+
     /** Topology change listeners. */
     private final Collection<Consumer<ClientChannel>> topChangeLsnrs = new CopyOnWriteArrayList<>();
 
@@ -220,6 +223,8 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
         handshake(DEFAULT_VERSION, cfg.getUserName(), cfg.getUserPassword(), cfg.getUserAttributes());
 
+        assert protocolCtx != null : "Protocol context after handshake is null";
+
         heartbeatTimer = protocolCtx.isFeatureSupported(HEARTBEAT) && cfg.getHeartbeatEnabled()
                 ? initHeartbeat(cfg.getHeartbeatInterval())
                 : null;
@@ -255,8 +260,15 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
 
             U.closeQuiet(sock);
 
-            for (ClientRequestFuture pendingReq : pendingReqs.values())
-                pendingReq.onDone(new ClientConnectionException("Channel is closed", cause));
+            pendingReqsLock.writeLock().lock();
+
+            try {
+                for (ClientRequestFuture pendingReq : pendingReqs.values())
+                    pendingReq.onDone(new ClientConnectionException("Channel is closed", cause));
+            }
+            finally {
+                pendingReqsLock.writeLock().unlock();
+            }
 
             notificationLsnrsGuard.readLock().lock();
 
@@ -310,16 +322,29 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     private ClientRequestFuture send(ClientOperation op, Consumer<PayloadOutputChannel> payloadWriter)
         throws ClientException {
         long id = reqId.getAndIncrement();
+        long startTimeNanos = System.nanoTime();
 
         PayloadOutputChannel payloadCh = new PayloadOutputChannel(this);
 
         try {
-            if (closed())
-                throw new ClientConnectionException("Channel is closed");
+            ClientRequestFuture fut;
 
-            ClientRequestFuture fut = new ClientRequestFuture();
+            pendingReqsLock.readLock().lock();
 
-            pendingReqs.put(id, fut);
+            try {
+                if (closed()) {
+                    ClientConnectionException err = new ClientConnectionException("Channel is closed");
+
+                    throw err;
+                }
+
+                fut = new ClientRequestFuture();
+
+                pendingReqs.put(id, fut);
+            }
+            finally {
+                pendingReqsLock.readLock().unlock();
+            }
 
             BinaryOutputStream req = payloadCh.out();
 
@@ -356,10 +381,11 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
         try {
             ByteBuffer payload = timeout > 0 ? pendingReq.get(timeout) : pendingReq.get();
 
-            if (payload == null || payloadReader == null)
-                return null;
+            T res = null;
+            if (payload != null && payloadReader != null)
+                res = payloadReader.apply(new PayloadInputChannel(this, payload));
 
-            return payloadReader.apply(new PayloadInputChannel(this, payload));
+            return res;
         }
         catch (IgniteCheckedException e) {
             log.warning("Failed to process response: " + e.getMessage(), e);
@@ -382,12 +408,11 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             try {
                 ByteBuffer payload = payloadFut.get();
 
-                if (payload == null || payloadReader == null)
-                    fut.complete(null);
-                else {
-                    T res = payloadReader.apply(new PayloadInputChannel(this, payload));
-                    fut.complete(res);
-                }
+                T res = null;
+                if (payload != null && payloadReader != null)
+                    res = payloadReader.apply(new PayloadInputChannel(this, payload));
+
+                fut.complete(res);
             }
             catch (Throwable t) {
                 log.warning("Failed to process response: " + t.getMessage(), t);
@@ -636,17 +661,104 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
     /** Client handshake. */
     private void handshake(ProtocolVersion ver, String user, String pwd, Map<String, String> userAttrs)
         throws ClientConnectionException, ClientAuthenticationException, ClientProtocolError {
-        ClientRequestFuture fut = new ClientRequestFuture();
-        pendingReqs.put(-1L, fut);
+        long requestId = -1L;
 
-        handshakeReq(ver, user, pwd, userAttrs);
+        while (true) {
+            ClientRequestFuture fut;
 
-        try {
-            ByteBuffer res = timeout > 0 ? fut.get(timeout) : fut.get();
-            handshakeRes(res, ver, user, pwd, userAttrs);
-        }
-        catch (IgniteCheckedException e) {
-            throw new ClientConnectionException(e.getMessage(), e);
+            pendingReqsLock.readLock().lock();
+
+            try {
+                if (closed())
+                    throw new ClientConnectionException("Channel is closed");
+
+                fut = new ClientRequestFuture();
+
+                pendingReqs.put(requestId, fut);
+            }
+            finally {
+                pendingReqsLock.readLock().unlock();
+            }
+
+            handshakeReq(ver, user, pwd, userAttrs);
+
+            try {
+                ByteBuffer buf = timeout > 0 ? fut.get(timeout) : fut.get();
+
+                BinaryInputStream res = BinaryByteBufferInputStream.create(buf);
+
+                try (BinaryReaderExImpl reader = ClientUtils.createBinaryReader(null, res)) {
+                    boolean success = res.readBoolean();
+
+                    if (success) {
+                        byte[] features = EMPTY_BYTES;
+
+                        if (ProtocolContext.isFeatureSupported(ver, BITMAP_FEATURES))
+                            features = reader.readByteArray();
+
+                        protocolCtx = new ProtocolContext(ver, ProtocolBitmaskFeature.enumSet(features));
+
+                        if (protocolCtx.isFeatureSupported(PARTITION_AWARENESS)) {
+                            // Reading server UUID
+                            srvNodeId = reader.readUuid();
+                        }
+
+                        if (log.isDebugEnabled())
+                            log.debug("Handshake succeeded [protocolVersion=" + protocolCtx.version() + ", srvNodeId=" + srvNodeId + ']');
+
+                        break;
+                    }
+                    else {
+                        ProtocolVersion srvVer = new ProtocolVersion(res.readShort(), res.readShort(), res.readShort());
+
+                        String err = reader.readString();
+                        int errCode = ClientStatus.FAILED;
+
+                        if (res.remaining() > 0)
+                            errCode = reader.readInt();
+
+                        if (log.isDebugEnabled())
+                            log.debug("Handshake failed [protocolVersion=" + srvVer + ", err=" + err + ", errCode=" + errCode + ']');
+
+                        RuntimeException resultErr = null;
+                        if (errCode == ClientStatus.AUTH_FAILED)
+                            resultErr = new ClientAuthenticationException(err);
+                        else if (ver.equals(srvVer))
+                            resultErr = new ClientProtocolError(err);
+                        else if (!supportedVers.contains(srvVer) ||
+                            (!ProtocolContext.isFeatureSupported(srvVer, AUTHORIZATION) && !F.isEmpty(user))) {
+                            // Server version is not supported by this client OR server version is less than 1.1.0 supporting
+                            // authentication and authentication is required.
+                            resultErr = new ClientProtocolError(String.format(
+                                "Protocol version mismatch: client %s / server %s. Server details: %s",
+                                ver,
+                                srvVer,
+                                err
+                            ));
+                        }
+
+                        if (resultErr != null) {
+                            throw resultErr;
+                        }
+                        else {
+                            // Retry with server version.
+                            if (log.isDebugEnabled())
+                                log.debug("Retrying handshake with server version [protocolVersion=" + srvVer + ']');
+
+                            ver = srvVer;
+                        }
+                    }
+                }
+            }
+            catch (IOException | IgniteCheckedException e) {
+                ClientException err;
+                if (e instanceof IOException)
+                    err = handleIOError((IOException)e);
+                else
+                    err = new ClientConnectionException(e.getMessage(), e);
+
+                throw err;
+            }
         }
     }
 
@@ -659,7 +771,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             ProtocolContext protocolCtx = protocolContextFromVersion(proposedVer);
 
             writer.writeInt(0); // reserve an integer for the request size
-            writer.writeByte((byte) ClientListenerRequest.HANDSHAKE);
+            writer.writeByte((byte)ClientListenerRequest.HANDSHAKE);
 
             writer.writeShort(proposedVer.major());
             writer.writeShort(proposedVer.minor());
@@ -682,7 +794,7 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
                 writer.writeString(pwd);
             }
 
-            writer.out().writeInt(0, writer.out().position() - 4);// actual size
+            writer.out().writeInt(0, writer.out().position() - 4); // actual size
 
             write(writer.out().arrayCopy(), writer.out().position(), null);
         }
@@ -698,69 +810,6 @@ class TcpClientChannel implements ClientChannel, ClientMessageHandler, ClientCon
             features = ProtocolBitmaskFeature.allFeaturesAsEnumSet();
 
         return new ProtocolContext(ver, features);
-    }
-
-    /** Receive and handle handshake response. */
-    private void handshakeRes(ByteBuffer buf, ProtocolVersion proposedVer, String user, String pwd, Map<String, String> userAttrs)
-        throws ClientConnectionException, ClientAuthenticationException, ClientProtocolError {
-        BinaryInputStream res = BinaryByteBufferInputStream.create(buf);
-
-        try (BinaryReaderExImpl reader = ClientUtils.createBinaryReader(null, res)) {
-            boolean success = res.readBoolean();
-
-            if (success) {
-                byte[] features = EMPTY_BYTES;
-
-                if (ProtocolContext.isFeatureSupported(proposedVer, BITMAP_FEATURES))
-                    features = reader.readByteArray();
-
-                protocolCtx = new ProtocolContext(proposedVer, ProtocolBitmaskFeature.enumSet(features));
-
-                if (protocolCtx.isFeatureSupported(PARTITION_AWARENESS)) {
-                    // Reading server UUID
-                    srvNodeId = reader.readUuid();
-                }
-
-                if (log.isDebugEnabled())
-                    log.debug("Handshake succeeded [protocolVersion=" + protocolCtx.version() + ", srvNodeId=" + srvNodeId + ']');
-            } else {
-                ProtocolVersion srvVer = new ProtocolVersion(res.readShort(), res.readShort(), res.readShort());
-
-                String err = reader.readString();
-                int errCode = ClientStatus.FAILED;
-
-                if (res.remaining() > 0)
-                    errCode = reader.readInt();
-
-                if (log.isDebugEnabled())
-                    log.debug("Handshake failed [protocolVersion=" + srvVer + ", err=" + err + ", errCode=" + errCode + ']');
-
-                if (errCode == ClientStatus.AUTH_FAILED)
-                    throw new ClientAuthenticationException(err);
-                else if (proposedVer.equals(srvVer))
-                    throw new ClientProtocolError(err);
-                else if (!supportedVers.contains(srvVer) ||
-                    (!ProtocolContext.isFeatureSupported(srvVer, AUTHORIZATION) && !F.isEmpty(user)))
-                    // Server version is not supported by this client OR server version is less than 1.1.0 supporting
-                    // authentication and authentication is required.
-                    throw new ClientProtocolError(String.format(
-                        "Protocol version mismatch: client %s / server %s. Server details: %s",
-                        proposedVer,
-                        srvVer,
-                        err
-                    ));
-                else {
-                    // Retry with server version.
-                    if (log.isDebugEnabled())
-                        log.debug("Retrying handshake with server version [protocolVersion=" + srvVer + ']');
-
-                    handshake(srvVer, user, pwd, userAttrs);
-                }
-            }
-        }
-        catch (IOException e) {
-            throw handleIOError(e);
-        }
     }
 
     /** Write bytes to the output stream. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpIgniteClient.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/TcpIgniteClient.java
@@ -415,6 +415,13 @@ public class TcpIgniteClient implements IgniteClient {
         return new TcpIgniteClient(cfg);
     }
 
+    /**
+     * @return Channel.
+     */
+    ReliableChannel reliableChannel() {
+        return ch;
+    }
+
     /** @throws IllegalArgumentException if the specified cache name is invalid. */
     private static void ensureCacheName(String name) {
         if (name == null || name.isEmpty())

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.net.ssl.SSLContext;
-
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.IgniteLogger;
@@ -154,6 +153,9 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
             }
 
             GridNioFuture<GridNioSession> sesFut = srv.createSession(ch, meta, false, null);
+
+            if (sesFut.error() != null)
+                sesFut.get();
 
             if (sslHandshakeFut != null)
                 sslHandshakeFut.get();

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
@@ -17,25 +17,80 @@
 
 package org.apache.ignite.internal.client.thin;
 
-import java.lang.management.ManagementFactory;
-import javax.management.MBeanServerInvocationHandler;
-import javax.management.ObjectName;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.client.ClientCache;
+import org.apache.ignite.client.ClientConnectionException;
+import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.client.SslMode;
+import org.apache.ignite.configuration.ClientConfiguration;
+import org.apache.ignite.configuration.ClientConnectorConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
-import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.internal.util.nio.GridNioServer;
 import org.apache.ignite.mxbean.ClientProcessorMXBean;
+import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import static org.apache.ignite.testframework.GridTestUtils.getFieldValue;
+import static org.apache.ignite.testframework.GridTestUtils.setFieldValue;
+import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
 
 /**
  * Test affinity awareness of thin client on unstable topology.
  */
+@RunWith(Parameterized.class)
 public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientAbstractAffinityAwarenessTest {
+    /** */
+    @Parameterized.Parameter
+    public boolean sslEnabled;
+
+    /** @return Test parameters. */
+    @Parameterized.Parameters(name = "sslEnabled={0}")
+    public static Collection<?> parameters() {
+        return Arrays.asList(new Object[][] {{false}, {true}});
+    }
+
     /** {@inheritDoc} */
     @Override protected void afterTest() throws Exception {
         super.afterTest();
 
         stopAllGrids();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        if (sslEnabled) {
+            cfg.setClientConnectorConfiguration(new ClientConnectorConfiguration()
+                .setSslEnabled(true)
+                .setSslClientAuth(true)
+                .setUseIgniteSslContextFactory(false)
+                .setSslContextFactory(GridTestUtils.sslFactory()));
+        }
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected ClientConfiguration getClientConfiguration(int... nodeIdxs) {
+        ClientConfiguration cfg = super.getClientConfiguration(nodeIdxs);
+
+        if (sslEnabled) {
+            cfg.setSslMode(SslMode.REQUIRED)
+                .setSslContextFactory(GridTestUtils.sslFactory());
+        }
+
+        return cfg;
     }
 
     /**
@@ -71,8 +126,6 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
 
         cache.put(key, 0);
 
-        // Cache partitions are requested from default channel, since it's first (and currently the only) channel
-        // which detects new topology.
         assertOpOnChannel(null, ClientOperation.CACHE_PARTITIONS);
 
         assertOpOnChannel(channels[3], ClientOperation.CACHE_PUT);
@@ -101,10 +154,8 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
 
         awaitPartitionMapExchange();
 
-        // Next request will also detect topology change.
-        opsQueue.clear();
-        client.getOrCreateCache(REPL_CACHE_NAME);
-        assertNotNull(opsQueue.poll());
+        // Detect topology change.
+        detectTopologyChange();
 
         // Test affinity awareness after node join.
         testAffinityAwareness(true);
@@ -124,8 +175,8 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
         // Test affinity awareness before connection to node lost.
         testAffinityAwareness(true);
 
-        // Choose node to disconnect (not default node).
-        int disconnectNodeIdx = null == channels[0] ? 1 : 0;
+        // Choose node to disconnect.
+        int disconnectNodeIdx = 0;
 
         // Drop all thin connections from the node.
         ObjectName mbeanName = U.makeMBeanName(grid(disconnectNodeIdx).name(), "Clients",
@@ -145,8 +196,8 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
 
         cache.put(key, 0);
 
-        // Request goes to default channel, since affinity node is disconnected.
-        assertOpOnChannel(null, ClientOperation.CACHE_PUT);
+        // Request goes to the connected channel, since affinity node is disconnected.
+        assertOpOnChannel(channels[1], ClientOperation.CACHE_PUT);
 
         cache.put(key, 0);
 
@@ -158,10 +209,10 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
     }
 
     /**
-     * Test that affinity awareness works when reconnecting to the new cluster (with lower topology version)
+     * Test that partition awareness works when reconnecting to the new cluster (with lower topology version)
      */
     @Test
-    public void testAffinityAwarenessOnClusterRestart() throws Exception {
+    public void testPartitionAwarenessOnClusterRestart() throws Exception {
         startGrids(3);
 
         awaitPartitionMapExchange();
@@ -173,8 +224,7 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
 
         stopAllGrids();
 
-        for (int i = 0; i < channels.length; i++)
-            channels[i] = null;
+        Arrays.fill(channels, null);
 
         // Start 2 grids, so topology version of the new cluster will be less then old cluster.
         startGrids(2);
@@ -184,7 +234,7 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
         // Send any request to failover.
         client.cache(REPL_CACHE_NAME).put(0, 0);
 
-        opsQueue.clear();
+        detectTopologyChange();
 
         awaitChannelsInit(0, 1);
 
@@ -212,6 +262,64 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
             }
 
             assertOpOnChannel(opCh, ClientOperation.CACHE_PUT);
+        }
+    }
+
+    /** */
+    @Test
+    public void testSessionCloseBeforeHandshake() throws Exception {
+        startGrid(0);
+
+        // TODO: We don't have events.
+//        ClientConfiguration cliCfg = getClientConfiguration(0)
+//            .setEventListeners(new ConnectionEventListener() {
+//                @Override public void onHandshakeStart(HandshakeStartEvent event) {
+//                    // Close connection.
+//                    stopAllGrids();
+//                }
+//            });
+
+        GridTestUtils.assertThrowsWithCause(() -> {
+            try (IgniteClient client = Ignition.startClient(cliCfg)) {
+                return client;
+            }
+        }, ClientConnectionException.class);
+    }
+
+    /** */
+    @Test
+    public void testCreateSessionAfterClose() throws Exception {
+        startGrids(2);
+
+        CountDownLatch srvStopped = new CountDownLatch(1);
+
+        AtomicBoolean dfltInited = new AtomicBoolean();
+
+        // The client should close pending requests on closing without waiting.
+        try (TcpIgniteClient client = new TcpIgniteClient((cfg, connMgr) -> {
+            // Skip default channel to successful client start.
+            if (!dfltInited.compareAndSet(false, true)) {
+                try {
+                    // Connection manager should be stopped before opening a new connection.
+                    srvStopped.await(getTestTimeout(), TimeUnit.MILLISECONDS);
+                }
+                catch (InterruptedException ignored) {
+                    // No-op.
+                }
+            }
+
+            return new TcpClientChannel(cfg, connMgr);
+        }, getClientConfiguration(0))) {
+            GridNioServer<ByteBuffer> srv = getFieldValue(client.reliableChannel(), "connMgr", "srv");
+
+            // Make sure handshake data will not be recieved.
+            setFieldValue(srv, "skipRead", true);
+
+            GridTestUtils.runAsync(() -> {
+                assertTrue(waitForCondition(() -> getFieldValue(srv, "closed"), getTestTimeout()));
+
+                srvStopped.countDown();
+            });
         }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
@@ -128,6 +128,8 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
 
         cache.put(key, 0);
 
+        // Cache partitions are requested from default channel, since it's first (and currently the only) channel
+        // which detects new topology.
         assertOpOnChannel(null, ClientOperation.CACHE_PARTITIONS);
 
         assertOpOnChannel(channels[3], ClientOperation.CACHE_PUT);
@@ -211,10 +213,10 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
     }
 
     /**
-     * Test that partition awareness works when reconnecting to the new cluster (with lower topology version)
+     * Test that affinity awareness works when reconnecting to the new cluster (with lower topology version)
      */
     @Test
-    public void testPartitionAwarenessOnClusterRestart() throws Exception {
+    public void testAffinityAwarenessOnClusterRestart() throws Exception {
         startGrids(3);
 
         awaitPartitionMapExchange();

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
@@ -24,10 +24,7 @@ import java.util.Collection;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.ignite.Ignition;
 import org.apache.ignite.client.ClientCache;
-import org.apache.ignite.client.ClientConnectionException;
-import org.apache.ignite.client.IgniteClient;
 import org.apache.ignite.client.SslMode;
 import org.apache.ignite.configuration.ClientConfiguration;
 import org.apache.ignite.configuration.ClientConnectorConfiguration;
@@ -268,27 +265,6 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
 
             assertOpOnChannel(opCh, ClientOperation.CACHE_PUT);
         }
-    }
-
-    /** */
-    @Test
-    public void testSessionCloseBeforeHandshake() throws Exception {
-        startGrid(0);
-
-        // TODO: We don't have events.
-        ClientConfiguration cliCfg = getClientConfiguration(0);
-//            .setEventListeners(new ConnectionEventListener() {
-//                @Override public void onHandshakeStart(HandshakeStartEvent event) {
-//                    // Close connection.
-//                    stopAllGrids();
-//                }
-//            });
-
-        GridTestUtils.assertThrowsWithCause(() -> {
-            try (IgniteClient client = Ignition.startClient(cliCfg)) {
-                return client;
-            }
-        }, ClientConnectionException.class);
     }
 
     /** */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientAffinityAwarenessUnstableTopologyTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.ignite.internal.client.thin;
 
+import java.lang.management.ManagementFactory;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
@@ -34,11 +35,15 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.processors.cache.IgniteInternalCache;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
 import org.apache.ignite.internal.util.nio.GridNioServer;
+import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.mxbean.ClientProcessorMXBean;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+
+import javax.management.MBeanServerInvocationHandler;
+import javax.management.ObjectName;
 
 import static org.apache.ignite.testframework.GridTestUtils.getFieldValue;
 import static org.apache.ignite.testframework.GridTestUtils.setFieldValue;
@@ -271,7 +276,7 @@ public class ThinClientAffinityAwarenessUnstableTopologyTest extends ThinClientA
         startGrid(0);
 
         // TODO: We don't have events.
-//        ClientConfiguration cliCfg = getClientConfiguration(0)
+        ClientConfiguration cliCfg = getClientConfiguration(0);
 //            .setEventListeners(new ConnectionEventListener() {
 //                @Override public void onHandshakeStart(HandshakeStartEvent event) {
 //                    // Close connection.


### PR DESCRIPTION
`testSessionCloseBeforeHandshake` is not ported, because it requires events - [GG-36241 [IGNITE-18615] Implement monitoring in java thin client](https://ggsystems.atlassian.net/browse/GG-36241).