### PR TITLE
GG-36879 Dynamic column re-creation ignores modified column constraints.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryField.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryField.java
@@ -27,6 +27,12 @@ public class QueryField implements Serializable {
     /** */
     private static final long serialVersionUID = 0L;
 
+    /** Undefined precision. */
+    public static final int UNDEFINED_PRECISION = -1;
+
+    /** Undefined scale. */
+    public static final int UNDEFINED_SCALE = -1;
+
     /** Field name. */
     private final String name;
 
@@ -51,7 +57,7 @@ public class QueryField implements Serializable {
      * @param nullable Nullable flag.
      */
     public QueryField(String name, String typeName, boolean nullable) {
-        this(name, typeName, nullable, null, -1, -1);
+        this(name, typeName, nullable, null, UNDEFINED_PRECISION, UNDEFINED_SCALE);
     }
 
     /**
@@ -61,7 +67,7 @@ public class QueryField implements Serializable {
      * @param dfltValue Default value.
      */
     public QueryField(String name, String typeName, boolean nullable, Object dfltValue) {
-        this(name, typeName, nullable, dfltValue, -1, -1);
+        this(name, typeName, nullable, dfltValue, UNDEFINED_PRECISION, UNDEFINED_SCALE);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QuerySchema.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QuerySchema.java
@@ -280,6 +280,14 @@ public class QuerySchema implements Serializable {
                 for (QueryField field : op0.columns()) {
                     target.getFields().put(field.name(), field.typeName());
 
+                    if (field.precision() != -1) {
+                        target.getFieldsPrecision().put(field.name(), field.precision());
+                    }
+
+                    if (field.scale() != -1) {
+                        target.getFieldsScale().put(field.name(), field.scale());
+                    }
+
                     if (!field.isNullable()) {
                         if (!(target instanceof QueryEntityEx)) {
                             target = new QueryEntityEx(target);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QuerySchema.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QuerySchema.java
@@ -280,11 +280,11 @@ public class QuerySchema implements Serializable {
                 for (QueryField field : op0.columns()) {
                     target.getFields().put(field.name(), field.typeName());
 
-                    if (field.precision() != -1) {
+                    if (field.precision() != QueryField.UNDEFINED_PRECISION) {
                         target.getFieldsPrecision().put(field.name(), field.precision());
                     }
 
-                    if (field.scale() != -1) {
+                    if (field.scale() != QueryField.UNDEFINED_SCALE) {
                         target.getFieldsScale().put(field.name(), field.scale());
                     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -1671,7 +1671,23 @@ public class QueryUtils {
      * @return {@code true} if the field is removed. Otherwise returns {@code false}.
      */
     public static boolean removeField(QueryEntity entity, String alias) {
-        return entity.getFields().remove(fieldNameByAlias(entity, alias)) != null;
+        String fieldName = fieldNameByAlias(entity, alias);
+
+        if (entity.getFields().remove(fieldName) != null) {
+            Set<String> notNUllFields = entity.getNotNullFields();
+
+            if (notNUllFields != null) {
+                notNUllFields.remove(fieldName);
+            }
+
+            entity.getDefaultFieldValues().remove(fieldName);
+            entity.getFieldsPrecision().remove(fieldName);
+            entity.getFieldsScale().remove(fieldName);
+
+            return true;
+        }
+
+        return false;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -1674,10 +1674,10 @@ public class QueryUtils {
         String fieldName = fieldNameByAlias(entity, alias);
 
         if (entity.getFields().remove(fieldName) != null) {
-            Set<String> notNUllFields = entity.getNotNullFields();
+            Set<String> notNullFields = entity.getNotNullFields();
 
-            if (notNUllFields != null) {
-                notNUllFields.remove(fieldName);
+            if (notNullFields != null) {
+                notNullFields.remove(fieldName);
             }
 
             entity.getDefaultFieldValues().remove(fieldName);

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
@@ -1117,12 +1117,12 @@ public class CommandProcessor {
                 dfltValues.put(e.getKey(), dfltVal);
 
             int precisionVal = convertH2ColumnPrecision(col.getType());
-            if (precisionVal != -1) {
+            if (precisionVal != QueryField.UNDEFINED_PRECISION) {
                 precision.put(e.getKey(), precisionVal);
             }
 
             int scaleVal = convertH2ColumnScale(col.getType());
-            if (scaleVal != -1) {
+            if (scaleVal != QueryField.UNDEFINED_SCALE) {
                 scale.put(e.getKey(), scaleVal);
             }
         }
@@ -1216,7 +1216,7 @@ public class CommandProcessor {
                 return (int)type.getPrecision();
         }
 
-        return -1;
+        return QueryField.UNDEFINED_PRECISION;
     }
 
     private static int convertH2ColumnScale(TypeInfo type) {
@@ -1224,7 +1224,7 @@ public class CommandProcessor {
             type.getScale() < H2Utils.DECIMAL_DEFAULT_SCALE)
             return type.getScale();
 
-        return -1;
+        return QueryField.UNDEFINED_SCALE;
     }
 
     /**

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
@@ -35,7 +35,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteCluster;
 import org.apache.ignite.IgniteDataStreamer;
@@ -132,6 +131,7 @@ import org.gridgain.internal.h2.command.ddl.DropTable;
 import org.gridgain.internal.h2.command.dml.NoOperation;
 import org.gridgain.internal.h2.table.Column;
 import org.gridgain.internal.h2.value.DataType;
+import org.gridgain.internal.h2.value.TypeInfo;
 import org.gridgain.internal.h2.value.Value;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -889,30 +889,14 @@ public class CommandProcessor {
                             }
                         }
 
-                        int precision = -1;
-                        int scale = -1;
-
-                        if (col.column().getType().getValueType() == Value.DECIMAL) {
-                            if (col.precision() < H2Utils.DECIMAL_DEFAULT_PRECISION) {
-                                precision = col.precision();
-                            }
-
-                            if (col.scale() < H2Utils.DECIMAL_DEFAULT_SCALE) {
-                                scale = col.scale();
-                            }
-                        }
-
-                        if ((col.column().getType().getValueType() == Value.STRING ||
-                            col.column().getType().getValueType() == Value.STRING_FIXED ||
-                            col.column().getType().getValueType() == Value.STRING_IGNORECASE) &&
-                            col.precision() < H2Utils.STRING_DEFAULT_PRECISION) {
-                            precision = col.precision();
-                        }
-
-                        QueryField field = new QueryField(col.columnName(),
+                        QueryField field = new QueryField(
+                            col.columnName(),
                             getTypeClassName(col),
-                            col.column().isNullable(), col.defaultValue(),
-                            precision, scale);
+                            col.column().isNullable(),
+                            col.defaultValue(),
+                            convertH2ColumnPrecision(col.column().getType()),
+                            convertH2ColumnScale(col.column().getType())
+                        );
 
                         cols.add(field);
 
@@ -1132,19 +1116,15 @@ public class CommandProcessor {
             if (dfltVal != null)
                 dfltValues.put(e.getKey(), dfltVal);
 
-            if (col.getType().getValueType() == Value.DECIMAL) {
-                if (col.getType().getPrecision() < H2Utils.DECIMAL_DEFAULT_PRECISION)
-                    precision.put(e.getKey(), (int)col.getType().getPrecision());
-
-                if (col.getType().getScale() < H2Utils.DECIMAL_DEFAULT_SCALE)
-                    scale.put(e.getKey(), col.getType().getScale());
+            int precisionVal = convertH2ColumnPrecision(col.getType());
+            if (precisionVal != -1) {
+                precision.put(e.getKey(), precisionVal);
             }
 
-            if (col.getType().getValueType() == Value.STRING ||
-                col.getType().getValueType() == Value.STRING_FIXED ||
-                col.getType().getValueType() == Value.STRING_IGNORECASE)
-                if (col.getType().getPrecision() < H2Utils.STRING_DEFAULT_PRECISION)
-                    precision.put(e.getKey(), (int)col.getType().getPrecision());
+            int scaleVal = convertH2ColumnScale(col.getType());
+            if (scaleVal != -1) {
+                scale.put(e.getKey(), scaleVal);
+            }
         }
 
         if (!F.isEmpty(dfltValues))
@@ -1222,6 +1202,29 @@ public class CommandProcessor {
             res.setAffinityKeyInlineSize(createTbl.affinityKeyInlineSize());
 
         return res;
+    }
+
+    private static int convertH2ColumnPrecision(TypeInfo type) {
+        if (type.getValueType() == Value.DECIMAL) {
+            if (type.getPrecision() < H2Utils.DECIMAL_DEFAULT_PRECISION)
+                return (int)type.getPrecision();
+        }
+        else if (type.getValueType() == Value.STRING ||
+            type.getValueType() == Value.STRING_FIXED ||
+            type.getValueType() == Value.STRING_IGNORECASE) {
+            if (type.getPrecision() < H2Utils.STRING_DEFAULT_PRECISION)
+                return (int)type.getPrecision();
+        }
+
+        return -1;
+    }
+
+    private static int convertH2ColumnScale(TypeInfo type) {
+        if (type.getValueType() == Value.DECIMAL &&
+            type.getScale() < H2Utils.DECIMAL_DEFAULT_SCALE)
+            return type.getScale();
+
+        return -1;
     }
 
     /**

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/CommandProcessor.java
@@ -889,10 +889,30 @@ public class CommandProcessor {
                             }
                         }
 
+                        int precision = -1;
+                        int scale = -1;
+
+                        if (col.column().getType().getValueType() == Value.DECIMAL) {
+                            if (col.precision() < H2Utils.DECIMAL_DEFAULT_PRECISION) {
+                                precision = col.precision();
+                            }
+
+                            if (col.scale() < H2Utils.DECIMAL_DEFAULT_SCALE) {
+                                scale = col.scale();
+                            }
+                        }
+
+                        if ((col.column().getType().getValueType() == Value.STRING ||
+                            col.column().getType().getValueType() == Value.STRING_FIXED ||
+                            col.column().getType().getValueType() == Value.STRING_IGNORECASE) &&
+                            col.precision() < H2Utils.STRING_DEFAULT_PRECISION) {
+                            precision = col.precision();
+                        }
+
                         QueryField field = new QueryField(col.columnName(),
                             getTypeClassName(col),
                             col.column().isNullable(), col.defaultValue(),
-                            col.precision(), col.scale());
+                            precision, scale);
 
                         cols.add(field);
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
@@ -17,6 +17,11 @@
 package org.apache.ignite.internal.processors.database;
 
 import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCheckedException;
@@ -30,10 +35,8 @@ import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.IgniteEx;
-import org.apache.ignite.internal.processors.cache.DynamicCacheDescriptor;
 import org.apache.ignite.internal.processors.cache.persistence.GridCacheDatabaseSharedManager;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointListener;
-import org.apache.ignite.internal.processors.query.QuerySchema;
 import org.apache.ignite.internal.processors.query.QueryUtils;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.testframework.junits.WithSystemProperty;
@@ -150,11 +153,11 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
 
         CountDownLatch cnt = checkpointLatch(node);
 
-        assertEquals(0, indexCnt(node, STATIC_CACHE_NAME));
+        checkOriginalSchema(node, STATIC_CACHE_NAME, Collections.emptyList());
 
         makeDynamicSchemaChanges(node, STATIC_CACHE_NAME);
 
-        checkDynamicSchemaChanges(node, STATIC_CACHE_NAME);
+        checkModifiedSchema(node, STATIC_CACHE_NAME);
 
         cnt.await();
 
@@ -166,7 +169,7 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
 
         node.active(true);
 
-        checkDynamicSchemaChanges(node, STATIC_CACHE_NAME);
+        checkModifiedSchema(node, STATIC_CACHE_NAME);
     }
 
     /**
@@ -184,14 +187,21 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
 
         CountDownLatch cnt = checkpointLatch(node);
 
-        node.context().query().querySqlFields(
-            new SqlFieldsQuery("create table \"Person\" (\"id\" int primary key, \"name\" varchar)"), false);
+        runSql("create table \"Person\" (" +
+                "\"id\" int primary key," +
+                "\"name\" varchar," +
+                "\"city\" int," +
+                "\"str1\" varchar," +
+                "\"str2\" char(10) not null default '1'," +
+                "\"num1\" decimal," +
+                "\"num2\" decimal(10, 2) not null default 1)"
+            , node, QueryUtils.DFLT_SCHEMA);
 
-        assertEquals(0, indexCnt(node, SQL_CACHE_NAME));
+        checkOriginalSchema(node, SQL_CACHE_NAME, F.asList("str2", "num2"));
 
         makeDynamicSchemaChanges(node, QueryUtils.DFLT_SCHEMA);
 
-        checkDynamicSchemaChanges(node, SQL_CACHE_NAME);
+        checkModifiedSchema(node, SQL_CACHE_NAME);
 
         cnt.await();
 
@@ -201,25 +211,9 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
 
         node.active(true);
 
-        checkDynamicSchemaChanges(node, SQL_CACHE_NAME);
+        checkModifiedSchema(node, SQL_CACHE_NAME);
 
         node.context().query().querySqlFields(new SqlFieldsQuery("drop table \"Person\""), false).getAll();
-    }
-
-    /** */
-    private int indexCnt(IgniteEx node, String cacheName) {
-        DynamicCacheDescriptor desc = node.context().cache().cacheDescriptor(cacheName);
-
-        int cnt = 0;
-
-        if (desc != null) {
-            QuerySchema schema = desc.schema();
-            if (schema != null) {
-                for (QueryEntity entity : schema.entities())
-                    cnt += entity.getIndexes().size();
-            }
-        }
-        return cnt;
     }
 
     /**
@@ -254,18 +248,51 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
      * @param schema Schema name.
      */
     private void makeDynamicSchemaChanges(IgniteEx node, String schema) {
-        node.context().query().querySqlFields(
-            new SqlFieldsQuery("create index \"my_idx\" on \"Person\" (\"id\", \"name\")").setSchema(schema), false)
-                .getAll();
+        runSql("create index \"my_idx\" on \"Person\" (\"id\", \"name\")", node, schema);
 
-        node.context().query().querySqlFields(
-            new SqlFieldsQuery("alter table \"Person\" add column (\"age\" int, \"city\" char, " +
-                "\"rate\" decimal not null, \"grade\" decimal(3, 1), \"alias\" varchar(10))")
-            .setSchema(schema), false).getAll();
+        runSql("alter table \"Person\" drop column " +
+            "\"city\", \"str1\", \"str2\", \"num1\", \"num2\"", node, schema);
 
-        node.context().query().querySqlFields(
-            new SqlFieldsQuery("alter table \"Person\" drop column \"city\"").setSchema(schema), false)
-            .getAll();
+        runSql("alter table \"Person\" add column (" +
+                "\"rate\" decimal(10, 2) not null," +
+                "\"str1\" char(10) not null," +
+                "\"str2\" varchar," +
+                "\"num1\" decimal(10, 2) not null," +
+                "\"num2\" decimal)", node, schema);
+    }
+
+    /**
+     * Executes SQL query.
+     *
+     * @param sql SQL query.
+     * @param node Ignite node.
+     * @param schema Target schema.
+     * @return Query execution result.
+     */
+    private List<List<?>> runSql(String sql, IgniteEx node, String schema) {
+        return node.context().query().querySqlFields(new SqlFieldsQuery(sql).setSchema(schema), false).getAll();
+    }
+
+    /**
+     * Check original schema.
+     *
+     * @param node Node.
+     * @param cacheName Cache name.
+     * @param expDfltFields List of fields that have a default value.
+     */
+    private void checkOriginalSchema(IgniteEx node, String cacheName, List<String> expDfltFields) {
+        Collection<QueryEntity> entities = node.context().cache().cacheDescriptor(cacheName).schema().entities();
+        assertEquals(1, entities.size());
+
+        QueryEntity e = F.first(entities);
+
+        assertEquals(0, e.getIndexes().size());
+
+        assertEqualsUnordered(F.asList("id", "name", "city", "str1", "str2", "num1", "num2"), e.getFields().keySet());
+        assertEqualsUnordered(F.asList("str2", "num2"), e.getNotNullFields());
+        assertEqualsUnordered(F.asList("num2"), e.getFieldsScale().keySet());
+        assertEqualsUnordered(F.asList("str2", "num2"), e.getFieldsPrecision().keySet());
+        assertEqualsUnordered(expDfltFields, e.getDefaultFieldValues().keySet());
     }
 
     /**
@@ -273,21 +300,29 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
      * @param node Node.
      * @param cacheName Cache name.
      */
-    private void checkDynamicSchemaChanges(IgniteEx node, String cacheName) {
-        assertEquals(1, indexCnt(node, cacheName));
+    private void checkModifiedSchema(IgniteEx node, String cacheName) {
+        Collection<QueryEntity> entities = node.context().cache().cacheDescriptor(cacheName).schema().entities();
+        assertEquals(1, entities.size());
 
-        DynamicCacheDescriptor desc = node.context().cache().cacheDescriptor(cacheName);
+        QueryEntity e = F.first(entities);
 
-        QuerySchema schema = desc.schema();
+        assertEquals(1, e.getIndexes().size());
+        assertEquals(0, e.getDefaultFieldValues().size());
 
-        assertEquals(1, schema.entities().size());
+        assertEqualsUnordered(F.asList("id", "name", "rate", "str1", "str2", "num1", "num2"), e.getFields().keySet());
+        assertEqualsUnordered(F.asList("rate", "str1", "num1"), e.getNotNullFields());
+        assertEqualsUnordered(F.asList("rate", "num1"), e.getFieldsScale().keySet());
+        assertEqualsUnordered(F.asList("rate", "str1", "num1"), e.getFieldsPrecision().keySet());
+    }
 
-        QueryEntity entity = F.first(schema.entities());
+    /**
+     * Compares collections without considering the order of the elements.
+     */
+    private void assertEqualsUnordered(List<String> expected, Set<String> actual) {
+        String msg = "expected=" + expected + ", actual=" + actual;
 
-        assertEquals(6, entity.getFields().size());
-        assertEquals(1, entity.getNotNullFields().size());
-        assertEquals(1, entity.getFieldsScale().size());
-        assertEquals(2, entity.getFieldsPrecision().size());
+        assertEquals(msg, expected.size(), actual.size());
+        assertTrue(msg, actual.containsAll(expected));
     }
 
     /**
@@ -316,27 +351,24 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
         @QuerySqlField
         protected String name;
 
-        /** {@inheritDoc} */
-        @Override public boolean equals(Object o) {
-            if (this == o)
-                return true;
+        /** */
+        @QuerySqlField
+        protected int city;
 
-            if (o == null || getClass() != o.getClass())
-                return false;
+        /** */
+        @QuerySqlField
+        protected String str1;
 
-            IgnitePersistentStoreSchemaLoadTest.Person person = (IgnitePersistentStoreSchemaLoadTest.Person) o;
+        /** */
+        @QuerySqlField(precision = 10, notNull = true)
+        protected String str2;
 
-            return id == person.id && (name != null ? name.equals(person.name) : person.name == null);
+        /** */
+        @QuerySqlField
+        protected BigDecimal num1;
 
-        }
-
-        /** {@inheritDoc} */
-        @Override public int hashCode() {
-            int res = id;
-
-            res = 31 * res + (name != null ? name.hashCode() : 0);
-
-            return res;
-        }
+        /** */
+        @QuerySqlField(precision = 10, scale = 2, notNull = true)
+        protected BigDecimal num2;
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
@@ -18,7 +18,6 @@ package org.apache.ignite.internal.processors.database;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -195,11 +194,7 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
             "\"str1\" varchar," +
             "\"str2\" char(10) not null default '1'," +
             "\"num1\" decimal," +
-            "\"num2\" decimal(10, 2) not null default 1," +
-            "\"time1\" timestamp," +
-            "\"time2\" timestamp(10, 2) not null," +
-            "\"float1\" float," +
-            "\"float2\" float(10) not null)", node, QueryUtils.DFLT_SCHEMA);
+            "\"num2\" decimal(10, 2) not null default 1)", node, QueryUtils.DFLT_SCHEMA);
 
         checkOriginalSchema(node, SQL_CACHE_NAME, F.asList("str2", "num2"));
 
@@ -254,19 +249,15 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
     private void makeDynamicSchemaChanges(IgniteEx node, String schema) {
         runSql("create index \"my_idx\" on \"Person\" (\"id\", \"name\")", node, schema);
 
-        runSql("alter table \"Person\" drop column \"city\", \"str1\", \"str2\", \"num1\", " +
-            "\"num2\", \"time1\", \"time2\", \"float1\", \"float2\"", node, schema);
+        runSql("alter table \"Person\" drop column " +
+            "\"city\", \"str1\", \"str2\", \"num1\", \"num2\"", node, schema);
 
         runSql("alter table \"Person\" add column (" +
-            "\"rate\" decimal(10, 2) not null," +
-            "\"str1\" char(10) not null," +
-            "\"str2\" varchar," +
-            "\"num1\" decimal(10, 2) not null," +
-            "\"num2\" decimal," +
-            "\"time1\" timestamp(10, 2) not null," +
-            "\"time2\" timestamp," +
-            "\"float1\" float(10) not null," +
-            "\"float2\" float)", node, schema);
+                "\"rate\" decimal(10, 2) not null," +
+                "\"str1\" char(10) not null," +
+                "\"str2\" varchar," +
+                "\"num1\" decimal(10, 2) not null," +
+                "\"num2\" decimal)", node, schema);
     }
 
     /**
@@ -296,9 +287,8 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
 
         assertEquals(0, e.getIndexes().size());
 
-        assertEqualsUnordered(F.asList("id", "name", "city", "str1", "str2",
-            "num1", "num2", "time1", "time2", "float1", "float2"), e.getFields().keySet());
-        assertEqualsUnordered(F.asList("str2", "num2", "time2", "float2"), e.getNotNullFields());
+        assertEqualsUnordered(F.asList("id", "name", "city", "str1", "str2", "num1", "num2"), e.getFields().keySet());
+        assertEqualsUnordered(F.asList("str2", "num2"), e.getNotNullFields());
         assertEqualsUnordered(F.asList("num2"), e.getFieldsScale().keySet());
         assertEqualsUnordered(F.asList("str2", "num2"), e.getFieldsPrecision().keySet());
         assertEqualsUnordered(expDfltFields, e.getDefaultFieldValues().keySet());
@@ -318,9 +308,8 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
         assertEquals(1, e.getIndexes().size());
         assertEquals(0, e.getDefaultFieldValues().size());
 
-        assertEqualsUnordered(F.asList("id", "name", "rate", "str1", "str2",
-            "num1", "num2", "time1", "time2", "float1", "float2"), e.getFields().keySet());
-        assertEqualsUnordered(F.asList("rate", "str1", "num1", "time1", "float1"), e.getNotNullFields());
+        assertEqualsUnordered(F.asList("id", "name", "rate", "str1", "str2", "num1", "num2"), e.getFields().keySet());
+        assertEqualsUnordered(F.asList("rate", "str1", "num1"), e.getNotNullFields());
         assertEqualsUnordered(F.asList("rate", "num1"), e.getFieldsScale().keySet());
         assertEqualsUnordered(F.asList("rate", "str1", "num1"), e.getFieldsPrecision().keySet());
     }
@@ -380,21 +369,5 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
         /** */
         @QuerySqlField(precision = 10, scale = 2, notNull = true)
         protected BigDecimal num2;
-
-        /** */
-        @QuerySqlField
-        protected Timestamp time1;
-
-        /** */
-        @QuerySqlField(notNull = true)
-        protected Timestamp time2;
-
-        /** */
-        @QuerySqlField
-        protected Float float1;
-
-        /** */
-        @QuerySqlField(notNull = true)
-        protected Float float2;
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
@@ -18,6 +18,7 @@ package org.apache.ignite.internal.processors.database;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -194,7 +195,11 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
             "\"str1\" varchar," +
             "\"str2\" char(10) not null default '1'," +
             "\"num1\" decimal," +
-            "\"num2\" decimal(10, 2) not null default 1)", node, QueryUtils.DFLT_SCHEMA);
+            "\"num2\" decimal(10, 2) not null default 1," +
+            "\"time1\" timestamp," +
+            "\"time2\" timestamp(10, 2) not null," +
+            "\"float1\" float," +
+            "\"float2\" float(10) not null)", node, QueryUtils.DFLT_SCHEMA);
 
         checkOriginalSchema(node, SQL_CACHE_NAME, F.asList("str2", "num2"));
 
@@ -249,15 +254,19 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
     private void makeDynamicSchemaChanges(IgniteEx node, String schema) {
         runSql("create index \"my_idx\" on \"Person\" (\"id\", \"name\")", node, schema);
 
-        runSql("alter table \"Person\" drop column " +
-            "\"city\", \"str1\", \"str2\", \"num1\", \"num2\"", node, schema);
+        runSql("alter table \"Person\" drop column \"city\", \"str1\", \"str2\", \"num1\", " +
+            "\"num2\", \"time1\", \"time2\", \"float1\", \"float2\"", node, schema);
 
         runSql("alter table \"Person\" add column (" +
-                "\"rate\" decimal(10, 2) not null," +
-                "\"str1\" char(10) not null," +
-                "\"str2\" varchar," +
-                "\"num1\" decimal(10, 2) not null," +
-                "\"num2\" decimal)", node, schema);
+            "\"rate\" decimal(10, 2) not null," +
+            "\"str1\" char(10) not null," +
+            "\"str2\" varchar," +
+            "\"num1\" decimal(10, 2) not null," +
+            "\"num2\" decimal," +
+            "\"time1\" timestamp(10, 2) not null," +
+            "\"time2\" timestamp," +
+            "\"float1\" float(10) not null," +
+            "\"float2\" float)", node, schema);
     }
 
     /**
@@ -287,8 +296,9 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
 
         assertEquals(0, e.getIndexes().size());
 
-        assertEqualsUnordered(F.asList("id", "name", "city", "str1", "str2", "num1", "num2"), e.getFields().keySet());
-        assertEqualsUnordered(F.asList("str2", "num2"), e.getNotNullFields());
+        assertEqualsUnordered(F.asList("id", "name", "city", "str1", "str2",
+            "num1", "num2", "time1", "time2", "float1", "float2"), e.getFields().keySet());
+        assertEqualsUnordered(F.asList("str2", "num2", "time2", "float2"), e.getNotNullFields());
         assertEqualsUnordered(F.asList("num2"), e.getFieldsScale().keySet());
         assertEqualsUnordered(F.asList("str2", "num2"), e.getFieldsPrecision().keySet());
         assertEqualsUnordered(expDfltFields, e.getDefaultFieldValues().keySet());
@@ -308,8 +318,9 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
         assertEquals(1, e.getIndexes().size());
         assertEquals(0, e.getDefaultFieldValues().size());
 
-        assertEqualsUnordered(F.asList("id", "name", "rate", "str1", "str2", "num1", "num2"), e.getFields().keySet());
-        assertEqualsUnordered(F.asList("rate", "str1", "num1"), e.getNotNullFields());
+        assertEqualsUnordered(F.asList("id", "name", "rate", "str1", "str2",
+            "num1", "num2", "time1", "time2", "float1", "float2"), e.getFields().keySet());
+        assertEqualsUnordered(F.asList("rate", "str1", "num1", "time1", "float1"), e.getNotNullFields());
         assertEqualsUnordered(F.asList("rate", "num1"), e.getFieldsScale().keySet());
         assertEqualsUnordered(F.asList("rate", "str1", "num1"), e.getFieldsPrecision().keySet());
     }
@@ -369,5 +380,21 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
         /** */
         @QuerySqlField(precision = 10, scale = 2, notNull = true)
         protected BigDecimal num2;
+
+        /** */
+        @QuerySqlField
+        protected Timestamp time1;
+
+        /** */
+        @QuerySqlField(notNull = true)
+        protected Timestamp time2;
+
+        /** */
+        @QuerySqlField
+        protected Float float1;
+
+        /** */
+        @QuerySqlField(notNull = true)
+        protected Float float2;
     }
 }

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/database/IgnitePersistentStoreSchemaLoadTest.java
@@ -188,14 +188,13 @@ public class IgnitePersistentStoreSchemaLoadTest extends GridCommonAbstractTest 
         CountDownLatch cnt = checkpointLatch(node);
 
         runSql("create table \"Person\" (" +
-                "\"id\" int primary key," +
-                "\"name\" varchar," +
-                "\"city\" int," +
-                "\"str1\" varchar," +
-                "\"str2\" char(10) not null default '1'," +
-                "\"num1\" decimal," +
-                "\"num2\" decimal(10, 2) not null default 1)"
-            , node, QueryUtils.DFLT_SCHEMA);
+            "\"id\" int primary key," +
+            "\"name\" varchar," +
+            "\"city\" int," +
+            "\"str1\" varchar," +
+            "\"str2\" char(10) not null default '1'," +
+            "\"num1\" decimal," +
+            "\"num2\" decimal(10, 2) not null default 1)", node, QueryUtils.DFLT_SCHEMA);
 
         checkOriginalSchema(node, SQL_CACHE_NAME, F.asList("str2", "num2"));
 


### PR DESCRIPTION
This patch includes fix for both `ADD COLUMN` (GG-36879) and `DROP COLUMN` (GG-36907) commands.

ADD COLUMN issue:
We forgot to set the `precision` and `scale` for the added column in `QueryEntity`, so after loading it from disk, we got the previous value.
Note: we do not support ADD COLUMN with a default value, so there is no need to set it.

DROP COLUMN issue:
We forgot to clean scale/precision/notnull/default column attributes in `QueryEntity` when removing field. So after reading entity from disk, we can get the previous values if column was re-created.





