### PR TITLE
GG-38647 [GG-38413] Fixed incorrect sender-group parsing in full-state-transfer DR command (#3069)

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/CommonArgParser.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/CommonArgParser.java
@@ -242,8 +242,8 @@ public class CommonArgParser {
 
             if (cmd != null) {
                 if (command != null)
-                    throw new IllegalArgumentException("Only one action can be specified, but found at least two:" +
-                        cmd.toString() + ", " + command.toString());
+                    throw new IllegalArgumentException("Only one action can be specified, but found at least two: " +
+                        cmd.name() + ", " + command.name());
 
                 cmd.parseArguments(argIter);
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/argument/CommandArgUtils.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/argument/CommandArgUtils.java
@@ -16,7 +16,12 @@
 
 package org.apache.ignite.internal.commandline.argument;
 
+import java.util.Collection;
+import org.apache.ignite.internal.util.typedef.F;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+
+import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
 
 /**
  * Utility class for control.sh arguments.
@@ -24,11 +29,14 @@ import org.jetbrains.annotations.Nullable;
 public class CommandArgUtils {
     /**
      * Tries convert {@code text} to one of values {@code enumClass}.
-     * @param text Input test.
-     * @param enumClass {@link CommandArg} enum class.
-     * @param <E>
+     * @param text Input text.
+     * @param enumClass {@link CommandArg} enum class, which values will be used for lookup
+     * @param <E> command argument type, must extend {@link CommandArg}
      * @return Converted argument or {@code null} if convert failed.
+     *
+     * @deprecated name <code>of()</code> is too abstract, consider using {@link #ofArg(Class, String)}
      */
+    @Deprecated
     public static <E extends Enum<E> & CommandArg> @Nullable E of(String text, Class<E> enumClass) {
         for (E e : enumClass.getEnumConstants()) {
             if (e.argName().equalsIgnoreCase(text))
@@ -36,6 +44,53 @@ public class CommandArgUtils {
         }
 
         return null;
+    }
+
+    /**
+     * Same as {@link #of(String, Class)} but name that more clearly reflects its purpose
+     */
+    public static <E extends Enum<E> & CommandArg> @Nullable E ofArg(Class<E> enumClass, @NotNull String text) {
+        return of(text, enumClass);
+    }
+
+    /**
+     * Tries convert {@code text} to one of values {@code enumClass}.
+     * @param text Input text.
+     * @param enumClass {@link CommandArg} enum class, which values will be used for lookup
+     * @param <E> command argument type, must extend {@link CommandArg}
+     * @return Converted argument or {@code null} if convert failed.
+     */
+    public static <E extends Enum<E>> @Nullable E ofEnum(Class<E> enumClass, @NotNull String text) {
+        for (E e : enumClass.getEnumConstants()) {
+            if (e.name().equalsIgnoreCase(text))
+                return e;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns provided value if it's not <code>null</code> otherwise
+     * throws {@link IllegalArgumentException} with specified message
+     */
+    public static <T> @NotNull T failIfNull(@Nullable T val, String errorMsg) throws IllegalArgumentException {
+        if (val == null)
+            throw new IllegalArgumentException(errorMsg);
+
+        return val;
+    }
+
+    /**
+     * Checks that provided cache list doesn't include illegal values (like internal <code>utility</code> cache)
+     */
+    public static <C extends Collection<String>> C validateCachesArgument(C caches, String operation) {
+        if (F.constainsStringIgnoreCase(caches, UTILITY_CACHE_NAME)) {
+            throw new IllegalArgumentException(
+                operation + " not allowed for '" + UTILITY_CACHE_NAME + "' cache."
+            );
+        }
+
+        return caches;
     }
 
     /** Private constructor. */

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/cache/CacheValidateIndexes.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/cache/CacheValidateIndexes.java
@@ -33,7 +33,6 @@ import org.apache.ignite.internal.commandline.CommandLogger;
 import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg;
 import org.apache.ignite.internal.processors.cache.verify.PartitionKey;
-import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.visor.verify.IndexIntegrityCheckIssue;
@@ -57,11 +56,10 @@ import static org.apache.ignite.internal.commandline.cache.CacheCommands.usageCa
 import static org.apache.ignite.internal.commandline.cache.CacheSubcommands.VALIDATE_INDEXES;
 import static org.apache.ignite.internal.commandline.cache.argument.IdleVerifyCommandArg.CACHE_FILTER;
 import static org.apache.ignite.internal.commandline.cache.argument.IdleVerifyCommandArg.EXCLUDE_CACHES;
-import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_FIRST;
-import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_THROUGH;
 import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_CRC;
+import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_FIRST;
 import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_SIZES;
-import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
+import static org.apache.ignite.internal.commandline.cache.argument.ValidateIndexesCommandArg.CHECK_THROUGH;
 
 /**
  * Validate indexes command.
@@ -342,11 +340,7 @@ public class CacheValidateIndexes extends AbstractCommand<CacheValidateIndexes.A
 
             caches = argIter.parseStringSet(nextArg);
 
-            if (F.constainsStringIgnoreCase(caches, UTILITY_CACHE_NAME)) {
-                throw new IllegalArgumentException(
-                    VALIDATE_INDEXES + " not allowed for `" + UTILITY_CACHE_NAME + "` cache."
-                );
-            }
+            CommandArgUtils.validateCachesArgument(caches, VALIDATE_INDEXES.toString());
         }
 
         args = new Arguments(caches, nodeId, checkFirst, checkThrough, checkCrc, checkSizes);

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/diagnostic/PageLocksCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/diagnostic/PageLocksCommand.java
@@ -126,7 +126,7 @@ public class PageLocksCommand extends AbstractCommand<PageLocksCommand.Arguments
 
                     break;
                 case NODES:
-                    nodeIds.addAll(argIter.nextStringSet(""));
+                    nodeIds.addAll(argIter.nextStringSet("list with node ids."));
 
                     break;
                 case PATH:
@@ -135,7 +135,7 @@ public class PageLocksCommand extends AbstractCommand<PageLocksCommand.Arguments
                     break;
                 default:
                     throw new IllegalArgumentException(
-                        "Unexpected argumetn:" + arg + ", supported:" + Arrays.toString(PageLocksCommandArg.values())
+                        "Unexpected argument:" + arg + ", supported:" + Arrays.toString(PageLocksCommandArg.values())
                     );
             }
         }
@@ -159,7 +159,7 @@ public class PageLocksCommand extends AbstractCommand<PageLocksCommand.Arguments
             optional(ALL),
             optional(CommandLogger.or(NODES, "nodeId1,nodeId2,..")),
             optional(CommandLogger.or(NODES, "consistentId1,consistentId2,..")),
-            "// Pring page locks dump to console on the node or nodes."));
+            "// Print page locks dump to console on the node or nodes."));
         logger.info("");
     }
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/DrCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/DrCommand.java
@@ -97,7 +97,7 @@ public class DrCommand extends AbstractCommand<Object> {
             optional(DrCacheCommand.METRICS_PARAM),
             optional(DrCacheCommand.CACHE_FILTER_PARAM, join("|", DrCacheCommand.CacheFilter.values())),
             optional(DrCacheCommand.SENDER_GROUP_PARAM, "<groupName>|" + join("|", DrCacheCommand.SenderGroup.values())),
-            optional(DrCacheCommand.ACTION_PARAM, DrCacheCommand.Action.START.text() + "|" + DrCacheCommand.Action.STOP.text()),
+            optional(DrCacheCommand.ACTION_PARAM, DrCacheCommand.Action.START.argName() + "|" + DrCacheCommand.Action.STOP.argName()),
             optional(CMD_AUTO_CONFIRMATION)
         );
 
@@ -113,7 +113,7 @@ public class DrCommand extends AbstractCommand<Object> {
                 "data center is configured:",
             DATA_CENTER_REPLICATION,
             FULL_STATE_TRANSFER.toString(),
-            optional(DrFSTCommand.Action.START.action()),
+            optional(DrFSTCommand.Action.START.argName()),
             optional(SNAPSHOT_ID, "<snapshotId>"),
             optional(CACHES_PARAM, "<cacheName1, ...>"),
             optional(SENDER_GROUP, "<groupName>|ALL|DEFAULT|NONE"),
@@ -125,7 +125,7 @@ public class DrCommand extends AbstractCommand<Object> {
         usage(log, "Cancel active full state transfer by id:",
             DATA_CENTER_REPLICATION,
             FULL_STATE_TRANSFER.toString(),
-            DrFSTCommand.Action.CANCEL.action(),
+            DrFSTCommand.Action.CANCEL.argName(),
             "<fullStateTransferUID>",
             optional(CMD_AUTO_CONFIRMATION)
         );
@@ -133,7 +133,7 @@ public class DrCommand extends AbstractCommand<Object> {
         usage(log, "Print list of active full state transfers:",
             DATA_CENTER_REPLICATION,
             FULL_STATE_TRANSFER.toString(),
-            DrFSTCommand.Action.LIST.action()
+            DrFSTCommand.Action.LIST.argName()
         );
 
         usage(log, "Stop data center replication on all caches in cluster:",

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrCacheCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrCacheCommand.java
@@ -33,6 +33,8 @@ import org.apache.ignite.internal.client.GridClientDisconnectedException;
 import org.apache.ignite.internal.client.GridClientException;
 import org.apache.ignite.internal.client.GridClientNode;
 import org.apache.ignite.internal.commandline.CommandArgIterator;
+import org.apache.ignite.internal.commandline.argument.CommandArg;
+import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.commandline.dr.DrSubCommandsList;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.T2;
@@ -112,13 +114,7 @@ public class DrCacheCommand extends
                 case CACHE_FILTER_PARAM: {
                     argIter.nextArg(null);
 
-                    String errorMsg = "--cache-filter parameter value required.";
-
-                    String cacheFilterStr = argIter.nextArg(errorMsg);
-                    cacheFilter = CacheFilter.valueOf(cacheFilterStr.toUpperCase(Locale.ENGLISH));
-
-                    if (cacheFilter == null)
-                        throw new IllegalArgumentException(errorMsg);
+                    cacheFilter = argIter.nextEnumOrFail(CacheFilter.class, CACHE_FILTER_PARAM);
 
                     break;
                 }
@@ -126,9 +122,9 @@ public class DrCacheCommand extends
                 case SENDER_GROUP_PARAM: {
                     argIter.nextArg(null);
 
-                    String arg = argIter.nextArg(SENDER_GROUP_PARAM + " parameter value required.");
+                    String arg = argIter.nextArgValue(SENDER_GROUP_PARAM);
 
-                    sndGrp = SenderGroup.parse(arg);
+                    sndGrp = CommandArgUtils.ofEnum(SenderGroup.class, arg);
 
                     if (sndGrp == null)
                         sndGrpName = arg;
@@ -139,12 +135,7 @@ public class DrCacheCommand extends
                 case ACTION_PARAM: {
                     argIter.nextArg(null);
 
-                    String errorMsg = ACTION_PARAM + " parameter value required.";
-
-                    act = Action.parse(argIter.nextArg(errorMsg));
-
-                    if (act == null)
-                        throw new IllegalArgumentException(errorMsg);
+                    act = argIter.nextCmdArgOrFail(Action.class, ACTION_PARAM);
 
                     break;
                 }
@@ -312,21 +303,11 @@ public class DrCacheCommand extends
     @SuppressWarnings("PublicInnerClass") public enum SenderGroup {
         /** All. */ ALL,
         /** Default. */ DEFAULT,
-        /** None. */ NONE;
-
-        /** */
-        public static SenderGroup parse(String text) {
-            try {
-                return valueOf(text.toUpperCase(Locale.ENGLISH));
-            }
-            catch (IllegalArgumentException e) {
-                return null;
-            }
-        }
+        /** None. */ NONE
     }
 
     /** */
-    @SuppressWarnings("PublicInnerClass") public enum Action {
+    @SuppressWarnings("PublicInnerClass") public enum Action implements CommandArg {
         /** Stop. */ STOP("stop"),
 
         /** Start. */ START("start"),
@@ -335,31 +316,20 @@ public class DrCacheCommand extends
         FULL_STATE_TRANSFER("full-state-transfer");
 
         /** String representation. */
-        private final String text;
+        private final String name;
 
         /** */
-        Action(String text) {
-            this.text = text;
+        Action(String name) {
+            this.name = name;
         }
 
-        /** */
-        public String text() {
-            return text;
-        }
-
-        /** */
-        public static Action parse(String text) {
-            for (Action action : values()) {
-                if (action.text.equalsIgnoreCase(text))
-                    return action;
-            }
-
-            return null;
+        @Override public String argName() {
+            return name;
         }
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return text;
+            return name;
         }
     }
 

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrCheckPartitionCountersCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrCheckPartitionCountersCommand.java
@@ -16,11 +16,6 @@
 
 package org.apache.ignite.internal.commandline.dr.subcommands;
 
-import static org.apache.ignite.internal.commandline.CommandLogger.DOUBLE_INDENT;
-import static org.apache.ignite.internal.commandline.CommandLogger.INDENT;
-import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.CHECK;
-import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
-
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map.Entry;
@@ -29,11 +24,15 @@ import java.util.UUID;
 import java.util.logging.Logger;
 import org.apache.ignite.internal.commandline.CommandArgIterator;
 import org.apache.ignite.internal.commandline.CommandLogger;
-import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.visor.dr.VisorDrCheckPartitionCountersJobResult;
 import org.apache.ignite.internal.visor.dr.VisorDrCheckPartitionCountersTaskArg;
 import org.apache.ignite.internal.visor.dr.VisorDrCheckPartitionCountersTaskResult;
+
+import static org.apache.ignite.internal.commandline.CommandLogger.DOUBLE_INDENT;
+import static org.apache.ignite.internal.commandline.CommandLogger.INDENT;
+import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.CHECK;
 
 /**
  * DR check partition counters command.
@@ -143,17 +142,7 @@ public class DrCheckPartitionCountersCommand extends
                     scanUntilFirstError = true;
                     break;
                 case CACHES_PARAM:
-                    if (!argIter.hasNextSubArg())
-                        throw new IllegalArgumentException(
-                                "Set of cache names for '" + nextArg + "' parameter expected.");
-
-                    caches = argIter.parseStringSet(argIter.nextArg(""));
-
-                    if (F.constainsStringIgnoreCase(caches, UTILITY_CACHE_NAME)) {
-                        throw new IllegalArgumentException(
-                                CHECK + " not allowed for `" + UTILITY_CACHE_NAME + "` cache."
-                        );
-                    }
+                    caches = CommandArgUtils.validateCachesArgument(argIter.nextCachesSet(CACHES_PARAM), CHECK.toString());
                     break;
                 default:
                     throw new IllegalArgumentException("Argument " + nextArg + " is not supported.");

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrFSTCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrFSTCommand.java
@@ -32,6 +32,8 @@ import org.apache.ignite.internal.client.GridClientConfiguration;
 import org.apache.ignite.internal.client.GridClientDisconnectedException;
 import org.apache.ignite.internal.client.GridClientNode;
 import org.apache.ignite.internal.commandline.CommandArgIterator;
+import org.apache.ignite.internal.commandline.argument.CommandArg;
+import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.internal.util.typedef.internal.S;
@@ -41,13 +43,12 @@ import org.apache.ignite.internal.visor.dr.VisorDrCacheTaskArgs;
 import org.apache.ignite.internal.visor.dr.VisorDrCacheTaskResult;
 import org.apache.ignite.internal.visor.dr.VisorDrFSTCmdArgs;
 import org.apache.ignite.lang.IgniteUuid;
+
 import static org.apache.ignite.internal.IgniteFeatures.NEW_DR_FST_COMMANDS;
 import static org.apache.ignite.internal.client.util.GridClientUtils.applyFilter;
 import static org.apache.ignite.internal.commandline.CommandHandler.DELIM;
 import static org.apache.ignite.internal.commandline.CommonArgParser.CMD_AUTO_CONFIRMATION;
-import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.CHECK;
 import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.FULL_STATE_TRANSFER;
-import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
 
 /** */
 public class DrFSTCommand
@@ -111,7 +112,7 @@ public class DrFSTCommand
                     return new VisorDrFSTCmdArgs(action.ordinal(), params0.operationId());
 
                 default:
-                    throw new IllegalArgumentException("Action [" + action.action() + "] not supported.");
+                    throw new IllegalArgumentException("Action [" + action.argName() + "] not supported.");
             }
         }
 
@@ -172,7 +173,7 @@ public class DrFSTCommand
 
         String actionStr = argIter.nextArg("One of possible actions: " + actions + " is required.");
 
-        Action action = Action.parse(actionStr);
+        Action action = CommandArgUtils.ofArg(Action.class, actionStr);
 
         if (action == null)
             throw new IllegalArgumentException("Action [" + actionStr + "] not supported.");
@@ -252,7 +253,7 @@ public class DrFSTCommand
     }
 
     /** FST actions. */
-    public enum Action {
+    public enum Action implements CommandArg {
         /** Start FST. */
         START("start", new ParseStart()),
 
@@ -263,30 +264,20 @@ public class DrFSTCommand
         LIST("list", new ParseNone());
 
         /** String representation. */
-        private final String action;
+        private final String name;
 
         /** */
         private final ParseAction parseAction;
 
         /** */
         Action(String item, ParseAction parseAction) {
-            action = item;
+            name = item;
             this.parseAction = parseAction;
         }
 
-        /** */
-        public String action() {
-            return action;
-        }
-
-        /** */
-        public static Action parse(String item) {
-            for (Action action : values()) {
-                if (action.action.equalsIgnoreCase(item))
-                    return action;
-            }
-
-            return null;
+        /** {@inheritDoc} */
+        @Override public String argName() {
+            return name;
         }
 
         /**
@@ -298,12 +289,12 @@ public class DrFSTCommand
 
         /** {@inheritDoc} */
         @Override public String toString() {
-            return action;
+            return name;
         }
     }
 
     /** */
-    private static interface ActionParams {
+    private interface ActionParams {
     }
 
     /** */
@@ -413,7 +404,7 @@ public class DrFSTCommand
     }
 
     /** */
-    private static interface ParseAction<T extends ActionParams> {
+    private interface ParseAction<T extends ActionParams> {
         /** Parse further params. */
         T parse(CommandArgIterator argIter);
     }
@@ -453,6 +444,7 @@ public class DrFSTCommand
         /** Data center id`s. */
         public static final String DATA_CENTERS = "--data-centers";
 
+        /** Sync mode flag. */
         public static final String SYNC_MODE = "--sync";
 
         /** {@inheritDoc} */
@@ -461,7 +453,7 @@ public class DrFSTCommand
             Long snapshotId = null;
             DrCacheCommand.SenderGroup sndGrp = DrCacheCommand.SenderGroup.ALL;
             String sndGrpName = null;
-            Set<Byte> dcIds = null;
+            final Set<Byte> dcIds = new HashSet<>();
             boolean syncMode = false;
 
             while (argIter.hasNextSubArg()) {
@@ -469,29 +461,17 @@ public class DrFSTCommand
 
                 switch (nextArg.toLowerCase(Locale.ENGLISH)) {
                     case SNAPSHOT_ID:
-                        snapshotId = Long.parseLong(argIter.nextArg("Snapshot identificator expected."));
+                        snapshotId = argIter.nextLongArg("snapshot identificator");
                         break;
 
                     case CACHES_PARAM:
-                        if (!argIter.hasNextSubArg())
-                            throw new IllegalArgumentException(
-                                "Set of cache names for '" + nextArg + "' parameter expected.");
-
-                        caches = argIter.parseStringSet(argIter.nextArg(""));
-
-                        if (F.constainsStringIgnoreCase(caches, UTILITY_CACHE_NAME)) {
-                            throw new IllegalArgumentException(
-                                CHECK + " not allowed for `" + UTILITY_CACHE_NAME + "` cache."
-                            );
-                        }
+                        caches = CommandArgUtils.validateCachesArgument(argIter.nextCachesSet(CACHES_PARAM), FULL_STATE_TRANSFER.toString());
                         break;
 
                     case SENDER_GROUP:
-                        argIter.nextArg(null);
+                        String arg = argIter.nextArgValue(SENDER_GROUP);
 
-                        String arg = argIter.nextArg(SENDER_GROUP + " parameter value required.");
-
-                        sndGrp = DrCacheCommand.SenderGroup.parse(arg);
+                        sndGrp = CommandArgUtils.ofEnum(DrCacheCommand.SenderGroup.class, arg);
 
                         if (sndGrp == null)
                             sndGrpName = arg;
@@ -499,23 +479,14 @@ public class DrFSTCommand
                         break;
 
                     case DATA_CENTERS:
-                        if (!argIter.hasNextSubArg())
-                            throw new IllegalArgumentException(
-                                "Set of datacenter id`s for '" + nextArg + "' parameter expected.");
+                        Set<String> dcIdsStr = argIter.nextNonEmptyStringSet("set of datacenter ids for '" + DATA_CENTERS + "' parameter");
 
-                        Set<String> dcIdsStr = argIter.parseStringSet(argIter.nextArg(""));
-
-                        dcIds = new HashSet<>();
-
-                        Set<Byte> dcIds0 = dcIds;
-
-                        dcIdsStr.forEach(dc -> dcIds0.add(Byte.parseByte(dc)));
+                        dcIdsStr.forEach(dc -> dcIds.add(Byte.parseByte(dc)));
 
                         break;
 
                     case SYNC_MODE:
                         syncMode = true;
-
                         break;
 
                     default:

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrRebuildPartitionLogCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrRebuildPartitionLogCommand.java
@@ -27,7 +27,7 @@ import org.apache.ignite.internal.commandline.AbstractCommand;
 import org.apache.ignite.internal.commandline.Command;
 import org.apache.ignite.internal.commandline.CommandArgIterator;
 import org.apache.ignite.internal.commandline.CommandLogger;
-import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.visor.dr.VisorDrRebuildTreeOperation;
 import org.apache.ignite.internal.visor.dr.VisorDrRebuildTreeTask;
@@ -38,7 +38,6 @@ import org.jetbrains.annotations.Nullable;
 import static org.apache.ignite.internal.commandline.TaskExecutor.executeTaskByNameOnNode;
 import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.REBUILD_TREES;
 import static org.apache.ignite.internal.commandline.util.TopologyUtils.anyConnectableServerNode;
-import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
 
 /**
  * Repair partition counters command.
@@ -138,32 +137,11 @@ public class DrRebuildPartitionLogCommand extends AbstractCommand<DrRebuildParti
 
                     switch (nextArg) {
                         case CACHES_ARG:
-                            if (!argIter.hasNextSubArg())
-                                throw new IllegalArgumentException(
-                                    "Set of cache names for '" + nextArg + "' parameter expected.");
-
-                            cacheNames = argIter.parseStringSet(argIter.nextArg(""));
-
-                            if (F.constainsStringIgnoreCase(cacheNames, UTILITY_CACHE_NAME)) {
-                                throw new IllegalArgumentException(
-                                    REBUILD_TREES + " not allowed for `" + UTILITY_CACHE_NAME + "` cache."
-                                );
-                            }
-
+                            cacheNames = CommandArgUtils.validateCachesArgument(argIter.nextCachesSet(nextArg), REBUILD_TREES.toString());
                             break;
+
                         case GROUPS_ARG:
-                            if (!argIter.hasNextSubArg())
-                                throw new IllegalArgumentException(
-                                    "Set of cache group names for '" + nextArg + "' parameter expected.");
-
-                            cacheGrps = argIter.parseStringSet(argIter.nextArg(""));
-
-                            if (F.constainsStringIgnoreCase(cacheGrps, UTILITY_CACHE_NAME)) {
-                                throw new IllegalArgumentException(
-                                    REBUILD_TREES + " not allowed for `" + UTILITY_CACHE_NAME + "` cache."
-                                );
-                            }
-
+                            cacheGrps = CommandArgUtils.validateCachesArgument(argIter.nextCacheGroupsSet(nextArg), REBUILD_TREES.toString());
                             break;
 
                         default:

--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrRepairPartitionCountersCommand.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/dr/subcommands/DrRepairPartitionCountersCommand.java
@@ -16,11 +16,6 @@
 
 package org.apache.ignite.internal.commandline.dr.subcommands;
 
-import static org.apache.ignite.internal.commandline.CommandLogger.DOUBLE_INDENT;
-import static org.apache.ignite.internal.commandline.CommandLogger.INDENT;
-import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.REPAIR;
-import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
-
 import java.util.Collection;
 import java.util.Locale;
 import java.util.Map.Entry;
@@ -29,11 +24,15 @@ import java.util.UUID;
 import java.util.logging.Logger;
 import org.apache.ignite.internal.commandline.CommandArgIterator;
 import org.apache.ignite.internal.commandline.CommandLogger;
-import org.apache.ignite.internal.util.typedef.F;
+import org.apache.ignite.internal.commandline.argument.CommandArgUtils;
 import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.visor.dr.VisorDrRepairPartitionCountersJobResult;
 import org.apache.ignite.internal.visor.dr.VisorDrRepairPartitionCountersTaskArg;
 import org.apache.ignite.internal.visor.dr.VisorDrRepairPartitionCountersTaskResult;
+
+import static org.apache.ignite.internal.commandline.CommandLogger.DOUBLE_INDENT;
+import static org.apache.ignite.internal.commandline.CommandLogger.INDENT;
+import static org.apache.ignite.internal.commandline.dr.DrSubCommandsList.REPAIR;
 
 /**
  * Repair partition counters command.
@@ -126,17 +125,7 @@ public class DrRepairPartitionCountersCommand extends DrAbstractRemoteSubCommand
 
             switch (nextArg.toLowerCase(Locale.ENGLISH)) {
                 case CACHES_PARAM:
-                    if (!argIter.hasNextSubArg())
-                        throw new IllegalArgumentException(
-                                "Set of cache names for '" + nextArg + "' parameter expected.");
-
-                    caches = argIter.parseStringSet(argIter.nextArg(""));
-
-                    if (F.constainsStringIgnoreCase(caches, UTILITY_CACHE_NAME)) {
-                        throw new IllegalArgumentException(
-                                REPAIR + " not allowed for `" + UTILITY_CACHE_NAME + "` cache."
-                        );
-                    }
+                    caches = CommandArgUtils.validateCachesArgument(argIter.nextCachesSet(CACHES_PARAM), REPAIR.toString());
                     break;
                 case BATCH_SIZE:
                     batchSize = readBatchSizeParam(argIter, nextArg);

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerParsingTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerParsingTest.java
@@ -592,7 +592,7 @@ public class CommandHandlerParsingTest {
             null,
             () -> parseArgs(asList("--cache", "validate_indexes", "cache1,ignite-sys-cache")),
             IllegalArgumentException.class,
-            "validate_indexes not allowed for `ignite-sys-cache` cache."
+            "validate_indexes not allowed for 'ignite-sys-cache' cache."
         );
     }
 
@@ -762,7 +762,7 @@ public class CommandHandlerParsingTest {
      *
      * --parallelism
      *      Int value from [0, 128] is expected.
-     *      If value is missing of differs from metioned integer -
+     *      If value is missing of differs from mentioned integer -
      *      IllegalArgumentException (Invalid parallelism) is expected.
      *
      * --batch-size

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerAbstractTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerAbstractTest.java
@@ -117,7 +117,7 @@ public abstract class GridCommandHandlerAbstractTest extends GridCommonAbstractT
     /** Enable automatic confirmation to avoid user interaction. */
     protected boolean autoConfirmation = true;
 
-    /** {@code True} if encription is enabled. */
+    /** {@code True} if encryption is enabled. */
     protected boolean encryptionEnabled;
 
     /**  Re-encryption rate limit in megabytes per second. */


### PR DESCRIPTION
Also minor refactoring in CLI components (mostly copy-paste deduplication)

(cherry picked from commit 13505c2fc15ff898875c9bdefc5f8af4fad3c500)