### PR TITLE
GG-36245 Fixed startDate month (should be January instead of February)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -681,7 +681,7 @@
                                                 if (digitVer != null)
                                                 {
                                                     // Date of the last major release
-                                                    var startDate = new Date(new Date().getFullYear(),1,1);
+                                                    var startDate = new Date(new Date().getFullYear(),0,1);
 
                                                     // Number of hours since the last major release
                                                     var buildNum = Math.round((new Date() - startDate)/(3600*1000));


### PR DESCRIPTION
In the past, "startDate" was a constant and was equal to 2015. But this required changes because the calculated version was greater than 65536.
After some changes the starting point became is the beginning of the current year, but a mistake was made here and February is indicated as the first month of the year, instead of January.