### PR TITLE
GG-36472 Add ClientConfiguration.clusterDiscoveryEnabled

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/configuration/ClientConfiguration.java
@@ -113,6 +113,11 @@ public final class ClientConfiguration implements Serializable {
     private boolean affinityAwarenessEnabled;
 
     /**
+     * Whether cluster discovery should be enabled.
+     */
+    private boolean clusterDiscoveryEnabled = true;
+
+    /**
      * Reconnect throttling period (in milliseconds). There are no more than {@code reconnectThrottlingRetries}
      * attempts to reconnect will be made within {@code reconnectThrottlingPeriod} in case of connection loss.
      * Throttling is disabled if either {@code reconnectThrottlingRetries} or {@code reconnectThrottlingPeriod} is 0.
@@ -517,6 +522,32 @@ public final class ClientConfiguration implements Serializable {
      */
     public ClientConfiguration setAffinityAwarenessEnabled(boolean affinityAwarenessEnabled) {
         this.affinityAwarenessEnabled = affinityAwarenessEnabled;
+
+        return this;
+    }
+
+    /**
+     * Gets a value indicating whether cluster discovery should be enabled.
+     * <p>
+     * Default is {@code true}: client get addresses of server nodes from the cluster and connects to all of them.
+     * <p>
+     * When {@code false}, client only connects to the addresses provided in {@link #setAddresses(String...)} and
+     * {@link #setAddressesFinder(ClientAddressFinder)}.
+     */
+    public boolean isClusterDiscoveryEnabled() {
+        return clusterDiscoveryEnabled;
+    }
+
+    /**
+     * Sets a value indicating whether cluster discovery should be enabled.
+     * <p>
+     * Default is {@code true}: client get addresses of server nodes from the cluster and connects to all of them.
+     * <p>
+     * When {@code false}, client only connects to the addresses provided in {@link #setAddresses(String...)} and
+     * {@link #setAddressesFinder(ClientAddressFinder)}.
+     */
+    public ClientConfiguration setClusterDiscoveryEnabled(boolean clusterDiscoveryEnabled) {
+        this.clusterDiscoveryEnabled = clusterDiscoveryEnabled;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientDiscoveryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientDiscoveryContext.java
@@ -63,6 +63,9 @@ public class ClientDiscoveryContext {
     @Nullable private final ClientAddressFinder addrFinder;
 
     /** */
+    private final boolean enabled;
+
+    /** */
     private volatile TopologyInfo topInfo;
 
     /** Cache addresses returned by {@link ClientAddressFinder}. */
@@ -76,6 +79,7 @@ public class ClientDiscoveryContext {
         log = NullLogger.whenNull(clientCfg.getLogger());
         addresses = clientCfg.getAddresses();
         addrFinder = clientCfg.getAddressesFinder();
+        enabled = clientCfg.isClusterDiscoveryEnabled();
         reset();
     }
 
@@ -93,8 +97,8 @@ public class ClientDiscoveryContext {
      * @return {@code True} if updated.
      */
     boolean refresh(ClientChannel ch) {
-        if (addrFinder != null)
-            return false; // Used custom address finder.
+        if (addrFinder != null || !enabled)
+            return false; // Disabled or custom finder is used.
 
         if (!ch.protocolCtx().isFeatureSupported(ProtocolBitmaskFeature.CLUSTER_GROUP_GET_NODES_ENDPOINTS))
             return false;

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientEnpointsDiscoveryTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ThinClientEnpointsDiscoveryTest.java
@@ -60,6 +60,21 @@ public class ThinClientEnpointsDiscoveryTest extends ThinClientAbstractAffinityA
 
     /** */
     @Test
+    public void testEndpointsDiscoveryDisabled() throws Exception {
+        startGrids(2);
+
+        // Set only subset of nodes to connect, but wait for init of all nodes channels (other nodes should be discovered).
+        initClient(getClientConfiguration(0).setClusterDiscoveryEnabled(false), 0);
+
+        Thread.sleep(300);
+
+        assertNull(channels[1]);
+        assertNull(channels[2]);
+        assertNull(channels[3]);
+    }
+
+    /** */
+    @Test
     public void testDiscoveryAfterAllNodesFailed() throws Exception {
         startGrids(2);
 


### PR DESCRIPTION
Cluster discovery is always enabled currently, which can be undesirable in some use cases. Add a config property to disable discovery.