### PR TITLE
GG-37739 MulticastIpFinder is replaced with VmIpFinder in tests, examples and as a default IpFinder implementation

### DIFF
--- a/examples-ml/config/example-default.xml
+++ b/examples-ml/config/example-default.xml
@@ -59,8 +59,8 @@
                         to our documentation: http://apacheignite.readme.io/docs/cluster-config
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/encryption/example-encrypted-store.xml
+++ b/examples/config/encryption/example-encrypted-store.xml
@@ -54,8 +54,8 @@
             <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
                 <property name="ipFinder">
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/example-cache.xml
+++ b/examples/config/example-cache.xml
@@ -57,8 +57,8 @@
                         to our documentation: http://apacheignite.readme.io/docs/cluster-config
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/example-data-regions.xml
+++ b/examples/config/example-data-regions.xml
@@ -89,8 +89,8 @@
                         to our documentation: http://apacheignite.readme.io/docs/cluster-config
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/example-default.xml
+++ b/examples/config/example-default.xml
@@ -59,8 +59,8 @@
                         to our documentation: http://apacheignite.readme.io/docs/cluster-config
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/persistentstore/example-persistent-store.xml
+++ b/examples/config/persistentstore/example-persistent-store.xml
@@ -37,8 +37,8 @@
             <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
                 <property name="ipFinder">
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                        <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/redis/example-redis.xml
+++ b/examples/config/redis/example-redis.xml
@@ -57,8 +57,8 @@
                         to our documentation: http://apacheignite.readme.io/docs/cluster-config
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/config/spark/example-shared-rdd.xml
+++ b/examples/config/spark/example-shared-rdd.xml
@@ -66,8 +66,8 @@
                         to our documentation: http://apacheignite.readme.io/docs/cluster-config
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/examples/src/main/java/org/apache/ignite/examples/misc/springbean/spring-bean.xml
+++ b/examples/src/main/java/org/apache/ignite/examples/misc/springbean/spring-bean.xml
@@ -44,8 +44,8 @@
                     <bean class="org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi">
                         <property name="ipFinder">
                             <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                            <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                            <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                            <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                                <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                                 <property name="addresses">
                                     <list>
                                         <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -2093,7 +2093,13 @@ public class IgnitionEx {
                 TcpDiscoverySpi tcpDisco = (TcpDiscoverySpi)cfg.getDiscoverySpi();
 
                 if (tcpDisco.getIpFinder() == null) {
-                    tcpDisco.setIpFinder(new TcpDiscoveryVmIpFinder(true));
+                    TcpDiscoveryVmIpFinder vmIpFinder = new TcpDiscoveryVmIpFinder(true);
+
+                    String addr = DFLT_IP_ADDR + ':' + DFLT_PORT + ".." + (DFLT_PORT + DFLT_PORT_RANGE);
+
+                    vmIpFinder.setAddresses(Collections.singletonList(addr));
+
+                    tcpDisco.setIpFinder(vmIpFinder);
                 }
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -2093,13 +2093,7 @@ public class IgnitionEx {
                 TcpDiscoverySpi tcpDisco = (TcpDiscoverySpi)cfg.getDiscoverySpi();
 
                 if (tcpDisco.getIpFinder() == null) {
-                    TcpDiscoveryVmIpFinder vmIpFinder = new TcpDiscoveryVmIpFinder(true);
-
-                    String addr = DFLT_IP_ADDR + ':' + DFLT_PORT + ".." + (DFLT_PORT + DFLT_PORT_RANGE);
-
-                    vmIpFinder.setAddresses(Collections.singletonList(addr));
-
-                    tcpDisco.setIpFinder(vmIpFinder);
+                    tcpDisco.setIpFinder(new TcpDiscoveryVmIpFinder(true));
                 }
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -113,7 +113,7 @@ import org.apache.ignite.spi.collision.noop.NoopCollisionSpi;
 import org.apache.ignite.spi.communication.tcp.TcpCommunicationSpi;
 import org.apache.ignite.spi.deployment.local.LocalDeploymentSpi;
 import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
-import org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder;
+import org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder;
 import org.apache.ignite.spi.encryption.noop.NoopEncryptionSpi;
 import org.apache.ignite.spi.eventstorage.NoopEventStorageSpi;
 import org.apache.ignite.spi.failover.always.AlwaysFailoverSpi;
@@ -2091,8 +2091,13 @@ public class IgnitionEx {
             if (cfg.getDiscoverySpi() instanceof TcpDiscoverySpi) {
                 TcpDiscoverySpi tcpDisco = (TcpDiscoverySpi)cfg.getDiscoverySpi();
 
-                if (tcpDisco.getIpFinder() == null)
-                    tcpDisco.setIpFinder(new TcpDiscoveryMulticastIpFinder());
+                if (tcpDisco.getIpFinder() == null) {
+                    TcpDiscoveryVmIpFinder vmIpFinder = new TcpDiscoveryVmIpFinder(true);
+
+                    vmIpFinder.setAddresses(Collections.singletonList("127.0.0.1:47500..47600"));
+
+                    tcpDisco.setIpFinder(vmIpFinder);
+                }
             }
 
             if (cfg.getCommunicationSpi() == null)

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -148,7 +148,9 @@ import static org.apache.ignite.configuration.MemoryConfiguration.DFLT_MEMORY_PO
 import static org.apache.ignite.configuration.MemoryConfiguration.DFLT_MEM_PLC_DEFAULT_NAME;
 import static org.apache.ignite.internal.IgniteComponentType.SPRING;
 import static org.apache.ignite.plugin.segmentation.SegmentationPolicy.RESTART_JVM;
-import static org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi.*;
+import static org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi.DFLT_IP_ADDR;
+import static org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi.DFLT_PORT;
+import static org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi.DFLT_PORT_RANGE;
 
 /**
  * This class is part of an internal API and can be modified at any time without backward compatibility.

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgnitionEx.java
@@ -148,6 +148,7 @@ import static org.apache.ignite.configuration.MemoryConfiguration.DFLT_MEMORY_PO
 import static org.apache.ignite.configuration.MemoryConfiguration.DFLT_MEM_PLC_DEFAULT_NAME;
 import static org.apache.ignite.internal.IgniteComponentType.SPRING;
 import static org.apache.ignite.plugin.segmentation.SegmentationPolicy.RESTART_JVM;
+import static org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi.*;
 
 /**
  * This class is part of an internal API and can be modified at any time without backward compatibility.
@@ -2094,7 +2095,9 @@ public class IgnitionEx {
                 if (tcpDisco.getIpFinder() == null) {
                     TcpDiscoveryVmIpFinder vmIpFinder = new TcpDiscoveryVmIpFinder(true);
 
-                    vmIpFinder.setAddresses(Collections.singletonList("127.0.0.1:47500..47600"));
+                    String addr = DFLT_IP_ADDR + ':' + DFLT_PORT + ".." + (DFLT_PORT + DFLT_PORT_RANGE);
+
+                    vmIpFinder.setAddresses(Collections.singletonList(addr));
 
                     tcpDisco.setIpFinder(vmIpFinder);
                 }

--- a/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySpi.java
@@ -247,6 +247,9 @@ public class TcpDiscoverySpi extends IgniteSpiAdapter implements IgniteDiscovery
     /** Default port to listen (value is <tt>47500</tt>). */
     public static final int DFLT_PORT = 47500;
 
+    /** Default IP address to seek other nodes at. */
+    public static final String DFLT_IP_ADDR = "127.0.0.1";
+
     /** Default timeout for joining topology (value is <tt>0</tt>). */
     public static final long DFLT_JOIN_TIMEOUT = 0;
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheFutureExceptionSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheFutureExceptionSelfTest.java
@@ -45,8 +45,7 @@ public class CacheFutureExceptionSelfTest extends GridCommonAbstractTest {
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
-        return new IgniteConfiguration()
-            .setIgniteInstanceName(igniteInstanceName)
+        return super.getConfiguration(igniteInstanceName)
             .setFailureHandler(new StopNodeFailureHandler());
     }
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/metric/SqlViewExporterSpiTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/metric/SqlViewExporterSpiTest.java
@@ -44,6 +44,7 @@ import org.apache.ignite.configuration.ClientConfiguration;
 import org.apache.ignite.configuration.DataRegionConfiguration;
 import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.configuration.SqlConfiguration;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.metric.AbstractExporterSpiTest;
 import org.apache.ignite.internal.metric.SystemViewSelfTest.TestPredicate;
@@ -359,7 +360,8 @@ public class SqlViewExporterSpiTest extends AbstractExporterSpiTest {
     /** */
     @Test
     public void testSchemas() throws Exception {
-        try (IgniteEx g = startGrid(new IgniteConfiguration().setSqlSchemas("MY_SCHEMA", "ANOTHER_SCHEMA"))) {
+        try (IgniteEx g = startGrid(getConfiguration(getTestIgniteInstanceName(3))
+                .setSqlConfiguration(new SqlConfiguration().setSqlSchemas("MY_SCHEMA", "ANOTHER_SCHEMA")))) {
             SystemView<SqlSchemaView> schemasSysView = g.context().systemView().view(SQL_SCHEMA_VIEW);
 
             Set<String> schemaFromSysView = new HashSet<>();

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/metric/SqlViewExporterSpiTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/metric/SqlViewExporterSpiTest.java
@@ -62,6 +62,7 @@ import org.junit.Test;
 
 import static java.util.Arrays.asList;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_EVENT_DRIVEN_SERVICE_PROCESSOR_ENABLED;
+import static org.apache.ignite.cluster.ClusterState.ACTIVE;
 import static org.apache.ignite.internal.metric.SystemViewSelfTest.TEST_PREDICATE;
 import static org.apache.ignite.internal.metric.SystemViewSelfTest.TEST_TRANSFORMER;
 import static org.apache.ignite.internal.processors.cache.GridCacheUtils.cacheGroupId;
@@ -109,7 +110,7 @@ public class SqlViewExporterSpiTest extends AbstractExporterSpiTest {
         ignite0 = startGrid(0);
         ignite1 = startGrid(1);
 
-        ignite0.cluster().active(true);
+        ignite0.cluster().state(ACTIVE);
     }
 
     /** {@inheritDoc} */

--- a/modules/platforms/cpp/benchmarks/odbc-sql/config/example-odbc.xml
+++ b/modules/platforms/cpp/benchmarks/odbc-sql/config/example-odbc.xml
@@ -102,8 +102,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/core-test/config/compute-client-default.xml
+++ b/modules/platforms/cpp/core-test/config/compute-client-default.xml
@@ -49,11 +49,11 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
-                        <property name="addresses">
-                            <list>
-                                <!-- In distributed environment, replace with actual host IP address. -->
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
+                            <property name="addresses">
+                                <list>
+                                    <!-- In distributed environment, replace with actual host IP address. -->
                                 <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>

--- a/modules/platforms/cpp/core-test/config/compute-server0-default.xml
+++ b/modules/platforms/cpp/core-test/config/compute-server0-default.xml
@@ -107,8 +107,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example-client.xml
+++ b/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example-client.xml
@@ -40,7 +40,7 @@
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->
-                                <value>127.0.0.1:47550..47551</value>
+                                <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>
                     </bean>

--- a/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example-client.xml
+++ b/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example-client.xml
@@ -35,8 +35,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example1.xml
+++ b/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example1.xml
@@ -40,7 +40,7 @@
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->
-                                <value>127.0.0.1:47550..47551</value>
+                                <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>
                     </bean>

--- a/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example1.xml
+++ b/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example1.xml
@@ -35,8 +35,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example2.xml
+++ b/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example2.xml
@@ -40,7 +40,7 @@
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->
-                                <value>127.0.0.1:47550..47551</value>
+                                <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>
                     </bean>

--- a/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example2.xml
+++ b/modules/platforms/cpp/examples/cluster-compute-example/config/cluster-compute-example2.xml
@@ -35,8 +35,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/compute-example/config/compute-example.xml
+++ b/modules/platforms/cpp/examples/compute-example/config/compute-example.xml
@@ -40,7 +40,7 @@
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->
-                                <value>127.0.0.1:47550..47551</value>
+                                <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>
                     </bean>

--- a/modules/platforms/cpp/examples/compute-example/config/compute-example.xml
+++ b/modules/platforms/cpp/examples/compute-example/config/compute-example.xml
@@ -35,8 +35,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/continuous-query-example/config/continuous-query-example.xml
+++ b/modules/platforms/cpp/examples/continuous-query-example/config/continuous-query-example.xml
@@ -40,7 +40,7 @@
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->
-                                <value>127.0.0.1:47550..47551</value>
+                                <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>
                     </bean>

--- a/modules/platforms/cpp/examples/continuous-query-example/config/continuous-query-example.xml
+++ b/modules/platforms/cpp/examples/continuous-query-example/config/continuous-query-example.xml
@@ -35,8 +35,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/odbc-example/config/example-odbc.xml
+++ b/modules/platforms/cpp/examples/odbc-example/config/example-odbc.xml
@@ -117,8 +117,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/put-get-example/config/example-cache.xml
+++ b/modules/platforms/cpp/examples/put-get-example/config/example-cache.xml
@@ -50,8 +50,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->

--- a/modules/platforms/cpp/examples/query-example/config/query-example.xml
+++ b/modules/platforms/cpp/examples/query-example/config/query-example.xml
@@ -119,7 +119,7 @@
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->
-                                <value>127.0.0.1:47550..47551</value>
+                                <value>127.0.0.1:47500..47501</value>
                             </list>
                         </property>
                     </bean>

--- a/modules/platforms/cpp/examples/query-example/config/query-example.xml
+++ b/modules/platforms/cpp/examples/query-example/config/query-example.xml
@@ -114,8 +114,8 @@
                         instead os static IP based discovery.
                     -->
                     <!-- Uncomment static IP finder to enable static-based discovery of initial nodes. -->
-                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">-->
-                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">
+                    <bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.vm.TcpDiscoveryVmIpFinder">
+                    <!--<bean class="org.apache.ignite.spi.discovery.tcp.ipfinder.multicast.TcpDiscoveryMulticastIpFinder">-->
                         <property name="addresses">
                             <list>
                                 <!-- In distributed environment, replace with actual host IP address. -->


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-37739