### PR TITLE
GG-37661 .NET: Fix DateTime handling in TestCallJavaService

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/PlatformTestService.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/PlatformTestService.cs
@@ -599,11 +599,11 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             var cache = _ignite.GetCache<int, DateTime>("net-dates");
 
-            var ts1 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
-            var ts2 = new DateTime(1982, 3, 31, 22, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
+            var ts1 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local);
+            var ts2 = new DateTime(1982, 3, 31, 22, 0, 0, 0, DateTimeKind.Local);
 
-            Assert.AreEqual(ts1, cache.Get(5));
-            Assert.AreEqual(ts2, cache.Get(6));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(ts1), cache.Get(5));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(ts2), cache.Get(6));
 
             cache.Put(7, ts1);
             cache.Put(8, ts2);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTestUtils.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Services
+{
+    using System;
+
+    /// <summary>
+    /// Service test utils.
+    /// </summary>
+    public static class ServiceTestUtils
+    {
+        public static DateTime MoscowToUniversal(DateTime date)
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(
+                dateTime: DateTime.SpecifyKind(date, DateTimeKind.Unspecified),
+                sourceTimeZone: TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow"));
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1174,17 +1174,17 @@ namespace Apache.Ignite.Core.Tests.Services
             cache.Put(5, dt3);
             cache.Put(6, dt4);
 
-            Assert.AreEqual(TimestampConverter.ToUniversal(dt3), cache.Get(5).ToUniversalTime());
-            Assert.AreEqual(TimestampConverter.ToUniversal(dt4), cache.Get(6).ToUniversalTime());
+            Assert.AreEqual(TimestampConverter.ToUniversal(dt3), cache.Get(5));
+            Assert.AreEqual(TimestampConverter.ToUniversal(dt4), cache.Get(6));
 
             svc.testLocalDateFromCache();
 
-            Assert.AreEqual(dt3, cache.Get(7).ToLocalTime());
-            Assert.AreEqual(dt4, cache.Get(8).ToLocalTime());
+            Assert.AreEqual(TimestampConverter.ToUniversal(dt3), cache.Get(7));
+            Assert.AreEqual(TimestampConverter.ToUniversal(dt4), cache.Get(8));
 
             var now = DateTime.Now;
             cache.Put(9, now);
-            Assert.AreEqual(now.ToUniversalTime(), cache.Get(9).ToUniversalTime());
+            Assert.AreEqual(TimestampConverter.ToUniversal(now), cache.Get(9));
 #endif
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Core.Tests.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -1165,6 +1166,8 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual("value", svc.contextAttribute("attr"));
 
 #if NETCOREAPP
+            DateTimeOffset dtOffset = new DateTimeOffset(1982, 4, 1, 0, 0, 0, 0, TimeSpan.FromHours(3));
+
             //This Date in Europe/Moscow have offset +4.
             DateTime dt3 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local);
             //This Date in Europe/Moscow have offset +3.
@@ -1962,7 +1965,11 @@ namespace Apache.Ignite.Core.Tests.Services
             public void ToJavaTicks(DateTime date, out long high, out int low)
             {
                 if (date.Kind == DateTimeKind.Local)
-                    date = date.ToUniversalTime();
+                {
+                    date = TimeZoneInfo.ConvertTimeToUtc(
+                        dateTime: DateTime.SpecifyKind(date, DateTimeKind.Unspecified),
+                        sourceTimeZone: TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow"));
+                }
 
                 BinaryUtils.ToJavaDate(date, out high, out low);
             }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1166,8 +1166,6 @@ namespace Apache.Ignite.Core.Tests.Services
             Assert.AreEqual("value", svc.contextAttribute("attr"));
 
 #if NETCOREAPP
-            DateTimeOffset dtOffset = new DateTimeOffset(1982, 4, 1, 0, 0, 0, 0, TimeSpan.FromHours(3));
-
             //This Date in Europe/Moscow have offset +4.
             DateTime dt3 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local);
             //This Date in Europe/Moscow have offset +3.
@@ -1176,8 +1174,8 @@ namespace Apache.Ignite.Core.Tests.Services
             cache.Put(5, dt3);
             cache.Put(6, dt4);
 
-            Assert.AreEqual(dt3.ToUniversalTime(), cache.Get(5).ToUniversalTime());
-            Assert.AreEqual(dt4.ToUniversalTime(), cache.Get(6).ToUniversalTime());
+            Assert.AreEqual(TimestampConverter.ToUniversal(dt3), cache.Get(5).ToUniversalTime());
+            Assert.AreEqual(TimestampConverter.ToUniversal(dt4), cache.Get(6).ToUniversalTime());
 
             svc.testLocalDateFromCache();
 
@@ -1966,9 +1964,7 @@ namespace Apache.Ignite.Core.Tests.Services
             {
                 if (date.Kind == DateTimeKind.Local)
                 {
-                    date = TimeZoneInfo.ConvertTimeToUtc(
-                        dateTime: DateTime.SpecifyKind(date, DateTimeKind.Unspecified),
-                        sourceTimeZone: TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow"));
+                    date = ToUniversal(date);
                 }
 
                 BinaryUtils.ToJavaDate(date, out high, out low);
@@ -1980,6 +1976,13 @@ namespace Apache.Ignite.Core.Tests.Services
                 return new DateTime(
                     BinaryUtils.JavaDateTicks + high * TimeSpan.TicksPerMillisecond + low / 100,
                     DateTimeKind.Utc);
+            }
+
+            public static DateTime ToUniversal(DateTime date)
+            {
+                return TimeZoneInfo.ConvertTimeToUtc(
+                    dateTime: DateTime.SpecifyKind(date, DateTimeKind.Unspecified),
+                    sourceTimeZone: TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow"));
             }
         }
 #endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -18,7 +18,6 @@ namespace Apache.Ignite.Core.Tests.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Threading;
@@ -1174,17 +1173,17 @@ namespace Apache.Ignite.Core.Tests.Services
             cache.Put(5, dt3);
             cache.Put(6, dt4);
 
-            Assert.AreEqual(TimestampConverter.ToUniversal(dt3), cache.Get(5));
-            Assert.AreEqual(TimestampConverter.ToUniversal(dt4), cache.Get(6));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt3), cache.Get(5));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt4), cache.Get(6));
 
             svc.testLocalDateFromCache();
 
