### PR TITLE
GG-38652 - Modify SQLLINE script to use it's own JVM_OPTS

### DIFF
--- a/modules/sqlline/bin/sqlline.bat
+++ b/modules/sqlline/bin/sqlline.bat
@@ -106,11 +106,11 @@ set JAVA_VER_STR=%JAVA_VER_STR:"=%
 for /f "tokens=1,2 delims=." %%a in ("%JAVA_VER_STR%.x") do set MAJOR_JAVA_VER=%%a& set MINOR_JAVA_VER=%%b
 if %MAJOR_JAVA_VER% == 1 set MAJOR_JAVA_VER=%MINOR_JAVA_VER%
 
-call "%SCRIPTS_HOME%\include\jvmdefaults.bat" %MAJOR_JAVA_VER% "%JVM_OPTS%" JVM_OPTS
+call "%SCRIPTS_HOME%\include\jvmdefaults.bat" %MAJOR_JAVA_VER% "%SQL_JVM_OPTS%" SQL_JVM_OPTS
 
 set CP=%IGNITE_LIBS%
 set CP=%CP%;%IGNITE_HOME%\bin\include\sqlline\*
 
-"%JAVA_HOME%\bin\java.exe" %JVM_OPTS% -cp "%CP%" sqlline.SqlLine -d org.apache.ignite.IgniteJdbcThinDriver %*
+"%JAVA_HOME%\bin\java.exe" %SQL_JVM_OPTS% -cp "%CP%" sqlline.SqlLine -d org.apache.ignite.IgniteJdbcThinDriver %*
 
 :error_finish

--- a/modules/sqlline/bin/sqlline.sh
+++ b/modules/sqlline/bin/sqlline.sh
@@ -61,8 +61,8 @@ osname=`uname`
 
 if [ $osname = "OS/390" ] ; then
     export TERM=dumb
-    JVM_OPTS="-Dfile.encoding=IBM-1047 $JVM_OPTS"
-    JVM_OPTS="$(getIbmSslOpts $version) $JVM_OPTS"
+    SQL_JVM_OPTS="-Dfile.encoding=IBM-1047 $SQL_JVM_OPTS"
+    SQL_JVM_OPTS="$(getIbmSslOpts $version) $SQL_JVM_OPTS"
 fi
 
 #
@@ -70,12 +70,12 @@ fi
 #
 . "${SCRIPTS_HOME}"/include/setenv.sh
 
-JVM_OPTS=${JVM_OPTS:-}
+SQL_JVM_OPTS=${SQL_JVM_OPTS:-}
 
 #
-# Final JVM_OPTS for Java 9+ compatibility
+# Final SQL_JVM_OPTS for Java 9+ compatibility
 #
-JVM_OPTS=$(getJavaSpecificOpts $version "$JVM_OPTS")
+SQL_JVM_OPTS=$(getJavaSpecificOpts $version "$SQL_JVM_OPTS")
 
 JDBCLINK="jdbc:ignite:thin://${HOST_AND_PORT:-}${SCHEMA_DELIMITER:-}${SCHEMA:-}${PARAMS:-}"
 
@@ -83,4 +83,4 @@ CP="${IGNITE_LIBS}"
 
 CP="${CP}${SEP}${IGNITE_HOME_TMP}/bin/include/sqlline/*"
 
-"$JAVA" ${JVM_OPTS} -cp ${CP} sqlline.SqlLine -d org.apache.ignite.IgniteJdbcThinDriver $@
+"$JAVA" ${SQL_JVM_OPTS} -cp ${CP} sqlline.SqlLine -d org.apache.ignite.IgniteJdbcThinDriver $@


### PR DESCRIPTION
Currently, sqlline.sh uses the JVM_OPTS property. Therefore, when run locally in the same host/pod as the gridgain node, it will take the same memory settings, GC logging, JFR settings.