### PR TITLE
GG-36552 .NET: Fix deadlock on continuous query close

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -180,6 +180,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
 
     /** {@inheritDoc} */
     @Override public void onUpdated(Iterable evts) throws CacheEntryListenerException {
+        // onUpdated is not under listenerLock, so there is no deadlock possibility like in evaluate
         lock.readLock().lock();
 
         try {
@@ -210,9 +211,8 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
         // - close() takes PlatformContinuousQueryImpl.lock, then listenerLock deeper in the call stack;
         // - evaluate() is called under listenerLock up the stack, then takes PlatformContinuousQueryImpl.lock.
         // We cannot ensure the same order of locks in both cases, so we use tryLock() here.
-        if (!lock.readLock().tryLock()) {
+        if (!lock.readLock().tryLock())
             throw closedException();
-        }
 
         try {
             if (ptr == 0)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -192,6 +192,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
         if (javaFilter != null)
             return javaFilter.evaluate(evt);
 
+        // Can't get a lock here, because query is closing (write lock taken on line 216)
         lock.readLock().lock();
 
         try {
@@ -215,6 +216,8 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
         lock.writeLock().lock();
 
         try {
+            // We are inside close, and waiting for the lock in CacheContinuousQueryManager#unregisterListener.
+            // Which, in turn, waits for all evaluate() calls to finish.
             close0();
         }
         finally {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -193,7 +193,9 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
             return javaFilter.evaluate(evt);
 
         // Can't get a lock here, because query is closing (write lock taken on line 216)
-        lock.readLock().lock();
+        if (!lock.readLock().tryLock()) {
+            throw new CacheEntryListenerException("Failed to evaluate the filter because it has been closed.");
+        }
 
         try {
             if (ptr == 0)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -198,7 +198,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
         if (javaFilter != null)
             return javaFilter.evaluate(evt);
 
-        // Make sure that the query is fully initialized.
+        // First, use startLatch to ensure full initialization.
         try {
             startLatch.await();
         } catch (InterruptedException e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -218,6 +218,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
         try {
             // We are inside close, and waiting for the lock in CacheContinuousQueryManager#unregisterListener.
             // Which, in turn, waits for all evaluate() calls to finish.
+            // Read lock is probably taken by GridCacheMapEntry#lockListenerReadLock - TODO double check
             close0();
         }
         finally {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -193,6 +193,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
             return javaFilter.evaluate(evt);
 
         // Can't get a lock here, because query is closing (write lock taken on line 216)
+        // TODO: Failure to acquire a lock here can happen on start too! Need a flag?
         if (!lock.readLock().tryLock()) {
             throw new CacheEntryListenerException("Failed to evaluate the filter because it has been closed.");
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/cache/query/PlatformContinuousQueryImpl.java
@@ -192,7 +192,7 @@ public class PlatformContinuousQueryImpl implements PlatformContinuousQuery {
 
         try {
             if (ptr == 0)
-                throw new CacheEntryListenerException("Failed to notify listener because it has been closed.");
+                return;
 
             PlatformUtils.applyContinuousQueryEvents(platformCtx, ptr, evts);
         }


### PR DESCRIPTION
Deadlock condition:
* Thread 1 processes continuous query events, takes `listenerLock`, then `PlatformContinuousQueryImpl.lock`
* Thread 2 processes continuous query close, takes `PlatformContinuousQueryImpl.lock`, then `listenerLock`

Fix: there is no way to ensure the same order of locks, so we resort to `tryLock` in `PlatformContinuousQueryImpl`.