-            Assert.AreEqual(TimestampConverter.ToUniversal(dt3), cache.Get(7));
-            Assert.AreEqual(TimestampConverter.ToUniversal(dt4), cache.Get(8));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt3), cache.Get(7));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt4), cache.Get(8));
 
             var now = DateTime.Now;
             cache.Put(9, now);
-            Assert.AreEqual(TimestampConverter.ToUniversal(now), cache.Get(9));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(now), cache.Get(9));
 #endif
         }
 
@@ -1964,7 +1963,7 @@ namespace Apache.Ignite.Core.Tests.Services
             {
                 if (date.Kind == DateTimeKind.Local)
                 {
-                    date = ToUniversal(date);
+                    date = ServiceTestUtils.MoscowToUniversal(date);
                 }
 
                 BinaryUtils.ToJavaDate(date, out high, out low);
@@ -1976,13 +1975,6 @@ namespace Apache.Ignite.Core.Tests.Services
                 return new DateTime(
                     BinaryUtils.JavaDateTicks + high * TimeSpan.TicksPerMillisecond + low / 100,
                     DateTimeKind.Utc);
-            }
-
-            public static DateTime ToUniversal(DateTime date)
-            {
-                return TimeZoneInfo.ConvertTimeToUtc(
-                    dateTime: DateTime.SpecifyKind(date, DateTimeKind.Unspecified),
-                    sourceTimeZone: TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow"));
             }
         }
 #endif


### PR DESCRIPTION
Fix incorrect assumption that local time zone is `Europe/Moscow` in service tests - add explicit conversions.