### PR TITLE
GG-37364 NullPointerException in org.apache.ignite.internal.IgniteKernal#allocatedPDSSize

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteKernal.java
@@ -2297,7 +2297,7 @@ public class IgniteKernal implements IgniteEx, IgniteMXBean, Externalizable {
     }
 
     private long allocatedPDSSize() {
-        if (ctx.clientNode())
+        if (ctx.clientNode() || ctx.grid().cluster().state() == ClusterState.INACTIVE)
             return 0;
 
         DataStorageConfiguration dsCfg = ctx.config().getDataStorageConfiguration();


### PR DESCRIPTION
-- add checking that cluster is ACTIVE before collect information about allocated PDS