### PR TITLE
GG-36615 [IGNITE-19359] .NET: Fix 'Affinity keys are not supported' exception

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -142,16 +142,18 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                 }
             };
 
-            var cache = Client.GetOrCreateCache<TestKeyWithAffinity, int>(cacheClientConfiguration);
-            Assert.DoesNotThrow(() => cache.Put(new TestKeyWithAffinity(1, "1"), 1));
-
             var logger = (ListLogger)Client.GetConfiguration().Logger;
+            logger.Clear();
+
+            var cache = Client.GetOrCreateCache<TestKeyWithAffinity, int>(cacheClientConfiguration);
+            cache.Put(new TestKeyWithAffinity(1, "1"), 1);
+            cache.Put(new TestKeyWithAffinity(1, "1"), 1);
 
             Assert.AreEqual(
                 "Failed to compute partition awareness hash code for type " +
                 "`Apache.Ignite.Core.Tests.Client.Cache.TestKeyWithAffinity`. " +
                 "Types with affinity keys and multidimensional arrays are not supported.",
-                logger.Entries.Last().Message);
+                logger.Entries.Single().Message);
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -154,6 +154,32 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         }
 
         [Test]
+        [TestCase(1, 1)]
+        [TestCase(2, 0)]
+        [TestCase(3, 0)]
+        [TestCase(4, 1)]
+        [TestCase(5, 1)]
+        [TestCase(6, 2)]
+        public void CachePut_UserDefinedTypeWithAffinityKeyBinarizable_RequestIsRoutedToPrimaryNode(int key, int gridIdx)
+        {
+            var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)
+            {
+                KeyConfiguration = new List<CacheKeyConfiguration>
+                {
+                    new CacheKeyConfiguration(typeof(TestKeyWithAffinityBinarizable))
+                    {
+                        AffinityKeyFieldName = "id"
+                    }
+                }
+            };
+
+            var cache = Client.GetOrCreateCache<TestKeyWithAffinityBinarizable, int>(cacheClientConfiguration);
+
+            cache.Put(new TestKeyWithAffinityBinarizable(key, Guid.NewGuid().ToString()), key);
+            Assert.AreEqual(gridIdx, GetClientRequestGridIndex("Put"));
+        }
+
+        [Test]
         [TestCase(1, 0)]
         [TestCase(2, 0)]
         [TestCase(3, 0)]
