### PR TITLE
GG-37555 [IGNITE-20586] .NET: Fix JNI string conversion causing node crash

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformConsoleWriteTask.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformConsoleWriteTask.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.platform;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobAdapter;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeTaskAdapter;
+import org.apache.ignite.internal.util.typedef.F;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Task to test Java console output.
+ */
+public class PlatformConsoleWriteTask extends ComputeTaskAdapter<byte[], Object> {
+    /** {@inheritDoc} */
+    @NotNull @Override public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid,
+        @Nullable byte[] arg) {
+        return Collections.singletonMap(new Job(arg), F.first(subgrid));
+    }
+
+    /** {@inheritDoc} */
+    @Nullable @Override public String reduce(List<ComputeJobResult> results) {
+        return results.get(0).getData();
+    }
+
+    /**
+     * Job.
+     */
+    private static class Job extends ComputeJobAdapter {
+        /** */
+        private final byte[] arg;
+
+        /**
+         * Ctor.
+         *
+         * @param arg arg.
+         */
+        private Job(byte[] arg) {
+            this.arg = arg;
+        }
+
+        /** {@inheritDoc} */
+        @Nullable @Override public String execute() {
+            String str = new String(arg, StandardCharsets.UTF_16LE);
+            System.out.println(str);
+
+            return null;
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/platform/PlatformTestUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/platform/PlatformTestUtils.java
@@ -30,4 +30,13 @@ public class PlatformTestUtils {
     public static int majorJavaVersion() {
         return U.majorJavaVersion(System.getProperty("java.version"));
     }
+
+    /**
+     * Prints line to standard output.
+     *
+     * @param str String.
+     */
+    public static void println(String str) {
+        System.out.println(str);
+    }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySelfTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Binary/BinarySelfTest.cs
@@ -54,7 +54,9 @@ namespace Apache.Ignite.Core.Tests.Binary
             new string(new[] {(char) 0xD800, '的', (char) 0xD800, (char) 0xD800, (char) 0xDC00, (char) 0xDFFF}),
             "ascii0123456789",
             "的的abcdкириллица",
-            new string(new[] {(char) 0xD801, (char) 0xDC37})
+            new string(new[] {(char) 0xD801, (char) 0xDC37}),
+            "Ḽơᶉëᶆ ȋṕšᶙṁ",
+            "A_\ud83e\udd26\ud83c\udffc\u200d\u2642\ufe0f_B" // A_🤦🏼‍♂️_B
         };
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/TestUtilsJni.cs
@@ -75,12 +75,12 @@ namespace Apache.Ignite.Core.Tests
                 var methodId = env.GetStaticMethodId(cls, "startProcess",
                     "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
 
-                using (var fileRef = env.NewStringUtf(file))
-                using (var arg1Ref = env.NewStringUtf(arg1))
-                using (var arg2Ref = env.NewStringUtf(arg2))
-                using (var envRef = env.NewStringUtf(envVars))
-                using (var workDirRef = env.NewStringUtf(workDir))
-                using (var waitForOutputRef = env.NewStringUtf(waitForOutput))
+                using (var fileRef = env.NewString(file))
+                using (var arg1Ref = env.NewString(arg1))
+                using (var arg2Ref = env.NewString(arg2))
+                using (var envRef = env.NewString(envVars))
+                using (var workDirRef = env.NewString(workDir))
+                using (var waitForOutputRef = env.NewString(waitForOutput))
                 {
                     var methodArgs = stackalloc long[6];
                     methodArgs[0] = fileRef.Target.ToInt64();
@@ -127,6 +127,11 @@ namespace Apache.Ignite.Core.Tests
             return CallIntMethod(ClassPlatformTestUtils, "majorJavaVersion", "()I");
         }
 
+        public static void Println(string str)
+        {
+            CallStringMethod(ClassPlatformTestUtils, "println", "(Ljava/lang/String;)V", str);
+        }
+
         /** */
         private static unsafe void CallStringMethod(string className, string methodName, string methodSig, string arg)
         {
@@ -134,7 +139,7 @@ namespace Apache.Ignite.Core.Tests
             using (var cls = env.FindClass(className))
             {
                 var methodId = env.GetStaticMethodId(cls, methodName, methodSig);
-                using (var gridNameRef = env.NewStringUtf(arg))
+                using (var gridNameRef = env.NewString(arg))
                 {
                     var args = stackalloc long[1];
                     args[0] = gridNameRef.Target.ToInt64();

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/IgniteUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/IgniteUtils.cs
@@ -127,26 +127,6 @@ namespace Apache.Ignite.Core.Impl
         }
 
         /// <summary>
-        /// Convert unmanaged char array to string.
-        /// </summary>
-        /// <param name="chars">Char array.</param>
-        /// <param name="charsLen">Char array length.</param>
-        /// <returns></returns>
-        public static unsafe string Utf8UnmanagedToString(sbyte* chars, int charsLen)
-        {
-            IntPtr ptr = new IntPtr(chars);
-
-            if (ptr == IntPtr.Zero)
-                return null;
-
-            byte[] arr = new byte[charsLen];
-
-            Marshal.Copy(ptr, arr, 0, arr.Length);
-
-            return Encoding.UTF8.GetString(arr);
-        }
-
-        /// <summary>
         /// Convert string to unmanaged byte array.
         /// </summary>
         /// <param name="str">String.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Env.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Env.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
     using System.Diagnostics;
     using System.Runtime.InteropServices;
     using System.Security;
+    using System.Text;
     using Apache.Ignite.Core.Common;
 
     /// <summary>
@@ -53,7 +54,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private readonly EnvDelegates.GetStaticMethodId _getStaticMethodId;
 
         /** */
-        private readonly EnvDelegates.NewStringUtf _newStringUtf;
+        private readonly EnvDelegates.NewString _newString;
 
         /** */
         private readonly EnvDelegates.ExceptionOccurred _exceptionOccurred;
@@ -71,23 +72,13 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         private readonly EnvDelegates.CallVoidMethod _callVoidMethod;
 
         /** */
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        // ReSharper disable once NotAccessedField.Local
-        private readonly EnvDelegates.GetStringChars _getStringChars;
+        private readonly EnvDelegates.GetStringCritical _getStringCritical;
 
         /** */
-        private readonly EnvDelegates.GetStringUtfChars _getStringUtfChars;
+        private readonly EnvDelegates.GetStringLength _getStringLength;
 
         /** */
-        private readonly EnvDelegates.GetStringUtfLength _getStringUtfLength;
-
-        /** */
-        private readonly EnvDelegates.ReleaseStringUtfChars _releaseStringUtfChars;
-
-        /** */
-        // ReSharper disable once PrivateFieldCanBeConvertedToLocalVariable
-        // ReSharper disable once NotAccessedField.Local
-        private readonly EnvDelegates.ReleaseStringChars _releaseStringChars;
+        private readonly EnvDelegates.ReleaseStringCritical _releaseStringCritical;
 
         /** */
         private readonly EnvDelegates.ExceptionClear _exceptionClear;
@@ -133,7 +124,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             GetDelegate(func.FindClass, out _findClass);
             GetDelegate(func.GetMethodID, out _getMethodId);
             GetDelegate(func.GetStaticMethodID, out _getStaticMethodId);
-            GetDelegate(func.NewStringUTF, out _newStringUtf);
+            GetDelegate(func.NewString, out _newString);
             GetDelegate(func.ExceptionOccurred, out _exceptionOccurred);
             GetDelegate(func.ExceptionClear, out _exceptionClear);
             GetDelegate(func.ExceptionCheck, out _exceptionCheck);
@@ -143,13 +134,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             GetDelegate(func.CallLongMethod, out _callLongMethod);
             GetDelegate(func.CallVoidMethod, out _callVoidMethod);
 
-            GetDelegate(func.GetStringChars, out _getStringChars);
-            GetDelegate(func.ReleaseStringChars, out _releaseStringChars);
-
-            GetDelegate(func.GetStringUTFChars, out _getStringUtfChars);
-            GetDelegate(func.ReleaseStringUTFChars, out _releaseStringUtfChars);
-
-            GetDelegate(func.GetStringUTFLength, out _getStringUtfLength);
+            GetDelegate(func.GetStringLength, out _getStringLength);
+            GetDelegate(func.GetStringCritical, out _getStringCritical);
+            GetDelegate(func.ReleaseStringCritical, out _releaseStringCritical);
 
             GetDelegate(func.RegisterNatives, out _registerNatives);
             GetDelegate(func.DeleteLocalRef, out _deleteLocalRef);
@@ -316,16 +303,16 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         }
 
         /// <summary>
-        /// Creates new jstring from UTF chars.
+        /// Creates new jstring from UTF16 chars.
         /// </summary>
-        private GlobalRef NewStringUtf(sbyte* utf)
+        private GlobalRef NewStringUtf16(IntPtr utf16, int len)
         {
-            if (utf == null)
+            if (utf16 == IntPtr.Zero)
             {
                 return null;
             }
 
-            var res = _newStringUtf(_envPtr, new IntPtr(utf));
+            var res = _newString(_envPtr, utf16, len);
 
             ExceptionCheck();
 
@@ -335,52 +322,47 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         /// <summary>
         /// Creates new jstring from string.
         /// </summary>
-        public GlobalRef NewStringUtf(string str)
+        public GlobalRef NewString(string str)
         {
             if (str == null)
             {
                 return null;
             }
 
-            var chars = IgniteUtils.StringToUtf8Unmanaged(str);
-
-            try
+            // .NET uses UTF-16 to represent strings internally - no conversion required, just take a pointer.
+            fixed (char* strPtr = str)
             {
-                return NewStringUtf(chars);
-            }
-            finally
-            {
-                Marshal.FreeHGlobal(new IntPtr(chars));
+                return NewStringUtf16(new IntPtr(strPtr), str.Length);
             }
         }
 
         /// <summary>
-        /// Gets the utf chars from jstring.
+        /// Gets UTF16 chars from jstring.
         /// </summary>
-        private IntPtr GetStringUtfChars(IntPtr jstring)
+        private IntPtr GetStringCritical(IntPtr jstring)
         {
             Debug.Assert(jstring != IntPtr.Zero);
 
             byte isCopy;
-            return _getStringUtfChars(_envPtr, jstring, &isCopy);
+            return _getStringCritical(_envPtr, jstring, &isCopy);
         }
 
         /// <summary>
-        /// Releases the string utf chars allocated by <see cref="GetStringUtfChars"/>.
+        /// Releases the chars allocated by <see cref="GetStringCritical"/>.
         /// </summary>
-        private void ReleaseStringUtfChars(IntPtr jstring, IntPtr chars)
+        private void ReleaseStringCritical(IntPtr jstring, IntPtr chars)
         {
-            _releaseStringUtfChars(_envPtr, jstring, chars);
+            _releaseStringCritical(_envPtr, jstring, chars);
         }
 
         /// <summary>
         /// Gets the length of the jstring.
         /// </summary>
-        private int GetStringUtfLength(IntPtr jstring)
+        private int GetStringLength(IntPtr jstring)
         {
             Debug.Assert(jstring != IntPtr.Zero);
 
-            return _getStringUtfLength(_envPtr, jstring);
+            return _getStringLength(_envPtr, jstring);
         }
 
         /// <summary>
@@ -424,16 +406,27 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
                 return null;
             }
 
-            var chars = GetStringUtfChars(jstring);
-            var len = GetStringUtfLength(jstring);
+            // 1. Use UTF16 to avoid Java-specific "modified UTF-8" issues.
+            //    https://stackoverflow.com/questions/32205446/getting-true-utf-8-characters-in-java-jni
+            // 2. Use GetStringCritical to avoid copying (when possible).
+            //    NOTE: The code block between GetStringCritical and ReleaseStringCritical
+            //    must not perform JNI calls (except GetStringLength) or block the thread.
+            var charsPtr = GetStringCritical(jstring);
+            if (charsPtr == IntPtr.Zero)
+            {
+                return null;
+            }
 
             try
             {
-                return IgniteUtils.Utf8UnmanagedToString((sbyte*) chars, len);
+                var charCount = GetStringLength(jstring);
+                var byteCount = charCount * 2; // UTF16 => x2 bytes.
+
+                return Encoding.Unicode.GetString((byte*)charsPtr, byteCount);
             }
             finally
             {
-                ReleaseStringUtfChars(jstring, chars);
+                ReleaseStringCritical(jstring, charsPtr);
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/EnvDelegates.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/EnvDelegates.cs
@@ -60,6 +60,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         internal delegate IntPtr NewStringUtf(IntPtr env, IntPtr utf);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        internal delegate IntPtr NewString(IntPtr env, IntPtr utf, int len);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate IntPtr ExceptionOccurred(IntPtr env);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -94,6 +97,12 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
         internal delegate void ReleaseStringChars(IntPtr env, IntPtr jstring, IntPtr chars);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        internal delegate IntPtr GetStringCritical(IntPtr env, IntPtr jstring, byte* isCopy);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        internal delegate void ReleaseStringCritical(IntPtr env, IntPtr jstring, IntPtr chars);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate IntPtr GetStringUtfChars(IntPtr env, IntPtr jstring, byte* isCopy);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
@@ -101,6 +110,9 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate int GetStringUtfLength(IntPtr env, IntPtr jstring);
+
+        [UnmanagedFunctionPointer(CallingConvention.StdCall)]
+        internal delegate int GetStringLength(IntPtr env, IntPtr jstring);
 
         [UnmanagedFunctionPointer(CallingConvention.StdCall)]
         internal delegate JniResult RegisterNatives(IntPtr env, IntPtr clazz,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/UnmanagedUtils.cs
@@ -32,8 +32,8 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             bool clientMode, bool userLogger, long igniteId, bool redirectConsole)
         {
             using (var mem = IgniteManager.Memory.Allocate().GetStream())
-            using (var cfgPath0 = env.NewStringUtf(cfgPath))
-            using (var gridName0 = env.NewStringUtf(gridName))
+            using (var cfgPath0 = env.NewString(cfgPath))
+            using (var gridName0 = env.NewString(gridName))
             {
                 mem.WriteBool(clientMode);
                 mem.WriteBool(userLogger);
@@ -57,7 +57,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged
             var env = Jvm.Get().AttachCurrentThread();
             var methodId = env.Jvm.MethodId;
 
-            using (var gridName1 = env.NewStringUtf(gridName))
+            using (var gridName1 = env.NewString(gridName))
             {
                 long* args = stackalloc long[2];
                 args[0] = gridName == null ? 0 : gridName1.Target.ToInt64();


### PR DESCRIPTION
When working with `jstring` in JNI, we used `GetStringUTFChars`, which returns Java-specific "modified UTF-8" characters, then passed those characters to `Encoding.UTF8.GetString` in .NET. However, "modified UTF-8" is not true UTF-8, and cannot be correctly decoded by .NET standard library; in some cases it can even cause `OverflowException` and crash the node.

The fix is to use `GetStringChars`, which returns UTF-16 characters without any quirks. Both Java and .NET use UTF-16 to represent strings internally, so this approach is also simpler and faster.

The fix (and the bug) does not affect user data serialization - JNI strings are only used for logging, console output, instance names, and config paths.