### PR TITLE
GG-36790 [IGNITE-18766] Fix incorrect id check in ClusterGroupAdapter.forNodeId

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/cluster/ClusterGroupAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cluster/ClusterGroupAdapter.java
@@ -471,7 +471,7 @@ public class ClusterGroupAdapter implements ClusterGroupEx, Externalizable {
                 nodeIds = U.newHashSet(ids.length + 1);
 
                 for (UUID id0 : ids) {
-                    if (contains(id))
+                    if (contains(id0))
                         nodeIds.add(id0);
                 }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridProjectionForCachesSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridProjectionForCachesSelfTest.java
@@ -17,6 +17,7 @@
 package org.apache.ignite.internal;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import org.apache.ignite.Ignite;
@@ -278,6 +279,19 @@ public class GridProjectionForCachesSelfTest extends GridCommonAbstractTest {
         catch (NullPointerException ignored) {
             // No-op.
         }
+    }
+
+    /**
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testProjectionWithBadId() {
+        ClusterNode locNode = ignite.cluster().localNode();
+
+        ClusterGroup prj = ignite.cluster().forNodeId(UUID.randomUUID(), locNode.id());
+        Collection<ClusterNode> nodes = prj.nodes();
+
+        assertEquals(1, nodes.size());
     }
 
     /**

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Log/dotnet-log4j.xml
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Config/Log/dotnet-log4j.xml
@@ -16,70 +16,127 @@
  limitations under the License.
 -->
 
-<Configuration>
-    <Appenders>
-        <Console name="CONSOLE" target="SYSTEM_OUT">
-            <LevelRangeFilter minLevel="INFO" maxLevel="DEBUG"/>
-            <PatternLayout pattern="[%d{dd-MM-yyyy HH:mm:ss}][%-5p][%t][%c{1}] %m%n"/>
-        </Console>
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN"
+        "http://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/xml/doc-files/log4j.dtd">
+<!--
+    Default log4j configuration for Ignite.
+-->
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/" debug="false">
+    <!--
+        Logs System.out messages to console.
+    -->
+    <appender name="CONSOLE" class="org.apache.log4j.ConsoleAppender">
+        <!-- Log to STDOUT. -->
+        <param name="Target" value="System.out"/>
 
-        <Console name="CONSOLE_ERR" target="SYSTEM_ERR">
-            <PatternLayout pattern="[%d{dd-MM-yyyy HH:mm:ss}][%-5p][%t][%c{1}] %m%n"/>
-        </Console>
+        <!-- Log from DEBUG and higher. -->
+        <param name="Threshold" value="DEBUG"/>
 
-        <RollingFile name="FILE"
-                     append="true"
-                     fileName="${sys:IGNITE_HOME}/work/log/dotnet-logger-test.log"
-                     filePattern="${sys:IGNITE_HOME}/work/log/dotnet-logger-test.log.%i">
-            <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}] %m%n"/>
-            <Policies>
-                <SizeBasedTriggeringPolicy size="10 MB"/>
-            </Policies>
-            <DefaultRolloverStrategy max="10"/>
-        </RollingFile>
-    </Appenders>
+        <!-- The default pattern: Date Priority [Category] Message\n -->
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d{dd-MM-yyyy HH:mm:ss}][%-5p][%t][%c{1}] %m%n"/>
+        </layout>
 
-    <Loggers>
-        <!--
-            Uncomment to enable Ignite debugging.
-        -->
-        <!--
-            <Logger name="org.apache.ignite" level="DEBUG"/>
-        -->
+        <!-- Do not log beyond INFO level. -->
+        <filter class="org.apache.log4j.varia.LevelRangeFilter">
+            <param name="levelMin" value="DEBUG"/>
+            <param name="levelMax" value="INFO"/>
+        </filter>
+    </appender>
 
-        <!--
-            Uncomment this category to enable cache query execution tracing.
-        -->
-        <!--
-            <Logger name="org.apache.ignite.cache.queries" level="DEBUG"/>
-        -->
+    <!--
+        Logs all System.err messages to console.
+    -->
+    <appender name="CONSOLE_ERR" class="org.apache.log4j.ConsoleAppender">
+        <!-- Log to STDERR. -->
+        <param name="Target" value="System.err"/>
 
-        <!--
-            Uncomment to enable DGC tracing.
-        -->
-        <!--
-            <Logger name="org.apache.ignite.grid.kernal.processors.cache.GridCacheDgcManager.trace" level="DEBUG"/>
-        -->
+        <!-- Log from WARN and higher. -->
+        <param name="Threshold" value="WARN"/>
 
-        <!--
-            Uncomment to disable courtesy notice.
-        -->
-        <!--
-           <Logger name="org.apache.ignite.CourtesyConfigNotice" level="OFF"/>
-        -->
+        <!-- The default pattern: Date Priority [Category] Message\n -->
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d{dd-MMM-yyyy HH:mm:ss}][%-5p][%t][%c{1}] %m%n"/>
+        </layout>
+    </appender>
 
-        <Logger name="org.springframework" level="WARN"/>
+    <!--
+        Logs all output to specified file.
+        By default, the logging goes to IGNITE_HOME/work/log folder
 
-        <Logger name="org.eclipse.jetty" level="FATAL"/>
+        Note, this appender is disabled by default.
+        To enable, uncomment the section below and also FILE appender in the <root> element.
+    -->
+    <appender name="FILE" class="org.apache.log4j.RollingFileAppender">
+        <param name="Threshold" value="DEBUG"/>
+        <param name="File" value="${IGNITE_HOME}/work/log/dotnet-logger-test.log"/>
+        <param name="Append" value="true"/>
+        <param name="MaxFileSize" value="10MB"/>
+        <param name="MaxBackupIndex" value="10"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="[%d{ISO8601}][%-5p][%t][%c{1}] %m%n"/>
+        </layout>
+    </appender>
 
-        <Logger name="com.amazonaws" level="WARN"/>
+    <!--
+        Uncomment to enable Ignite debugging.
+    -->
+    <!--
+    <category name="org.apache.ignite">
+        <level value="DEBUG"/>
+    </category>
+    -->
 
-        <Logger name="org.apache.ignite.internal.processors.odbc.ClientListenerNioListener" level="TRACE"/>
+    <!--
+        Uncomment this category to enable cache
+        query execution tracing.
+    -->
+    <!--
+    <category name="org.apache.ignite.cache.queries">
+        <level value="DEBUG"/>
+    </category>
+    -->
 
-        <Root level="DEBUG">
-            <AppenderRef ref="CONSOLE" level="DEBUG"/>
-            <AppenderRef ref="CONSOLE_ERR" level="WARN"/>
-            <AppenderRef ref="FILE" level="DEBUG"/>
-        </Root>
-    </Loggers>
-</Configuration>
+    <!--
+        Uncomment to enable DGC tracing.
+    -->
+    <!--
+    <category name="org.apache.ignite.grid.kernal.processors.cache.GridCacheDgcManager.trace">
+        <level value="DEBUG"/>
+    </category>
+    -->
+
+    <!--
+        Uncomment to disable courtesy notice.
+    -->
+    <!--
+    <category name="org.apache.ignite.CourtesyConfigNotice">
+        <level value="OFF"/>
+    </category>
+    -->
+
+    <category name="org.springframework">
+        <level value="WARN"/>
+    </category>
+
+    <category name="org.eclipse.jetty">
+        <level value="FATAL"/>
+    </category>
+
+    <category name="com.amazonaws">
+        <level value="WARN"/>
+    </category>
+
+    <!-- Default settings. -->
+    <root>
+        <!-- Print out all info by default. -->
+        <level value="DEBUG"/>
+
+        <!-- Append to console. -->
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="CONSOLE_ERR"/>
+
+        <!-- Uncomment to enable logging to a file. -->
+        <appender-ref ref="FILE"/>
+    </root>
+</log4j:configuration>


### PR DESCRIPTION
Also revert previous changes to `dotnet-log4j.xml` to fix TestJavaLogger (broken in #2883)