### PR TITLE
GG-38304 Updated aws sdk version from 1.12.494 to 1.12.651 due to CVE-2024-21634

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -59,7 +59,7 @@
         <asm.version>4.2</asm.version>
         <aspectj.bundle.version>1.9.8</aspectj.bundle.version>
         <aspectj.version>1.9.8</aspectj.version>
-        <aws.sdk.version>1.12.494</aws.sdk.version>
+        <aws.sdk.version>1.12.651</aws.sdk.version>
         <aws.encryption.sdk.version>2.4.0</aws.encryption.sdk.version>
         <camel.version>2.22.3</camel.version>
         <bouncycastle.version>1.75</bouncycastle.version>


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-38304