### PR TITLE
GG-36503 Java thin: Add connection and SSL handshake timeout

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -165,10 +165,14 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
             if (sesFut.error() != null)
                 sesFut.get();
 
-            if (sslHandshakeFut != null)
-                sslHandshakeFut.get(timeout);
+            if (sslHandshakeFut != null) {
+                if (timeout == 0)
+                    sslHandshakeFut.get();
+                else
+                    sslHandshakeFut.get(timeout);
+            }
 
-            GridNioSession ses = sesFut.get(timeout);
+            GridNioSession ses = timeout == 0 ? sesFut.get() : sesFut.get(timeout);
 
             return new GridNioClientConnection(ses, msgHnd, stateHnd);
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientConnectionMultiplexer.java
@@ -159,20 +159,17 @@ public class GridNioClientConnectionMultiplexer implements ClientConnectionMulti
 
             GridNioFuture<GridNioSession> sesFut = srv.createSession(ch, meta, false, null);
 
-            // TODO:
-            //  1. Add timeout.
-            //  2. Wait on both futures.
             if (sesFut.error() != null)
                 sesFut.get();
 
             if (sslHandshakeFut != null) {
-                if (timeout == 0)
+                if (timeout <= 0)
                     sslHandshakeFut.get();
                 else
                     sslHandshakeFut.get(timeout);
             }
 
-            GridNioSession ses = timeout == 0 ? sesFut.get() : sesFut.get(timeout);
+            GridNioSession ses = timeout <= 0 ? sesFut.get() : sesFut.get(timeout);
 
             return new GridNioClientConnection(ses, msgHnd, stateHnd);
         }

--- a/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
@@ -16,7 +16,10 @@
 
 package org.apache.ignite.client;
 
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ForkJoinPool;
 import javax.net.ssl.SSLHandshakeException;
 import org.apache.ignite.Ignition;
 import org.apache.ignite.configuration.CacheConfiguration;
@@ -34,6 +37,7 @@ import org.junit.Test;
 /**
  * Tests cases when node connects to cluster with different set of cipher suites.
  */
+@SuppressWarnings({"ThrowableNotThrown", "resource"})
 public class SslParametersTest extends GridCommonAbstractTest {
     /** */
     public static final String TEST_CACHE_NAME = "TEST";
@@ -54,7 +58,7 @@ public class SslParametersTest extends GridCommonAbstractTest {
 
         cfg.setSslContextFactory(createSslFactory());
 
-        CacheConfiguration ccfg = new CacheConfiguration(TEST_CACHE_NAME);
+        CacheConfiguration<?, ?> ccfg = new CacheConfiguration<>(TEST_CACHE_NAME);
 
         cfg.setCacheConfiguration(ccfg);
 
@@ -76,7 +80,7 @@ public class SslParametersTest extends GridCommonAbstractTest {
      * @return SSL factory.
      */
     @NotNull private SslContextFactory createSslFactory() {
-        SslContextFactory factory = (SslContextFactory)GridTestUtils.sslTrustedFactory("node01", "trustone");
+        SslContextFactory factory = GridTestUtils.sslTrustedFactory("node01", "trustone");
 
         factory.setCipherSuites(cipherSuites);
         factory.setProtocols(protocols);
@@ -285,12 +289,34 @@ public class SslParametersTest extends GridCommonAbstractTest {
         );
     }
 
+    @Test
+    public void testConnectionFailBeforeSslHandshake() {
+        ForkJoinPool.commonPool().execute(() -> {
+            // Open a server socket, accept client connection, close the socket
+            // before SSL handshake is completed.
+            try (ServerSocket serverSocket = new ServerSocket(10901)) {
+                Socket socket = serverSocket.accept();
+                Thread.sleep(100);
+                socket.close();
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+        });
+
+        GridTestUtils.assertThrowsAnyCause(
+                null,
+                () -> Ignition.startClient(getClientConfiguration().setAddresses("127.0.0.1:10901")),
+                ClientConnectionException.class,
+                "SSL handshake failed (connection closed)."
+        );
+    }
+
     /**
      * @param cipherSuites list of cipher suites
      * @param protocols list of protocols
-     * @throws Exception If failed.
      */
-    private void checkSuccessfulClientStart(String[] cipherSuites, String[] protocols) throws Exception {
+    private void checkSuccessfulClientStart(String[] cipherSuites, String[] protocols) {
         this.cipherSuites = F.isEmpty(cipherSuites) ? null : cipherSuites;
         this.protocols = F.isEmpty(protocols) ? null : protocols;
 

--- a/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/SslParametersTest.java
@@ -304,9 +304,13 @@ public class SslParametersTest extends GridCommonAbstractTest {
             }
         });
 
+        ClientConfiguration cfg = getClientConfiguration()
+                .setAddresses("127.0.0.1:10901")
+                .setTimeout(3000);
+
         GridTestUtils.assertThrowsAnyCause(
                 null,
-                () -> Ignition.startClient(getClientConfiguration().setAddresses("127.0.0.1:10901")),
+                () -> Ignition.startClient(cfg),
                 ClientConnectionException.class,
                 "SSL handshake failed (connection closed)."
         );


### PR DESCRIPTION
Fix potential indefinite connection hangs by using configured timeout while opening `GridNioSession` and waiting for SSL handshake.