### PR TITLE
GG-38417 [IGNITE-21417] .NET: Disable TestReconnectToOldNodeDisablesPartitionAwareness on JDK 11+

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientReconnectCompatibilityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Compatibility/ClientReconnectCompatibilityTest.cs
@@ -36,6 +36,14 @@ namespace Apache.Ignite.Core.Tests.Client.Compatibility
         [Test]
         public void TestReconnectToOldNodeDisablesPartitionAwareness()
         {
+            TestUtils.EnsureJvmCreated();
+            if (TestUtilsJni.GetJavaMajorVersion() >= 11)
+            {
+                // Can't run old Ignite versions on Java 11+.
+                Console.WriteLine($"Skipping {nameof(TestReconnectToOldNodeDisablesPartitionAwareness)} on Java 11+");
+                return;
+            }
+
             IIgniteClient client = null;
             var clientConfiguration = new IgniteClientConfiguration(JavaServer.GetClientConfiguration())
             {


### PR DESCRIPTION
Old Ignite versions can't run on newer JDKs.