### PR TITLE
GG-38346 .NET: Fix TestExpiredEventsAreDeliveredWhenIncludeExpiredIsTrue flakiness

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/Query/Continuous/ContinuousQueryAbstractTest.cs
@@ -324,9 +324,9 @@ namespace Apache.Ignite.Core.Tests.Cache.Query.Continuous
                 cache[1] = Entry(2);
 
                 CB_EVTS.TryTake(out var event1, 9000);
-                CB_EVTS.TryTake(out var event2, 9000);
-
                 Assert.AreEqual(CacheEntryEventType.Created, event1.EventType);
+
+                CB_EVTS.TryTake(out var event2, 9000);
                 Assert.AreEqual(CacheEntryEventType.Expired, event2.EventType);
 
                 Assert.IsTrue(event2.HasValue);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -700,7 +700,11 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             {
                 cache[1] = 2;
 
-                TestUtils.WaitForTrueCondition(() => events.Count == 2, 5000);
+                TestUtils.WaitForTrueCondition(
+                    cond: () => events.Count == 2,
+                    messageFunc: () => $"Expected 2 events, got {events.Count}: " +
+                                       string.Concat(", ", events.Select(x => x.EventType)),
+                    5000);
             }
 
             Assert.AreEqual(2, events.Count);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -704,7 +704,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                     cond: () => events.Count == 2,
                     messageFunc: () => $"Expected 2 events, got {events.Count}: " +
                                        string.Concat(", ", events.Select(x => x.EventType)),
-                    5000);
+                    15000);
             }
 
             Assert.AreEqual(2, events.Count);


### PR DESCRIPTION
Increase event wait time - from the test execution time history on TeamCity it is clear that 5 seconds is not enough:

![image](https://github.com/gridgain/gridgain/assets/10922892/40463e31-f301-4e8a-b0b6-60763297e5aa)

