### PR TITLE
GG-37661 .NET: Fix DateTime handling in TestCallJavaService (#2948)

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/PlatformTestService.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/PlatformTestService.cs
@@ -599,11 +599,11 @@ namespace Apache.Ignite.Core.Tests.Services
         {
             var cache = _ignite.GetCache<int, DateTime>("net-dates");
 
-            var ts1 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
-            var ts2 = new DateTime(1982, 3, 31, 22, 0, 0, 0, DateTimeKind.Local).ToUniversalTime();
+            var ts1 = new DateTime(1982, 4, 1, 1, 0, 0, 0, DateTimeKind.Local);
+            var ts2 = new DateTime(1982, 3, 31, 22, 0, 0, 0, DateTimeKind.Local);
 
-            Assert.AreEqual(ts1, cache.Get(5));
-            Assert.AreEqual(ts2, cache.Get(6));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(ts1), cache.Get(5));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(ts2), cache.Get(6));
 
             cache.Put(7, ts1);
             cache.Put(8, ts2);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTestUtils.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServiceTestUtils.cs
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2023 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.Services
+{
+    using System;
+
+    /// <summary>
+    /// Service test utils.
+    /// </summary>
+    public static class ServiceTestUtils
+    {
+        public static DateTime MoscowToUniversal(DateTime date)
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(
+                dateTime: DateTime.SpecifyKind(date, DateTimeKind.Unspecified),
+                sourceTimeZone: TimeZoneInfo.FindSystemTimeZoneById("Europe/Moscow"));
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Services/ServicesTest.cs
@@ -1157,17 +1157,17 @@ namespace Apache.Ignite.Core.Tests.Services
             cache.Put(5, dt3);
             cache.Put(6, dt4);
 
-            Assert.AreEqual(dt3.ToUniversalTime(), cache.Get(5).ToUniversalTime());
-            Assert.AreEqual(dt4.ToUniversalTime(), cache.Get(6).ToUniversalTime());
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt3), cache.Get(5));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt4), cache.Get(6));
 
             svc.testLocalDateFromCache();
 
-            Assert.AreEqual(dt3, cache.Get(7).ToLocalTime());
-            Assert.AreEqual(dt4, cache.Get(8).ToLocalTime());
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt3), cache.Get(7));
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(dt4), cache.Get(8));
 
             var now = DateTime.Now;
             cache.Put(9, now);
-            Assert.AreEqual(now.ToUniversalTime(), cache.Get(9).ToUniversalTime());
+            Assert.AreEqual(ServiceTestUtils.MoscowToUniversal(now), cache.Get(9));
 #endif
         }
 
@@ -1946,7 +1946,9 @@ namespace Apache.Ignite.Core.Tests.Services
             public void ToJavaTicks(DateTime date, out long high, out int low)
             {
                 if (date.Kind == DateTimeKind.Local)
-                    date = date.ToUniversalTime();
+                {
+                    date = ServiceTestUtils.MoscowToUniversal(date);
+                }
 
                 BinaryUtils.ToJavaDate(date, out high, out low);
             }


### PR DESCRIPTION
Fix incorrect assumption that local time zone is `Europe/Moscow` in service tests - add explicit conversions.

(cherry picked from commit 9bc9bf41b515a95d6decd8145a6878ae224baafd)