### PR TITLE
GG-38158 Add new physical WAL record to cover updating time-to-live value of fragmented data entries.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/WALRecord.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/WALRecord.java
@@ -276,7 +276,10 @@ public abstract class WALRecord {
         PARTITION_CLEARING_START_RECORD(73, LOGICAL),
 
         /** Ecnrypted out-of-order update which is used by atomic caches on backup nodes. */
-        ENCRYPTED_OUT_OF_ORDER_UPDATE(74, LOGICAL);
+        ENCRYPTED_OUT_OF_ORDER_UPDATE(74, LOGICAL),
+
+        /** Physical WAL record that represents a fragment of an entry update. */
+        DATA_PAGE_FRAGMENTED_UPDATE_RECORD(81, PHYSICAL);
 
         /** Index for serialization. Should be consistent throughout all versions. */
         private final int idx;

--- a/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/delta/DataPageFragmentedUpdateRecord.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/pagemem/wal/record/delta/DataPageFragmentedUpdateRecord.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.pagemem.wal.record.delta;
+
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.internal.pagemem.PageMemory;
+import org.apache.ignite.internal.processors.cache.persistence.tree.io.DataPageIO;
+import org.apache.ignite.internal.processors.cache.persistence.tree.io.PageIO;
+import org.apache.ignite.internal.util.typedef.internal.S;
+
+/**
+ * Physical WAL record that represents a fragment of an entry update.
+ */
+public class DataPageFragmentedUpdateRecord extends DataPageUpdateRecord {
+    /** Link to the next entry fragment. */
+    private final long linkToNextFragment;
+
+    /**
+     * @param grpId Cache group ID.
+     * @param pageId Page ID.
+     * @param itemId Item ID.
+     * @param linkToNextFragment Link to the next entry fragment.
+     * @param payload Record data.
+     */
+    public DataPageFragmentedUpdateRecord(
+        int grpId,
+        long pageId,
+        int itemId,
+        long linkToNextFragment,
+        byte[] payload
+    ) {
+        super(grpId, pageId, itemId, payload);
+
+        this.linkToNextFragment = linkToNextFragment;
+    }
+
+    /**
+     * @return Link to the next entry fragment.
+     */
+    public long linkToNextFragment() {
+        return linkToNextFragment;
+    }
+
+    /** {@inheritDoc} */
+    @Override public void applyDelta(PageMemory pageMem, long pageAddr) throws IgniteCheckedException {
+        assert payload() != null;
+
+        DataPageIO io = PageIO.getPageIO(pageAddr);
+
+        io.updateFragmentedData(pageAddr, itemId(), pageMem.realPageSize(groupId()), linkToNextFragment, payload());
+    }
+
+    /** {@inheritDoc} */
+    @Override public RecordType type() {
+        return RecordType.DATA_PAGE_FRAGMENTED_UPDATE_RECORD;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(DataPageFragmentedUpdateRecord.class, this, "super", super.toString());
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheMapEntry.java
@@ -4137,10 +4137,7 @@ public abstract class GridCacheMapEntry extends GridMetadataAwareAdapter impleme
         assert cctx.shared().database().checkpointLockIsHeldByThread() :
             "Checkpoint lock must be held by the thread before acquiring entry lock";
 
-        if (cctx.queries().enabled() || cctx.mvccEnabled() || cctx.cacheObjectContext().compressionStrategy() != null || isNear() ||
-            cctx.group().persistenceEnabled()) {
-            // TODO https://ggsystems.atlassian.net/browse/GG-38158
-
+        if (cctx.queries().enabled() || cctx.mvccEnabled() || cctx.cacheObjectContext().compressionStrategy() != null || isNear()) {
             // Fast update is not possible for this entry. Need to fallback to writing the whole entry.
             //  - in general, enabling sql indices should not prevent from using fast update. Can be improved later.
             //  - mvcc and compression are not supported for fast update yet.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/AbstractDataPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/AbstractDataPageIO.java
@@ -194,13 +194,13 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
     private static final int ITEM_SIZE = 2;
 
     /** */
-    private static final int PAYLOAD_LEN_SIZE = 2;
+    protected static final int PAYLOAD_LEN_SIZE = 2;
 
     /** */
-    private static final int LINK_SIZE = 8;
+    protected static final int LINK_SIZE = 8;
 
     /** */
-    private static final int FRAGMENTED_FLAG = 0b10000000_00000000;
+    protected static final int FRAGMENTED_FLAG = 0b10000000_00000000;
 
     /** */
     public static final int MIN_DATA_PAGE_OVERHEAD = ITEMS_OFF + ITEM_SIZE + PAYLOAD_LEN_SIZE + LINK_SIZE;
@@ -1472,7 +1472,7 @@ public abstract class AbstractDataPageIO<T extends Storable> extends PageIO impl
         assertPageType(pageAddr);
 
         PageUtils.putShort(pageAddr, dataOff, (short)payload.length);
-        dataOff += 2;
+        dataOff += PAYLOAD_LEN_SIZE;
 
         PageUtils.putBytes(pageAddr, dataOff, payload);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/DataPageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/DataPageIO.java
@@ -233,6 +233,37 @@ public class DataPageIO extends AbstractDataPageIO<CacheDataRow> {
     }
 
     /**
+     * Updates fragmented data row with the given payload.
+     *
+     * @param pageAddr Page address.
+     * @param itemId Item ID.
+     * @param pageSize Page size.
+     * @param linkToNextFragment Link to the next fragment.
+     * @param payload Payload.
+     */
+    public void updateFragmentedData(
+        long pageAddr,
+        int itemId,
+        int pageSize,
+        long linkToNextFragment,
+        byte[] payload
+    ) {
+        assertPageType(pageAddr);
+        assert checkIndex(itemId) : "Invalid item Id [itemId=" + itemId + ']';
+        assert payload != null : "Payload is null";
+
+        int dataOff = getDataOffset(pageAddr, itemId, pageSize);
+
+        PageUtils.putShort(pageAddr, dataOff, (short)(payload.length | FRAGMENTED_FLAG));
+        dataOff += PAYLOAD_LEN_SIZE;
+
+        PageUtils.putLong(pageAddr, dataOff, linkToNextFragment);
+        dataOff += LINK_SIZE;
+
+        PageUtils.putBytes(pageAddr, dataOff, payload);
+    }
+
+    /**
      * Calculates start position of the fragment defined by {@code type}.
      *
      * @param row Row.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/serializer/RecordDataV2Serializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/wal/serializer/RecordDataV2Serializer.java
@@ -45,6 +45,7 @@ import org.apache.ignite.internal.pagemem.wal.record.SnapshotRecord;
 import org.apache.ignite.internal.pagemem.wal.record.TxRecord;
 import org.apache.ignite.internal.pagemem.wal.record.WALRecord;
 import org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType;
+import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageFragmentedUpdateRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.TrackingPageRepairDeltaRecord;
 import org.apache.ignite.internal.processors.cache.CacheObject;
 import org.apache.ignite.internal.processors.cache.CacheObjectContext;
@@ -130,6 +131,12 @@ public class RecordDataV2Serializer extends RecordDataV1Serializer {
 
             case PARTITION_CLEARING_START_RECORD:
                 return 4 + 4 + 8;
+
+            case DATA_PAGE_FRAGMENTED_UPDATE_RECORD:
+                DataPageFragmentedUpdateRecord uRec = (DataPageFragmentedUpdateRecord)rec;
+
+                return /*group id*/4 + /*page id*/8 + /*item id*/4 + /*link to the next entry fragment*/8 +
+                    /*payload length*/2 + uRec.payload().length;
 
             default:
                 return super.plainSize(rec);
@@ -268,6 +275,25 @@ public class RecordDataV2Serializer extends RecordDataV1Serializer {
 
                 return new OutOfOrderDataRecord(entries, timeStamp);
 
+            case DATA_PAGE_FRAGMENTED_UPDATE_RECORD: {
+                cacheId = in.readInt();
+                pageId = in.readLong();
+
+                int itemId = in.readInt();
+
+                int size = in.readUnsignedShort();
+
+                long linkToNextEntryFragment = in.readLong();
+
+                in.ensure(size);
+
+                byte[] payload = new byte[size];
+
+                in.readFully(payload);
+
+                return new DataPageFragmentedUpdateRecord(cacheId, pageId, itemId, linkToNextEntryFragment, payload);
+            }
+
             default:
                 return super.readPlainRecord(type, in, encrypted, recordSize);
         }
@@ -370,6 +396,20 @@ public class RecordDataV2Serializer extends RecordDataV1Serializer {
                 break;
 
             case CONSISTENT_CUT:
+                break;
+
+            case DATA_PAGE_FRAGMENTED_UPDATE_RECORD:
+                DataPageFragmentedUpdateRecord uRec = (DataPageFragmentedUpdateRecord)rec;
+
+                buf.putInt(uRec.groupId());
+                buf.putLong(uRec.pageId());
+                buf.putInt(uRec.itemId());
+
+                buf.putShort((short)uRec.payload().length);
+                buf.putLong(uRec.linkToNextFragment());
+
+                buf.put(uRec.payload());
+
                 break;
 
             default:

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgnitePdsWithTtlTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/db/IgnitePdsWithTtlTest.java
@@ -16,6 +16,10 @@
 
 package org.apache.ignite.internal.processors.cache.persistence.db;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -26,9 +30,11 @@ import javax.cache.expiry.AccessedExpiryPolicy;
 import javax.cache.expiry.CreatedExpiryPolicy;
 import javax.cache.expiry.Duration;
 import javax.cache.expiry.ExpiryPolicy;
+import javax.cache.expiry.TouchedExpiryPolicy;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteException;
 import org.apache.ignite.cache.CacheMode;
 import org.apache.ignite.cache.CachePeekMode;
 import org.apache.ignite.cache.CacheRebalanceMode;
@@ -46,13 +52,21 @@ import org.apache.ignite.failure.NoOpFailureHandler;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.IgniteFutureTimeoutCheckedException;
 import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.pagemem.wal.WALIterator;
+import org.apache.ignite.internal.pagemem.wal.WALPointer;
+import org.apache.ignite.internal.pagemem.wal.record.WALRecord;
 import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.GridCacheSharedContext;
 import org.apache.ignite.internal.processors.cache.IgniteCacheOffheapManager;
 import org.apache.ignite.internal.processors.cache.IgniteCacheProxy;
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtLocalPartition;
+import org.apache.ignite.internal.processors.cache.persistence.GridCacheDatabaseSharedManager;
+import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointEntry;
 import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointManager;
+import org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointMarkersStorage;
+import org.apache.ignite.internal.processors.cache.persistence.wal.reader.IgniteWalIteratorFactory;
 import org.apache.ignite.internal.util.ReentrantReadWriteLockWithTracking;
+import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.internal.util.lang.GridAbsPredicate;
 import org.apache.ignite.internal.util.lang.GridCursor;
 import org.apache.ignite.internal.util.typedef.F;
@@ -60,15 +74,23 @@ import org.apache.ignite.internal.util.typedef.PA;
 import org.apache.ignite.internal.util.typedef.X;
 import org.apache.ignite.internal.util.typedef.internal.CU;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.lang.IgniteBiTuple;
+import org.apache.ignite.logger.NullLogger;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.MvccFeatureChecker;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.ignite.IgniteSystemProperties.IGNITE_DEFAULT_DISK_PAGE_COMPRESSION;
 import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
 import static org.apache.ignite.cache.CacheAtomicityMode.TRANSACTIONAL;
 import static org.apache.ignite.cluster.ClusterState.ACTIVE;
 import static org.apache.ignite.cluster.ClusterState.INACTIVE;
+import static org.apache.ignite.internal.processors.cache.persistence.CheckpointState.FINISHED;
+import static org.apache.ignite.internal.processors.cache.persistence.checkpoint.CheckpointEntryType.END;
 import static org.apache.ignite.testframework.GridTestUtils.runAsync;
 import static org.apache.ignite.testframework.GridTestUtils.runMultiThreadedAsync;
 import static org.apache.ignite.testframework.GridTestUtils.waitForAllFutures;
@@ -438,7 +460,7 @@ public class IgnitePdsWithTtlTest extends GridCommonAbstractTest {
             srv.cluster().baselineAutoAdjustEnabled(false);
 
             startGrid(1);
-            srv.cluster().active(true);
+            srv.cluster().state(ACTIVE);
 
             ExpiryPolicy plc = CreatedExpiryPolicy.factoryOf(Duration.ONE_DAY).create();
 
@@ -471,6 +493,77 @@ public class IgnitePdsWithTtlTest extends GridCommonAbstractTest {
         finally {
             stopAllGrids();
         }
+    }
+
+    /**
+     * Tests that expiration of large entries (that require more than one data pages)
+     * work correctly after node stopping in the midle of checkpoint.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testExpirationLargeEntriesAfterNodeRestart() throws Exception {
+        if (System.getProperty(IGNITE_DEFAULT_DISK_PAGE_COMPRESSION) != null) {
+            log.info("Test is skipped because of " + IGNITE_DEFAULT_DISK_PAGE_COMPRESSION + " property is set.");
+
+            return;
+        }
+
+        IgniteEx srv = startGrid(0);
+
+        srv.cluster().state(ACTIVE);
+
+        String nodeFolderName = srv.context().pdsFolderResolver().resolveFolders().folderName();
+
+        IgniteCache<Integer, byte[]> c = srv.getOrCreateCache(CACHE_NAME_ATOMIC);
+
+        // Insert a new value to the cache.
+        // It assumed that the entry will be spit to two pages. Moreover, the time to live value will be split on both pages.
+        c.withExpiryPolicy(new TouchedExpiryPolicy(new Duration(MILLISECONDS, EXPIRATION_TIMEOUT * 10)))
+            .put(12, new byte[1024 * 4 - 100]);
+
+        // Touch the entry to update the time to live value.
+        c.withExpiryPolicy(new TouchedExpiryPolicy(new Duration(SECONDS, EXPIRATION_TIMEOUT))).touch(12);
+
+        // Create a checkpoint and remove checkpoint end marker in order to emulate stopping the node in the middle of checkpoint.
+        GridCacheDatabaseSharedManager dbMgr = (GridCacheDatabaseSharedManager) srv.context().cache().context().database();
+
+        IgniteInternalFuture<?> cpFinishFut = dbMgr.forceCheckpoint("test checkpoint").futureFor(FINISHED);
+
+        cpFinishFut = cpFinishFut.chain(fut -> {
+            CheckpointEntry cpEntry = dbMgr.checkpointHistory().lastCheckpoint();
+
+            String cpEndFileName = CheckpointMarkersStorage.checkpointFileName(cpEntry, END);
+
+            GridFutureAdapter<Void> fut0 = new GridFutureAdapter<>();
+
+            try {
+                Files.delete(Paths.get(dbMgr.checkpointDirectory().getAbsolutePath(), cpEndFileName));
+            }
+            catch (IOException e) {
+                fut0.onDone(new IgniteException("Failed to remove checkpoint end marker.", e));
+            }
+            finally {
+                fut0.onDone();
+            }
+
+            return fut0;
+        });
+
+        cpFinishFut.get(10, SECONDS);
+
+        stopGrid(0, true);
+
+        // Check that WAL contains two physical records related to the entry.
+        verifyDataPageFragmentUpdateRecords(nodeFolderName, 2);
+
+        // Restart the node.
+        srv = startGrid(0);
+
+        c = srv.getOrCreateCache(CACHE_NAME_ATOMIC);
+
+        // Check that the entry was expired.
+        waitAndCheckExpired(srv, c);
     }
 
     /**
@@ -566,5 +659,69 @@ public class IgnitePdsWithTtlTest extends GridCommonAbstractTest {
         System.out.println(msg + " {{");
         cache.context().printMemoryStats();
         System.out.println("}} " + msg);
+    }
+
+    /**
+     * @param nodeFolderName Folder name
+     * @param expRecNum Expected number of DATA_PAGE_FRAGMENTED_UPDATE_RECORDs.
+     * @throws IgniteCheckedException If failed.
+     */
+    private void verifyDataPageFragmentUpdateRecords(String nodeFolderName, int expRecNum) throws IgniteCheckedException {
+        String workDir = U.defaultWorkDirectory();
+        File dbDir = U.resolveWorkDirectory(U.defaultWorkDirectory(), "db", false);
+
+        File walDir = new File(dbDir, "wal");
+        File archiveDir = new File(walDir, "archive");
+
+        File nodeWalDir = new File(walDir, nodeFolderName);
+        File nodeArchiveDir = new File(archiveDir, nodeFolderName);
+
+        IgniteWalIteratorFactory factory = new IgniteWalIteratorFactory(new NullLogger());
+
+        IgniteWalIteratorFactory.IteratorParametersBuilder params = createIteratorParametersBuilder(workDir, nodeFolderName)
+            .filesOrDirs(nodeWalDir, nodeArchiveDir);
+
+        int recNum = 0;
+        try (WALIterator iter = factory.iterator(params)) {
+            while (iter.hasNextX()) {
+                IgniteBiTuple<WALPointer, WALRecord> tup = iter.nextX();
+
+                WALRecord walRecord = tup.get2();
+                WALRecord.RecordType type = walRecord.type();
+
+                switch (type) {
+                    case DATA_PAGE_FRAGMENTED_UPDATE_RECORD:
+                        recNum++;
+
+                        break;
+
+                    default:
+                        // No-op.
+                }
+            }
+        }
+
+        assertEquals("Unexpected number of DATA_PAGE_FRAGMENTED_UPDATE_RECORDs", expRecNum, recNum);
+    }
+
+    /**
+     * @param workDir Work directory.
+     * @param nodeFolderName Subfolder name.
+     * @return WAL iterator factory.
+     * @throws IgniteCheckedException If failed.
+     */
+    @NotNull
+    private IgniteWalIteratorFactory.IteratorParametersBuilder createIteratorParametersBuilder(
+        String workDir,
+        String nodeFolderName
+    ) throws IgniteCheckedException {
+        File binaryMeta = U.resolveWorkDirectory(workDir, DataStorageConfiguration.DFLT_BINARY_METADATA_PATH,
+            false);
+        File binaryMetaWithConsId = new File(binaryMeta, nodeFolderName);
+        File marshallerMapping = U.resolveWorkDirectory(workDir, DataStorageConfiguration.DFLT_MARSHALLER_PATH, false);
+
+        return new IgniteWalIteratorFactory.IteratorParametersBuilder()
+            .binaryMetadataFileStoreDir(binaryMetaWithConsId)
+            .marshallerMappingFileStoreDir(marshallerMapping);
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/testframework/wal/record/RecordUtils.java
+++ b/modules/core/src/test/java/org/apache/ignite/testframework/wal/record/RecordUtils.java
@@ -42,6 +42,7 @@ import org.apache.ignite.internal.pagemem.wal.record.SnapshotRecord;
 import org.apache.ignite.internal.pagemem.wal.record.SwitchSegmentRecord;
 import org.apache.ignite.internal.pagemem.wal.record.TxRecord;
 import org.apache.ignite.internal.pagemem.wal.record.WALRecord;
+import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageFragmentedUpdateRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageInsertFragmentRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageInsertRecord;
 import org.apache.ignite.internal.pagemem.wal.record.delta.DataPageMvccMarkUpdatedRecord;
@@ -116,6 +117,7 @@ import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.BTREE_PAGE_REPLACE;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.CHECKPOINT_RECORD;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.CONSISTENT_CUT;
+import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.DATA_PAGE_FRAGMENTED_UPDATE_RECORD;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.DATA_PAGE_INSERT_FRAGMENT_RECORD;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.DATA_PAGE_INSERT_RECORD;
 import static org.apache.ignite.internal.pagemem.wal.record.WALRecord.RecordType.DATA_PAGE_REMOVE_RECORD;
@@ -231,6 +233,7 @@ public class RecordUtils {
             put(PAGE_LIST_META_RESET_COUNT_RECORD, RecordUtils::buildPageListMetaResetCountRecord);
             put(SWITCH_SEGMENT_RECORD, RecordUtils::buildSwitchSegmentRecord);
             put(DATA_PAGE_UPDATE_RECORD, RecordUtils::buildDataPageUpdateRecord);
+            put(DATA_PAGE_FRAGMENTED_UPDATE_RECORD, RecordUtils::buildDataPageFragmentedUpdateRecord);
             put(BTREE_META_PAGE_INIT_ROOT2, RecordUtils::buildMetaPageInitRootInlineRecord);
             put(PARTITION_DESTROY, RecordUtils::buildPartitionDestroyRecord);
             put(SNAPSHOT, RecordUtils::buildSnapshotRecord);
@@ -504,6 +507,12 @@ public class RecordUtils {
         byte[] random = {1, 3, 5};
 
         return new DataPageUpdateRecord(1, 1, 1, random);
+    }
+
+    public static DataPageFragmentedUpdateRecord buildDataPageFragmentedUpdateRecord() {
+        byte[] random = {1, 3, 5};
+
+        return new DataPageFragmentedUpdateRecord(1, 1, 1, 123L, random);
     }
 
     /** **/


### PR DESCRIPTION
(cherry picked from commit 1c959750a3447f984504f8d44b971a3e3a6a20dd)