@@ -162,7 +188,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase(6, 1)]
         public void CachePut_UserDefinedTypeWithUserTypeAffinityKey_RequestIsRoutedToPrimaryNode(int key, int gridIdx)
         {
-            // TODO: Test with IBinarizable and custom field names.
             var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)
             {
                 KeyConfiguration = new List<CacheKeyConfiguration>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -162,6 +162,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase(6, 1)]
         public void CachePut_UserDefinedTypeWithUserTypeAffinityKey_RequestIsRoutedToPrimaryNode(int key, int gridIdx)
         {
+            // TODO: Test with IBinarizable and custom field names.
             var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)
             {
                 KeyConfiguration = new List<CacheKeyConfiguration>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -131,7 +131,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         {
             // Note: annotation-based configuration is not supported on Java side.
             // Use manual configuration instead.
-            var cacheClientConfiguration = new CacheClientConfiguration("c_custom_key_aff")
+            var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)
             {
                 KeyConfiguration = new List<CacheKeyConfiguration>
                 {
@@ -147,11 +147,29 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             var cache = Client.GetOrCreateCache<TestKeyWithAffinity, int>(cacheClientConfiguration);
             cache.Put(new TestKeyWithAffinity(1, "1"), 1);
-            cache.Put(new TestKeyWithAffinity(1, "1"), 1);
+            cache.Put(new TestKeyWithAffinity(2, "2"), 2);
 
             Assert.AreEqual(
                 "Failed to compute partition awareness hash code for type " +
-                "`Apache.Ignite.Core.Tests.Client.Cache.TestKeyWithAffinity`. " +
+                "'Apache.Ignite.Core.Tests.Client.Cache.TestKeyWithAffinity'. " +
+                "Types with affinity keys and multidimensional arrays are not supported.",
+                logger.Entries.Single().Message);
+        }
+
+        [Test]
+        public void CachePut_MultidimensionalArrayKey_LogsWarningAndBypassesPartitionAwareness()
+        {
+            var logger = (ListLogger)Client.GetConfiguration().Logger;
+            logger.Clear();
+
+            var cache = Client.GetOrCreateCache<int[,], int>(TestUtils.TestName);
+
+            cache.Put(new int[1, 1], 1);
+            cache.Put(new int[2, 2], 2);
+
+            Assert.AreEqual(
+                "Failed to compute partition awareness hash code for type " +
+                "'System.Int32[,]'. " +
                 "Types with affinity keys and multidimensional arrays are not supported.",
                 logger.Entries.Single().Message);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -28,7 +28,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Client.DataStructures;
-    using Apache.Ignite.Core.Common;
     using NUnit.Framework;
 
     /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -146,6 +146,8 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             logger.Clear();
 
             var cache = Client.GetOrCreateCache<TestKeyWithAffinity, int>(cacheClientConfiguration);
+
+            // Two operations, single warning.
             cache.Put(new TestKeyWithAffinity(1, "1"), 1);
             cache.Put(new TestKeyWithAffinity(2, "2"), 2);
 
@@ -164,6 +166,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             var cache = Client.GetOrCreateCache<int[,], int>(TestUtils.TestName);
 
+            // Two operations, single warning.
             cache.Put(new int[1, 1], 1);
             cache.Put(new int[2, 2], 2);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -135,7 +135,6 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase(6, 2)]
         public void CachePut_UserDefinedTypeWithAffinityKey_RequestIsRoutedToPrimaryNode(int key, int gridIdx)
         {
-            // TODO: Same test with other data types: string, TestKey
             // Note: annotation-based configuration is not supported on Java side.
             // Use manual configuration instead.
             var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)
@@ -151,7 +150,35 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
             var cache = Client.GetOrCreateCache<TestKeyWithAffinity, int>(cacheClientConfiguration);
 
-            cache.Put(new TestKeyWithAffinity(key, "1"), key);
+            cache.Put(new TestKeyWithAffinity(key, Guid.NewGuid().ToString()), key);
+            Assert.AreEqual(gridIdx, GetClientRequestGridIndex("Put"));
+        }
+
+        [Test]
+        [TestCase(1, 0)]
+        [TestCase(2, 0)]
+        [TestCase(3, 0)]
+        [TestCase(4, 2)]
+        [TestCase(5, 2)]
+        [TestCase(6, 1)]
+        public void CachePut_UserDefinedTypeWithUserTypeAffinityKey_RequestIsRoutedToPrimaryNode(int key, int gridIdx)
+        {
+            var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)
+            {
+                KeyConfiguration = new List<CacheKeyConfiguration>
+                {
+                    new CacheKeyConfiguration(typeof(TestKeyWithUserObjectAffinity))
+                    {
+                        AffinityKeyFieldName = "_key"
+                    }
+                }
+            };
+
+            var cache = Client.GetOrCreateCache<TestKeyWithUserObjectAffinity, int>(cacheClientConfiguration);
+
+            var keyObj = new TestKeyWithUserObjectAffinity(new TestKey(key, key.ToString()), Guid.NewGuid().ToString());
+            cache.Put(keyObj, key);
+
             Assert.AreEqual(gridIdx, GetClientRequestGridIndex("Put"));
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/PartitionAwarenessTest.cs
@@ -135,6 +135,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         [TestCase(6, 2)]
         public void CachePut_UserDefinedTypeWithAffinityKey_RequestIsRoutedToPrimaryNode(int key, int gridIdx)
         {
+            // TODO: Same test with other data types: string, TestKey
             // Note: annotation-based configuration is not supported on Java side.
             // Use manual configuration instead.
             var cacheClientConfiguration = new CacheClientConfiguration(TestUtils.TestName)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithAffinityBinarizable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithAffinityBinarizable.cs
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Cache
+{
+    using Apache.Ignite.Core.Binary;
+
+    public sealed class TestKeyWithAffinityBinarizable : IBinarizable
+    {
+        private int _i;
+
+        private string _s;
+
+        public TestKeyWithAffinityBinarizable(int i, string s)
+        {
+            _i = i;
+            _s = s;
+        }
+
+        private bool Equals(TestKeyWithAffinityBinarizable other)
+        {
+            return _i == other._i && string.Equals(_s, other._s);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((TestKeyWithAffinityBinarizable) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                // ReSharper disable NonReadonlyMemberInGetHashCode (effectively readonly).
+                return (_i * 397) ^ (_s != null ? _s.GetHashCode() : 0);
+            }
+        }
+
+        public void WriteBinary(IBinaryWriter writer)
+        {
+            writer.WriteInt("id", _i);
+            writer.WriteString("str", _s);
+        }
+
+        public void ReadBinary(IBinaryReader reader)
+        {
+            _i = reader.ReadInt("id");
+            _s = reader.ReadString("str");
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithAffinityBinarizable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithAffinityBinarizable.cs
@@ -54,14 +54,14 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
         public void WriteBinary(IBinaryWriter writer)
         {
-            writer.WriteInt("id", _i);
             writer.WriteString("str", _s);
+            writer.WriteInt("id", _i);
         }
 
         public void ReadBinary(IBinaryReader reader)
         {
-            _i = reader.ReadInt("id");
             _s = reader.ReadString("str");
+            _i = reader.ReadInt("id");
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithAffinityBinarizable.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithAffinityBinarizable.cs
@@ -24,10 +24,13 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 
         private string _s;
 
-        public TestKeyWithAffinityBinarizable(int i, string s)
+        private readonly bool _skipKey;
+
+        public TestKeyWithAffinityBinarizable(int i, string s, bool skipKey = false)
         {
             _i = i;
             _s = s;
+            _skipKey = skipKey;
         }
 
         private bool Equals(TestKeyWithAffinityBinarizable other)
@@ -55,7 +58,11 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         public void WriteBinary(IBinaryWriter writer)
         {
             writer.WriteString("str", _s);
-            writer.WriteInt("id", _i);
+
+            if (!_skipKey)
+            {
+                writer.WriteInt("id", _i);
+            }
         }
 
         public void ReadBinary(IBinaryReader reader)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithUserObjectAffinity.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/TestKeyWithUserObjectAffinity.cs
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Client.Cache
+{
+    using Apache.Ignite.Core.Cache.Affinity;
+
+    public sealed class TestKeyWithUserObjectAffinity
+    {
+        [AffinityKeyMapped]
+        private readonly TestKey _key;
+
+        private readonly string _s;
+
+        public TestKeyWithUserObjectAffinity(TestKey key, string s)
+        {
+            _key = key;
+            _s = s;
+        }
+
+        private bool Equals(TestKeyWithUserObjectAffinity other)
+        {
+            return _key.Equals(other._key) && string.Equals(_s, other._s);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((TestKeyWithUserObjectAffinity) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (_key.GetHashCode() * 397) ^ (_s != null ? _s.GetHashCode() : 0);
+            }
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -222,6 +222,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                 {
                     if (affinityKeyFieldIds != null && affinityKeyFieldIds.ContainsKey(header.TypeId))
                     {
+                        // TODO: Return null instead of throwing exception; log warning once for every problematic type.
                         var err = string.Format(
                             "Affinity keys are not supported. Object '{0}' has an affinity key.", obj);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -241,6 +241,7 @@ namespace Apache.Ignite.Core.Impl.Binary
                 };
 
                 writer.Write(val);
+                marsh.FinishMarshal(writer);
 
                 if (hashCode != null && !hasAffinityKey)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -265,7 +265,10 @@ namespace Apache.Ignite.Core.Impl.Binary
                     }
 
                     stream.Seek(affKeyOffset.Value, SeekOrigin.Begin);
-                    var affKey = marsh.Unmarshal<object>(stream, BinaryMode.KeepBinary);
+
+                    // Use ForceBinary to avoid deserializing the object. Only primitives will be deserialized.
+                    // For complex objects we can access BinaryObject hash code directly.
+                    var affKey = marsh.Unmarshal<object>(stream, BinaryMode.ForceBinary);
 
                     return GetHashCode(affKey, marsh, affKeyFieldIds);
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -228,12 +228,13 @@ namespace Apache.Ignite.Core.Impl.Binary
                 int? hashCode = null;
                 bool hasAffinityKey = false;
 
-                writer.OnObjectWritten += (header, obj) =>
+                writer.OnObjectWritten += (header, desc, schema) =>
                 {
                     // TODO: We need
                     // 1. Affinity key field id (get from map)
                     // 2. Schema to get field position
                     // 3. Then just seek the stream and do _marsh.Unmarshal<T>(stream, BinaryMode.ForceBinary, builder)
+                    header.SchemaOffset
 
                     if (affinityKeyFieldIds != null && affinityKeyFieldIds.ContainsKey(header.TypeId))
                     {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryHashCodeUtils.cs
@@ -230,6 +230,11 @@ namespace Apache.Ignite.Core.Impl.Binary
 
                 writer.OnObjectWritten += (header, obj) =>
                 {
+                    // TODO: We need
+                    // 1. Affinity key field id (get from map)
+                    // 2. Schema to get field position
+                    // 3. Then just seek the stream and do _marsh.Unmarshal<T>(stream, BinaryMode.ForceBinary, builder)
+
                     if (affinityKeyFieldIds != null && affinityKeyFieldIds.ContainsKey(header.TypeId))
                     {
                         hasAffinityKey = true;

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
@@ -120,19 +120,6 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
         }
 
-        /// <summary>
-        /// Gets field value by id.
-        /// </summary>
-        /// <param name="fieldId">Field id.</param>
-        /// <returns>Field value.</returns>
-        public T GetField<T>(int fieldId)
-        {
-            var desc = _marsh.GetDescriptor(true, _header.TypeId);
-            InitializeFields(desc);
-
-            return GetField<T>(_fields[fieldId], null);
-        }
-
         /** <inheritdoc /> */
         public T Deserialize<T>()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObject.cs
@@ -120,6 +120,19 @@ namespace Apache.Ignite.Core.Impl.Binary
             }
         }
 
+        /// <summary>
+        /// Gets field value by id.
+        /// </summary>
+        /// <param name="fieldId">Field id.</param>
+        /// <returns>Field value.</returns>
+        public T GetField<T>(int fieldId)
+        {
+            var desc = _marsh.GetDescriptor(true, _header.TypeId);
+            InitializeFields(desc);
+
+            return GetField<T>(_fields[fieldId], null);
+        }
+
         /** <inheritdoc /> */
         public T Deserialize<T>()
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectSchemaHolder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectSchemaHolder.cs
@@ -119,26 +119,5 @@ namespace Apache.Ignite.Core.Impl.Binary
 
             return result;
         }
-
-        /// <summary>
-        /// Gets the schema.
-        /// </summary>
-        /// <param name="schemaOffset">The schema offset.</param>
-        /// <returns>Current schema as a dictionary.</returns>
-        public Dictionary<int, int> GetFullSchema(int schemaOffset)
-        {
-            var size = _idx - schemaOffset;
-
-            var result = new Dictionary<int, int>(size);
-
-            for (int i = schemaOffset; i < _idx; i++)
-            {
-                var fld = _fields[i];
-
-                result[fld.Id] = fld.Offset;
-            }
-
-            return result;
-        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectSchemaHolder.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryObjectSchemaHolder.cs
@@ -119,5 +119,22 @@ namespace Apache.Ignite.Core.Impl.Binary
 
             return result;
         }
+
+        /// <summary>
+        /// Gets the field offset.
+        /// </summary>
+        /// <param name="schemaOffset">Schema offset.</param>
+        /// <param name="fieldId">Field id.</param>
+        /// <returns>Field offset.</returns>
+        public int GetFieldOffset(int schemaOffset, int fieldId)
+        {
+            for (int i = schemaOffset; i < _idx; i++)
+            {
+                if (_fields[i].Id == fieldId)
+                    return _fields[i].Offset;
+            }
+
+            return -1;
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -1262,7 +1262,6 @@ namespace Apache.Ignite.Core.Impl.Binary
                     flags |= BinaryObjectHeader.Flag.CompactFooter;
 
                 var hasSchema = _schema.WriteSchema(_stream, schemaIdx, out schemaId, ref flags);
-                int[] schema = null;
 
                 if (hasSchema)
                 {
@@ -1273,11 +1272,9 @@ namespace Apache.Ignite.Core.Impl.Binary
                         _stream.WriteInt(_frame.RawPos - pos); // raw offset is in the last 4 bytes
 
                     // Update schema in type descriptor
-                    schema = desc.Schema.Get(schemaId);
-                    if (schema == null)
+                    if (desc.Schema.Get(schemaId) == null)
                     {
-                        schema = _schema.GetSchema(schemaIdx);
-                        desc.Schema.Add(schemaId, schema);
+                        desc.Schema.Add(schemaId, _schema.GetSchema(schemaIdx));
                         isNewSchema = true;
                     }
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Binary/BinaryWriter.cs
@@ -70,7 +70,7 @@ namespace Apache.Ignite.Core.Impl.Binary
         /// <summary>
         /// Invoked when binary object writing finishes.
         /// </summary>
-        internal event Action<BinaryObjectHeader, IBinaryTypeDescriptor, int[]> OnObjectWritten;
+        internal event Action<BinaryObjectHeader, BinaryObjectSchemaHolder, int> OnObjectWritten;
 
         /// <summary>
         /// Write named boolean value.
@@ -1297,10 +1297,7 @@ namespace Apache.Ignite.Core.Impl.Binary
 
                 BinaryObjectHeader.Write(header, _stream, pos);
 
-                if (OnObjectWritten != null)
-                {
-                    OnObjectWritten(header, desc, schema);
-                }
+                OnObjectWritten?.Invoke(header, _schema, schemaIdx);
 
                 Stream.Seek(pos + len, SeekOrigin.Begin); // Seek to the end
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -821,7 +821,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 {
                     // Log warning only once for the given type.
                     _logger.Warn(
-                        "Failed to compute partition awareness hash code for type `{0}`. " +
+                        "Failed to compute partition awareness hash code for type '{0}'. " +
                         "Types with affinity keys and multidimensional arrays are not supported.",
                         keyType);
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/ClientFailoverSocket.cs
@@ -820,10 +820,7 @@ namespace Apache.Ignite.Core.Impl.Client
                 if (_partitionAwarenessUnsupportedKeyTypes.TryAdd(keyType, null))
                 {
                     // Log warning only once for the given type.
-                    _logger.Warn(
-                        "Failed to compute partition awareness hash code for type '{0}'. " +
-                        "Types with affinity keys and multidimensional arrays are not supported.",
-                        keyType);
+                    _logger.Warn("Failed to compute partition awareness hash code for type '{0}'", keyType);
                 }
 
                 return null;


### PR DESCRIPTION
1. Support hash calculation for affinity keys.
2. When partition awareness hash still can't be computed, do not throw an exception; log a warning (once per type) and use the default connection.