### PR TITLE
GG-36321 SQL: Print warning if primary key is potentially misconfigured.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcQueryTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcQueryTask.java
@@ -39,7 +39,6 @@ import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.processors.cache.QueryCursorImpl;
 import org.apache.ignite.internal.processors.cache.query.SqlFieldsQueryEx;
 import org.apache.ignite.internal.processors.query.GridQueryFieldMetadata;
-import org.apache.ignite.internal.processors.query.IgniteSQLException;
 import org.apache.ignite.internal.util.typedef.CAX;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteCallable;

--- a/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcQueryTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/jdbc2/JdbcQueryTask.java
@@ -39,6 +39,7 @@ import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.processors.cache.QueryCursorImpl;
 import org.apache.ignite.internal.processors.cache.query.SqlFieldsQueryEx;
 import org.apache.ignite.internal.processors.query.GridQueryFieldMetadata;
+import org.apache.ignite.internal.processors.query.IgniteSQLException;
 import org.apache.ignite.internal.util.typedef.CAX;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteCallable;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxyImpl.java
@@ -56,6 +56,7 @@ import org.apache.ignite.cache.CacheManager;
 import org.apache.ignite.cache.CacheMetrics;
 import org.apache.ignite.cache.CachePeekMode;
 import org.apache.ignite.cache.query.AbstractContinuousQuery;
+import org.apache.ignite.cache.query.BulkLoadContextCursor;
 import org.apache.ignite.cache.query.ContinuousQuery;
 import org.apache.ignite.cache.query.ContinuousQueryWithTransformer;
 import org.apache.ignite.cache.query.ContinuousQueryWithTransformer.EventListener;
@@ -82,6 +83,7 @@ import org.apache.ignite.internal.processors.cache.query.CacheQueryFuture;
 import org.apache.ignite.internal.processors.cache.query.GridCacheQueryType;
 import org.apache.ignite.internal.processors.cache.query.QueryCursorEx;
 import org.apache.ignite.internal.processors.query.GridQueryFieldMetadata;
+import org.apache.ignite.internal.processors.query.IgniteSQLException;
 import org.apache.ignite.internal.processors.query.QueryUtils;
 import org.apache.ignite.internal.util.GridCloseableIteratorAdapter;
 import org.apache.ignite.internal.util.GridEmptyIterator;
@@ -810,9 +812,18 @@ public class IgniteCacheProxyImpl<K, V> extends AsyncSupportAdapter<IgniteCache<
             if (qry instanceof SqlQuery)
                 return (QueryCursor<R>)ctx.kernalContext().query().querySql(ctx, (SqlQuery)qry, keepBinary);
 
-            if (qry instanceof SqlFieldsQuery)
-                return (FieldsQueryCursor<R>)ctx.kernalContext().query().querySqlFields(ctx, (SqlFieldsQuery)qry,
+            if (qry instanceof SqlFieldsQuery) {
+                FieldsQueryCursor<R> cursor = (FieldsQueryCursor<R>)ctx.kernalContext().query().querySqlFields(ctx, (SqlFieldsQuery)qry,
                     null, keepBinary, true).get(0);
+
+                if (cursor instanceof BulkLoadContextCursor) {
+                    cursor.close();
+
+                    throw new IgniteSQLException("COPY command is currently supported only in thin JDBC driver.");
+                }
+
+                return cursor;
+            }
 
             if (qry instanceof ScanQuery)
                 return query((ScanQuery)qry, null, projection(qry.isLocal()));

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -1976,6 +1976,15 @@ public class IgniteH2Indexing implements GridQueryIndexing {
     @Override public boolean registerType(GridCacheContextInfo cacheInfo, GridQueryTypeDescriptor type, boolean isSql)
         throws IgniteCheckedException {
         validateTypeDescriptor(type);
+
+        // Print warning if _key is of custom user type and no key fields are configured, thus
+        // key object can't be created and used for COPY FROM operation.
+        // Note: QueryEntity can't be properly validated instantly due to compatibility reasons, and
+        // warning can't be printed in QE due to absence of logger.
+        if (type.keyClass() == Object.class && F.isEmpty(type.primaryKeyFields())) {
+            log.warning("Key of user type has no fields configured for table=" + type.tableName());
+        }
+
         schemaMgr.onCacheTypeCreated(cacheInfo, this, type, isSql);
 
         return true;

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -1979,8 +1979,8 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
         // Print warning if _key is of custom user type and no key fields are configured, thus
         // key object can't be created and used for COPY FROM operation.
-        // Note: QueryEntity can't be properly validated instantly due to compatibility reasons, and
-        // warning can't be printed in QE due to absence of logger.
+        // Note: QueryEntity can't be properly validated due to compatibility reasons, and a warning can't be printed
+        // from inside QueryEntity class due to absence of the logger.
         if (type.keyClass() == Object.class && F.isEmpty(type.primaryKeyFields())) {
             log.warning("Key of user type has no fields configured for table=" + type.tableName());
         }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheSqlDmlErrorSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/IgniteCacheSqlDmlErrorSelfTest.java
@@ -23,8 +23,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import javax.cache.CacheException;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
-import org.apache.ignite.cache.query.annotations.QuerySqlField;
-import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.internal.processors.cache.index.AbstractIndexingCommonTest;
 import org.apache.ignite.internal.processors.query.IgniteSQLException;
 import org.apache.ignite.internal.processors.query.h2.dml.UpdatePlanBuilder;

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/index/QueryEntityValidationSelfTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/index/QueryEntityValidationSelfTest.java
@@ -41,12 +41,10 @@ public class QueryEntityValidationSelfTest extends AbstractIndexingCommonTest {
     private static final String CACHE_NAME = "cache";
 
     /** Logger listener. */
-    private static ListeningTestLogger srvLog;
+    private static final ListeningTestLogger srvLog = new ListeningTestLogger(log);
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
-        srvLog = new ListeningTestLogger(log);
-
         startGrid(0);
     }
 
@@ -316,8 +314,14 @@ public class QueryEntityValidationSelfTest extends AbstractIndexingCommonTest {
 
         srvLog.registerListener(logListener);
 
-        grid(0).createCache(ccfg);
+        try {
+            grid(0).createCache(ccfg);
 
-        assertTrue(logListener.check());
+            assertTrue(logListener.check());
+        }
+        finally {
+            srvLog.clearListeners();
+            grid(0).destroyCache(CACHE_NAME);
+        }
     }
 }


### PR DESCRIPTION
Also forbid to run COPY command from Java API because this was is broken. Seemd, we assumed COPY will run only from JDBC Thin Client.