### PR TITLE
GG-36507 .NET: Add IgniteClientConfiguration.EnableClusterDiscovery

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Affinity.Rendezvous;
     using Apache.Ignite.Core.Cache.Configuration;
@@ -601,6 +602,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var cfg = base.GetClientConfiguration();
 
             cfg.EnablePartitionAwareness = true;
+            cfg.EnableClusterDiscovery = false;
             cfg.Endpoints.Add(string.Format("{0}:{1}", IPAddress.Loopback, IgniteClientConfiguration.DefaultPort + 1));
             cfg.Endpoints.Add(string.Format("{0}:{1}", IPAddress.Loopback, IgniteClientConfiguration.DefaultPort + 2));
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -22,7 +22,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Globalization;
     using System.Linq;
     using System.Net;
-    using System.Runtime.CompilerServices;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Affinity.Rendezvous;
     using Apache.Ignite.Core.Cache.Configuration;
@@ -41,7 +40,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         private const int ServerCount = 3;
 
         /** */
-        private ICacheClient<int, int> _cache;
+        protected ICacheClient<int, int> _cache;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PartitionAwarenessTest"/> class.
@@ -151,44 +150,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             Assert.AreEqual(expected, ex.Message);
         }
-
-#if NETCOREAPP // TODO: IGNITE-15710
-        [Test]
-        public void CacheGet_NewNodeEnteredTopology_RequestIsRoutedToNewNode()
-        {
-            // Warm-up.
-            Assert.AreEqual(1, _cache.Get(1));
-
-            // Before topology change.
-            Assert.AreEqual(12, _cache.Get(12));
-            Assert.AreEqual(1, GetClientRequestGridIndex());
-
-            Assert.AreEqual(14, _cache.Get(14));
-            Assert.AreEqual(2, GetClientRequestGridIndex());
-
-            // After topology change.
-            var cfg = GetIgniteConfiguration();
-            cfg.AutoGenerateIgniteInstanceName = true;
-
-            using (Ignition.Start(cfg))
-            {
-                TestUtils.WaitForTrueCondition(() =>
-                {
-                    // Keys 12 and 14 belong to a new node now (-1).
-                    Assert.AreEqual(12, _cache.Get(12));
-                    if (GetClientRequestGridIndex() != -1)
-                    {
-                        return false;
-                    }
-
-                    Assert.AreEqual(14, _cache.Get(14));
-                    Assert.AreEqual(-1, GetClientRequestGridIndex());
-
-                    return true;
-                }, 6000);
-            }
-        }
-#endif
 
         [Test]
         [TestCase(1, 1)]
@@ -609,7 +570,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             return cfg;
         }
 
-        private int GetClientRequestGridIndex(string message = null, string prefix = null)
+        protected int GetClientRequestGridIndex(string message = null, string prefix = null)
         {
             message = message ?? "Get";
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -500,8 +500,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase("default-grp-partitioned-set", null, CacheMode.Partitioned, 4, 1)]
         [TestCase("custom-grp-partitioned-set", "testIgniteSet1", CacheMode.Partitioned, 1, 1)]
         [TestCase("custom-grp-partitioned-set", "testIgniteSet1", CacheMode.Partitioned, 3, 0)]
-        [TestCase("custom-grp-replicated-set", "testIgniteSet2", CacheMode.Replicated, 1, 1)]
-        [TestCase("custom-grp-replicated-set", "testIgniteSet2", CacheMode.Replicated, 3, 1)]
         public void IgniteSet_RequestIsRoutedToPrimaryNode(
             string name, string groupName, CacheMode cacheMode, int item, int gridIdx)
         {
@@ -532,9 +530,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase("custom-grp-partitioned-set-2", "testIgniteSetColocated1", CacheMode.Partitioned, 1, 1)]
         [TestCase("custom-grp-partitioned-set-2", "testIgniteSetColocated1", CacheMode.Partitioned, 2, 1)]
         [TestCase("custom-grp-partitioned-set-2", "testIgniteSetColocated1", CacheMode.Partitioned, 3, 1)]
