### PR TITLE
GG-37407 Fixed flaky test JdbcThinQueryMemoryTrackerSelfTest.testPartialResultRead

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinQueryMemoryTrackerSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinQueryMemoryTrackerSelfTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import static org.apache.ignite.internal.util.IgniteUtils.MB;
+import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
 
 /**
  * Query memory manager for local queries.
@@ -77,7 +78,9 @@ public class JdbcThinQueryMemoryTrackerSelfTest extends JdbcQueryMemoryTrackerSe
             }
         }
 
-        assertEquals(localResults.size(), closedResultCntr.get());
+        // A wait is required because the query cancel request handler runs asynchronously.
+        boolean success = waitForCondition(() -> localResults.size() == closedResultCntr.get(), getTestTimeout());
+        assertTrue(success);
 
         Throwable err = localResultErr.get();
 

--- a/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinQueryMemoryTrackerSelfTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/jdbc/thin/JdbcThinQueryMemoryTrackerSelfTest.java
@@ -79,7 +79,7 @@ public class JdbcThinQueryMemoryTrackerSelfTest extends JdbcQueryMemoryTrackerSe
         }
 
         // A wait is required because the query cancel request handler runs asynchronously.
-        boolean success = waitForCondition(() -> localResults.size() == closedResultCntr.get(), getTestTimeout());
+        boolean success = waitForCondition(() -> localResults.size() == closedResultCntr.get(), 10_000);
         assertTrue(success);
 
         Throwable err = localResultErr.get();


### PR DESCRIPTION
The test is flaky because the local handler of GridQueryCancelRequest executes asynchronously ([at this line](https://github.com/gridgain/gridgain/blob/master/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/twostep/GridReduceQueryExecutor.java#L1058) `send()` is called with `runLocParallel=true`) and `CloseResultCntr` may update a little later than expected.