### PR TITLE
GG-36501 Fix ClientSizeCacheCreationDestructionTest flakiness

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/common/ClientSideCacheCreationDestructionWileTopologyChangeTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/ClientSideCacheCreationDestructionWileTopologyChangeTest.java
@@ -43,11 +43,13 @@ public class ClientSideCacheCreationDestructionWileTopologyChangeTest extends Cl
 
     /** {@inheritDoc} */
     @Override protected void afterTest() throws Exception {
-        procTopChanges.set(false);
+        try {
+            procTopChanges.set(false);
 
-        topChangeProcFut.get();
-
-        super.afterTest();
+            topChangeProcFut.get();
+        } finally {
+            super.afterTest();
+        }
     }
 
     /**

--- a/modules/clients/src/test/java/org/apache/ignite/common/ClientSideCacheCreationDestructionWileTopologyChangeTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/ClientSideCacheCreationDestructionWileTopologyChangeTest.java
@@ -46,7 +46,8 @@ public class ClientSideCacheCreationDestructionWileTopologyChangeTest extends Cl
         try {
             procTopChanges.set(false);
 
-            topChangeProcFut.get();
+            if (topChangeProcFut != null)
+                topChangeProcFut.get();
         } finally {
             super.afterTest();
         }

--- a/modules/clients/src/test/java/org/apache/ignite/common/ClientSizeCacheCreationDestructionTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/ClientSizeCacheCreationDestructionTest.java
@@ -94,6 +94,11 @@ public class ClientSizeCacheCreationDestructionTest extends GridCommonAbstractTe
 
         thickClient = startClientGrid(1);
 
+        // TODO: Thin client fails on start
+        // 1. Client connector processor has started on TCP port 10801 (server)
+        // 2. Client connector processor has started on TCP port 10802 (thick client)
+        // Therefore, some other node is on port 10800, from a previous test?
+        // Additionally, we have exceptions in the server log "Failed to parse incoming packet" from the REST listener
         thinClient = Ignition.startClient(new ClientConfiguration().setAddresses("127.0.0.1:10800"));
 
         jdbcConn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1:10800");

--- a/modules/clients/src/test/java/org/apache/ignite/common/ClientSizeCacheCreationDestructionTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/ClientSizeCacheCreationDestructionTest.java
@@ -99,6 +99,7 @@ public class ClientSizeCacheCreationDestructionTest extends GridCommonAbstractTe
         // 2. Client connector processor has started on TCP port 10802 (thick client)
         // Therefore, some other node is on port 10800, from a previous test?
         // Additionally, we have exceptions in the server log "Failed to parse incoming packet" from the REST listener
+        // TODO 2: Server nodes are not stopped, which causes ClientSideCacheCreationDestructionWileTopologyChangeTest to fail. Add afterAll() method?
         thinClient = Ignition.startClient(new ClientConfiguration().setAddresses("127.0.0.1:10800"));
 
         jdbcConn = DriverManager.getConnection("jdbc:ignite:thin://127.0.0.1:10800");

--- a/modules/clients/src/test/java/org/apache/ignite/common/ClientSizeCacheCreationDestructionTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/ClientSizeCacheCreationDestructionTest.java
@@ -94,6 +94,7 @@ public class ClientSizeCacheCreationDestructionTest extends GridCommonAbstractTe
 
         thickClient = startClientGrid(1);
 
+        // https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_JavaClient/8877550?buildTab=tests&status=failed&suite=org.apache.ignite.internal.client.suite.IgniteClientTestSuite%3A+&expandedTest=build%3A%28id%3A8877550%29%2Cid%3A83481
         // TODO: Thin client fails on start
         // 1. Client connector processor has started on TCP port 10801 (server)
         // 2. Client connector processor has started on TCP port 10802 (thick client)

--- a/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/common/NodeSslConnectionMetricTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.Ignition;
 import org.apache.ignite.client.ClientConnectionException;
 import org.apache.ignite.client.Config;
 import org.apache.ignite.client.IgniteClient;
@@ -49,6 +50,7 @@ import static java.sql.DriverManager.getConnection;
 import static org.apache.ignite.Ignition.startClient;
 import static org.apache.ignite.internal.client.GridClientFactory.start;
 import static org.apache.ignite.internal.processors.metric.GridMetricManager.CLIENT_CONNECTOR_METRICS;
+import static org.apache.ignite.internal.processors.odbc.ClientListenerProcessor.CLIENT_LISTENER_PORT;
 import static org.apache.ignite.internal.processors.rest.protocols.tcp.GridTcpRestProtocol.REST_CONNECTOR_METRIC_REGISTRY_NAME;
 import static org.apache.ignite.internal.util.nio.GridNioServer.RECEIVED_BYTES_METRIC_NAME;
 import static org.apache.ignite.internal.util.nio.GridNioServer.SENT_BYTES_METRIC_NAME;
@@ -390,12 +392,14 @@ public class NodeSslConnectionMetricTest extends GridCommonAbstractTest {
         String cipherSuite,
         String protocol
     ) {
-       return new ClientConfiguration()
-            .setAddresses("127.0.0.1:10800")
-            // When PA is enabled, async client channel init executes and spoils the metrics.
-            .setAffinityAwarenessEnabled(false)
-            .setSslMode(SslMode.REQUIRED)
-            .setSslContextFactory(sslContextFactory(keyStore, trustStore, cipherSuite, protocol));
+        int port = (Integer) Ignition.allGrids().get(0).cluster().localNode().attributes().get(CLIENT_LISTENER_PORT);
+
+        return new ClientConfiguration()
+                .setAddresses("127.0.0.1:" + port)
+                // When PA is enabled, async client channel init executes and spoils the metrics.
+                .setAffinityAwarenessEnabled(false)
+                .setSslMode(SslMode.REQUIRED)
+                .setSslContextFactory(sslContextFactory(keyStore, trustStore, cipherSuite, protocol));
     }
 
     /** Checks that the node join failed if the connection was performed with the specified SSL options. */


### PR DESCRIPTION
* Fix client port - get from node, do not assume 10800.
* Fix `ClientSideCacheCreationDestructionWileTopologyChangeTest#afterTest`