### PR TITLE
GG-36528 Java thin: Fix index sort order when reading cache configuration

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -487,7 +487,7 @@ public final class ClientUtils {
 
                                     LinkedHashMap<String, Boolean> fields = ClientUtils.collection(
                                         in,
-                                        unused5 -> new SimpleEntry<>(reader.readString(), reader.readBoolean())
+                                        unused5 -> new SimpleEntry<>(reader.readString(), !reader.readBoolean())
                                     ).stream().collect(Collectors.toMap(
                                             SimpleEntry::getKey,
                                             SimpleEntry::getValue,

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -348,7 +348,7 @@ public final class ClientUtils {
                                 w.writeInt(i.getInlineSize());
                                 ClientUtils.collection(i.getFields().entrySet(), out, (unused5, f) -> {
                                             w.writeString(f.getKey());
-                                            w.writeBoolean(f.getValue());
+                                            w.writeBoolean(!f.getValue());
                                         }
                                 );
                             });

--- a/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/client/FunctionalTest.java
@@ -185,7 +185,7 @@ public class FunctionalTest extends GridCommonAbstractTest {
      */
     @Test
     public void testCacheConfiguration() throws Exception {
-        try (Ignite ignored = Ignition.start(Config.getServerConfiguration());
+        try (Ignite server = Ignition.start(Config.getServerConfiguration());
              IgniteClient client = Ignition.startClient(getClientConfiguration())
         ) {
             final String CACHE_NAME = "testCacheConfiguration";
@@ -230,10 +230,15 @@ public class FunctionalTest extends GridCommonAbstractTest {
                     .setExpiryPolicy(new PlatformExpiryPolicy(10, 20, 30));
 
             ClientCache<Object, Object> cache = client.createCache(cacheCfg);
+            ClientCacheConfiguration clientCfg = cache.getConfiguration();
+            CacheConfiguration serverCfg = server.cache(CACHE_NAME).getConfiguration(CacheConfiguration.class);
 
             assertEquals(CACHE_NAME, cache.getName());
+            assertTrue(Comparers.equal(cacheCfg, clientCfg));
 
-            assertTrue(Comparers.equal(cacheCfg, cache.getConfiguration()));
+            QueryEntity clientQueryEntity = clientCfg.getQueryEntities()[0];
+            QueryEntity serverQueryEntity = (QueryEntity) serverCfg.getQueryEntities().iterator().next();
+            assertEquals(clientQueryEntity.getIndexes(), serverQueryEntity.getIndexes());
         }
     }
 


### PR DESCRIPTION
Invert the order on the client the same way we invert it on the server. Add a test to check against server-side config.