-        [TestCase("custom-grp-replicated-set-2", "testIgniteSetColocated2", CacheMode.Replicated, 1, 1)]
-        [TestCase("custom-grp-replicated-set-2", "testIgniteSetColocated2", CacheMode.Replicated, 2, 1)]
-        [TestCase("custom-grp-replicated-set-2", "testIgniteSetColocated2", CacheMode.Replicated, 3, 1)]
         public void IgniteSetColocated_RequestIsRoutedToPrimaryNode(
             string name, string groupName, CacheMode cacheMode, int item, int gridIdx)
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessWithClusterDiscoveryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessWithClusterDiscoveryTest.cs
@@ -18,12 +18,52 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 {
     using System.Linq;
     using Apache.Ignite.Core.Client;
+    using NUnit.Framework;
 
     /// <summary>
     /// Tests Partition Awareness functionality combined with Cluster Discovery.
     /// </summary>
     public class PartitionAwarenessWithClusterDiscoveryTest : PartitionAwarenessTest
     {
+#if NETCOREAPP // TODO: IGNITE-15710
+        [Test]
+        public void CacheGet_NewNodeEnteredTopology_RequestIsRoutedToNewNode()
+        {
+            // Warm-up.
+            Assert.AreEqual(1, _cache.Get(1));
+
+            // Before topology change.
+            Assert.AreEqual(12, _cache.Get(12));
+            Assert.AreEqual(1, GetClientRequestGridIndex());
+
+            Assert.AreEqual(14, _cache.Get(14));
+            Assert.AreEqual(2, GetClientRequestGridIndex());
+
+            // After topology change.
+            var cfg = GetIgniteConfiguration();
+            cfg.AutoGenerateIgniteInstanceName = true;
+
+            using (Ignition.Start(cfg))
+            {
+                TestUtils.WaitForTrueCondition(() =>
+                {
+                    // Keys 12 and 14 belong to a new node now (-1).
+                    Assert.AreEqual(12, _cache.Get(12));
+                    if (GetClientRequestGridIndex() != -1)
+                    {
+                        return false;
+                    }
+
+                    Assert.AreEqual(14, _cache.Get(14));
+                    Assert.AreEqual(-1, GetClientRequestGridIndex());
+
+                    return true;
+                }, 6000);
+            }
+        }
+#endif
+
+
         protected override IgniteClientConfiguration GetClientConfiguration()
         {
             var cfg = base.GetClientConfiguration();

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessWithClusterDiscoveryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessWithClusterDiscoveryTest.cs
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Cache
+{
+    using System.Linq;
+    using Apache.Ignite.Core.Client;
+
+    /// <summary>
+    /// Tests Partition Awareness functionality combined with Cluster Discovery.
+    /// </summary>
+    public class PartitionAwarenessWithClusterDiscoveryTest : PartitionAwarenessTest
+    {
+        protected override IgniteClientConfiguration GetClientConfiguration()
+        {
+            var cfg = base.GetClientConfiguration();
+
+            // Enable discovery and keep only one endpoint, let the client discover others.
+            cfg.EnableClusterDiscovery = true;
+            cfg.Endpoints = cfg.Endpoints.Take(1).ToList();
+
+            return cfg;
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTests.cs
@@ -81,12 +81,14 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         /// Tests that originally known node can leave and client maintains connections to other cluster nodes.
         /// </summary>
         [Test]
-        public void TestClientMaintainsConnectionWhenOriginalNodeLeaves()
+        public void TestClientMaintainsConnectionWhenOriginalNodeLeaves(
+            [Values(true, false)] bool enablePartitionAwareness)
         {
             // Client knows about single server node initially.
             var ignite = Ignition.Start(GetIgniteConfiguration());
             var cfg = GetClientConfiguration();
             cfg.Endpoints = new[] {IPAddress.Loopback + ":10803"};
+            cfg.EnablePartitionAwareness = enablePartitionAwareness;
 
             // Client starts and discovers other server nodes.
             var client = Ignition.StartClient(cfg);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterDiscoveryTestsBase.cs
@@ -59,6 +59,38 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
                 AssertClientConnectionCount(client, 3);
             }
         }
+
+        /// <summary>
+        /// Tests that client with one initial endpoint discovers all servers.
+        /// </summary>
+        [Test]
+        public void TestDisabledDiscovery()
+        {
+            var cfg = new IgniteClientConfiguration(GetClientConfiguration())
+            {
+                EnableClusterDiscovery = false
+            };
+
+            using var client = Ignition.StartClient(cfg);
+
+            AssertClientConnectionCount(client, 1);
+        }
+
+        /// <summary>
+        /// Tests that client with one initial endpoint discovers all servers.
+        /// </summary>
+        [Test]
+        public void TestDisabledPartitionAwareness()
+        {
+            var cfg = new IgniteClientConfiguration(GetClientConfiguration())
+            {
+                EnablePartitionAwareness = false
+            };
+
+            using var client = Ignition.StartClient(cfg);
+
+            AssertClientConnectionCount(client, 1);
+        }
 #endif
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesAsyncWrapper.cs
@@ -17,7 +17,6 @@
 namespace Apache.Ignite.Core.Tests.Services
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Apache.Ignite.Core.Cluster;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/CacheAtomicityMode.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Configuration/CacheAtomicityMode.cs
@@ -79,7 +79,7 @@ namespace Apache.Ignite.Core.Cache.Configuration
         /// If a transaction is executed over multiple caches, all caches must have the same atomicity mode,
         /// either TRANSACTIONAL_SNAPSHOT or TRANSACTIONAL.
         /// </summary>
-        [IgniteExperimentalAttribute]
+        [IgniteExperimental]
         TransactionalSnapshot,
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -254,8 +254,10 @@ namespace Apache.Ignite.Core.Client
         /// <summary>
         /// Gets or sets a value indicating whether Cluster Discovery should be enabled.
         /// <para />
-        /// Default is true: when <see cref="EnablePartitionAwareness"/> is also true,
-        /// Ignite client will maintain an actual list of all server nodes in the cluster and connect to all of them.
+        /// Default is true: Ignite will maintain an actual list of all server nodes in the cluster and connect to
+        /// them when necessary.
+        /// When <see cref="EnablePartitionAwareness"/> is false, this list of nodes will be used for failover.
+        /// When <see cref="EnablePartitionAwareness"/> is true, connections will be established to all known nodes.
         /// <para />
         /// When false: Ignite client will connect only to nodes in the <see cref="Endpoints"/> list.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -245,6 +245,8 @@ namespace Apache.Ignite.Core.Client
         /// To do so, connection is established to every known server node at all times.
         /// <para />
         /// When false: only one connection is established at a given moment to a random server node.
+        /// <para />
+        /// See also <see cref="EnableClusterDiscovery"/>.
         /// </summary>
         [DefaultValue(DefaultEnablePartitionAwareness)]
         public bool EnablePartitionAwareness { get; set; }
@@ -252,8 +254,8 @@ namespace Apache.Ignite.Core.Client
         /// <summary>
         /// Gets or sets a value indicating whether Cluster Discovery should be enabled.
         /// <para />
-        /// Default is true: Ignite client will maintain an actual list of all server nodes in the cluster
-        /// and connect to all of them.
+        /// Default is true: when <see cref="EnablePartitionAwareness"/> is also true,
+        /// Ignite client will maintain an actual list of all server nodes in the cluster and connect to all of them.
         /// <para />
         /// When false: Ignite client will connect only to nodes in the <see cref="Endpoints"/> list.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IgniteClientConfiguration.cs
@@ -60,6 +60,11 @@ namespace Apache.Ignite.Core.Client
         public const bool DefaultEnablePartitionAwareness = true;
 
         /// <summary>
+        /// Default value of <see cref="EnableClusterDiscovery" /> property.
+        /// </summary>
+        public const bool DefaultEnableClusterDiscovery = true;
+
+        /// <summary>
         /// Default socket timeout.
         /// </summary>
         public static readonly TimeSpan DefaultSocketTimeout = TimeSpan.FromMilliseconds(5000);
@@ -83,6 +88,7 @@ namespace Apache.Ignite.Core.Client
             SocketTimeout = DefaultSocketTimeout;
             Logger = new ConsoleLogger();
             EnablePartitionAwareness = DefaultEnablePartitionAwareness;
+            EnableClusterDiscovery = DefaultEnableClusterDiscovery;
         }
 
         /// <summary>
@@ -129,6 +135,7 @@ namespace Apache.Ignite.Core.Client
             Endpoints = cfg.Endpoints == null ? null : cfg.Endpoints.ToList();
             ReconnectDisabled = cfg.ReconnectDisabled;
             EnablePartitionAwareness = cfg.EnablePartitionAwareness;
+            EnableClusterDiscovery = cfg.EnableClusterDiscovery;
             Logger = cfg.Logger;
             ProtocolVersion = cfg.ProtocolVersion;
 
@@ -241,6 +248,17 @@ namespace Apache.Ignite.Core.Client
         /// </summary>
         [DefaultValue(DefaultEnablePartitionAwareness)]
         public bool EnablePartitionAwareness { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether Cluster Discovery should be enabled.
+        /// <para />
+        /// Default is true: Ignite client will maintain an actual list of all server nodes in the cluster
+        /// and connect to all of them.
+        /// <para />
+        /// When false: Ignite client will connect only to nodes in the <see cref="Endpoints"/> list.
+        /// </summary>
+        [DefaultValue(DefaultEnableClusterDiscovery)]
+        public bool EnableClusterDiscovery { get; set; }
 
         /// <summary>
         /// Gets or sets the logger.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteClientConfigurationSection.xsd
@@ -334,6 +334,11 @@
                     <xs:documentation>Enables partition-aware connection: client will establish connection to every known server and route requests to primary nodes for cache operations.</xs:documentation>
                 </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="enableClusterDiscovery" type="xs:boolean">
+                <xs:annotation>
+                    <xs:documentation>Enables cluster discovery: client will maintain an actual list of all server nodes and connect to all of them.</xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="userName" type="xs:string">
                 <xs:annotation>
                     <xs:documentation>Username to be used to connect to secured cluster.</xs:documentation>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/IgniteConfiguration.cs
@@ -1665,7 +1665,7 @@ namespace Apache.Ignite.Core
         /// Time interval between MVCC vacuum runs in milliseconds.
         /// </summary>
         [DefaultValue(DefaultMvccVacuumFrequency)]
-        [IgniteExperimentalAttribute]
+        [IgniteExperimental]
         public long MvccVacuumFrequency
         {
             get { return _mvccVacuumFreq ?? DefaultMvccVacuumFrequency; }
@@ -1678,7 +1678,7 @@ namespace Apache.Ignite.Core
         /// Number of MVCC vacuum threads.
         /// </summary>
         [DefaultValue(DefaultMvccVacuumThreadCount)]
-        [IgniteExperimentalAttribute]
+        [IgniteExperimental]
         public int MvccVacuumThreadCount
         {
             get { return _mvccVacuumThreadCnt ?? DefaultMvccVacuumThreadCount; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -508,7 +508,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 );
             }
 
-            if (!_config.EnablePartitionAwareness || !_config.EnableClusterDiscovery)
+            if (!_config.EnableClusterDiscovery)
             {
                 _enableDiscovery = false;
             }
@@ -591,7 +591,7 @@ namespace Apache.Ignite.Core.Impl.Client
         {
             _affinityTopologyVersion = affinityTopologyVersion;
 
-            if (_discoveryTopologyVersion < affinityTopologyVersion.Version &&_config.EnablePartitionAwareness)
+            if (_discoveryTopologyVersion < affinityTopologyVersion.Version && _enableDiscovery)
             {
                 ThreadPool.QueueUserWorkItem(_ =>
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -508,7 +508,9 @@ namespace Apache.Ignite.Core.Impl.Client
                 );
             }
 
-            if (!_socket.Features.HasFeature(ClientBitmaskFeature.ClusterGroupGetNodesEndpoints))
+            if (!_config.EnablePartitionAwareness ||
+                !_config.EnableClusterDiscovery ||
+                !_socket.Features.HasFeature(ClientBitmaskFeature.ClusterGroupGetNodesEndpoints))
             {
                 _enableDiscovery = false;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -508,9 +508,12 @@ namespace Apache.Ignite.Core.Impl.Client
                 );
             }
 
-            if (!_config.EnablePartitionAwareness ||
-                !_config.EnableClusterDiscovery ||
-                !_socket.Features.HasFeature(ClientBitmaskFeature.ClusterGroupGetNodesEndpoints))
+            if (!_config.EnablePartitionAwareness || !_config.EnableClusterDiscovery)
+            {
+                _enableDiscovery = false;
+            }
+
+            if (_enableDiscovery && !_socket.Features.HasFeature(ClientBitmaskFeature.ClusterGroupGetNodesEndpoints))
             {
                 _enableDiscovery = false;
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Transactions/TransactionConfiguration.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Transactions/TransactionConfiguration.cs
@@ -94,7 +94,7 @@ namespace Apache.Ignite.Core.Transactions
         /// <see cref="TimeSpan.Zero"/> for disabling deadlock detection.
         /// </summary>
         [DefaultValue(typeof(TimeSpan), "00:00:10")]
-        [IgniteExperimentalAttribute]
+        [IgniteExperimental]
         public TimeSpan DeadlockTimeout { get; set; }
 
         /// <summary>


### PR DESCRIPTION
* Add `IgniteClientConfiguration.EnableClusterDiscovery`.
* Allow any combinations of `EnableClusterDiscovery` and `EnablePartitionAwareness`:
  * Only `EnablePartitionAwareness`: use configured endpoints to route requests.
  * Only `EnableClusterDiscovery`: use discovered endpoints for failover, but maintain only one connection.
  * Both enabled: discover all, connect to all.
  * Both disabled: maintain one connection, use only configured endpoints for failover.