### PR TITLE
GG-38457 Thin client: Add ClientCacheConfiguration.pluginConfigurations

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCacheConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCacheConfiguration.java
@@ -29,6 +29,7 @@ import org.apache.ignite.cache.QueryEntity;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.typedef.internal.S;
+import org.apache.ignite.plugin.CachePluginConfiguration;
 
 /** Cache configuration. */
 public final class ClientCacheConfiguration implements Serializable {
@@ -136,6 +137,11 @@ public final class ClientCacheConfiguration implements Serializable {
      */
     private ExpiryPolicy expiryPlc;
 
+    /**
+     * @serial Cache plugin configurations.
+     */
+    private CachePluginConfiguration[] pluginCfgs;
+
     /** Default constructor. */
     public ClientCacheConfiguration() {
         // No-op.
@@ -178,6 +184,7 @@ public final class ClientCacheConfiguration implements Serializable {
         sqlSchema = ccfg.getSqlSchema();
         statisticsEnabled = ccfg.isStatisticsEnabled();
         writeSynchronizationMode = ccfg.getWriteSynchronizationMode();
+        pluginCfgs = ccfg.getPluginConfigurations();
     }
 
     /**
@@ -716,6 +723,27 @@ public final class ClientCacheConfiguration implements Serializable {
      */
     public ClientCacheConfiguration setExpiryPolicy(ExpiryPolicy expiryPlc) {
         this.expiryPlc = expiryPlc;
+
+        return this;
+    }
+
+    /**
+     * Gets cache plugin configurations.
+     *
+     * @return Cache plugin configurations.
+     */
+    public CachePluginConfiguration[] getPluginConfigurations() {
+        return pluginCfgs != null ? pluginCfgs : new CachePluginConfiguration[0];
+    }
+
+    /**
+     * Sets cache plugin configurations.
+     *
+     * @param pluginCfgs Cache plugin configurations.
+     * @return {@code this} for chaining.
+     */
+    public ClientCacheConfiguration setPluginConfigurations(CachePluginConfiguration... pluginCfgs) {
+        this.pluginCfgs = pluginCfgs;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCacheConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCacheConfiguration.java
@@ -29,7 +29,6 @@ import org.apache.ignite.cache.QueryEntity;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.typedef.internal.S;
-import org.apache.ignite.plugin.CachePluginConfiguration;
 
 /** Cache configuration. */
 public final class ClientCacheConfiguration implements Serializable {
@@ -140,7 +139,7 @@ public final class ClientCacheConfiguration implements Serializable {
     /**
      * @serial Cache plugin configurations.
      */
-    private CachePluginConfiguration[] pluginCfgs;
+    private ClientCachePluginConfiguration[] pluginCfgs;
 
     /** Default constructor. */
     public ClientCacheConfiguration() {
@@ -732,8 +731,8 @@ public final class ClientCacheConfiguration implements Serializable {
      *
      * @return Cache plugin configurations.
      */
-    public CachePluginConfiguration[] getPluginConfigurations() {
-        return pluginCfgs != null ? pluginCfgs : new CachePluginConfiguration[0];
+    public ClientCachePluginConfiguration[] getPluginConfigurations() {
+        return pluginCfgs != null ? pluginCfgs : new ClientCachePluginConfiguration[0];
     }
 
     /**
@@ -742,7 +741,7 @@ public final class ClientCacheConfiguration implements Serializable {
      * @param pluginCfgs Cache plugin configurations.
      * @return {@code this} for chaining.
      */
-    public ClientCacheConfiguration setPluginConfigurations(CachePluginConfiguration... pluginCfgs) {
+    public ClientCacheConfiguration setPluginConfigurations(ClientCachePluginConfiguration... pluginCfgs) {
         this.pluginCfgs = pluginCfgs;
 
         return this;

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-package org.apache.ignite.plugin;
+package org.apache.ignite.client;
 
-import java.io.Serializable;
-
-import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.binary.BinaryRawWriter;
-import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.plugin.CachePluginConfiguration;
 
 /**
- * Cache plugin configuration. It is a point to extend existing {@link CacheConfiguration} 
- * and extend existing functionality of cache.
+ * Client cache plugin configuration. Maps to {@link CachePluginConfiguration} on the server side.
  */
-public interface CachePluginConfiguration<K, V> extends Serializable {
+public interface ClientCachePluginConfiguration {
+    /**
+     * Serializes the configuration on the client side.
+     *
+     * @param writer Writer.
+     */
+    default void serializeFromClient(BinaryRawWriter writer) {
+        throw new UnsupportedOperationException("CachePluginConfiguration does not support thin client: " + getClass());
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
@@ -28,7 +28,5 @@ public interface ClientCachePluginConfiguration {
      *
      * @param writer Writer.
      */
-    default void serializeFromClient(BinaryRawWriter writer) {
-        throw new UnsupportedOperationException("CachePluginConfiguration does not support thin client: " + getClass());
-    }
+    void write(BinaryRawWriter writer);
 }

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
@@ -24,6 +24,13 @@ import org.apache.ignite.plugin.CachePluginConfiguration;
  */
 public interface ClientCachePluginConfiguration {
     /**
+     * Gets the name of the plugin.
+     *
+     * @return Plugin name.
+     */
+    String pluginName();
+
+    /**
      * Serializes the configuration on the client side.
      *
      * @param writer Writer.

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -381,11 +381,7 @@ public final class ClientUtils {
                     w.writeInt(cachePluginCfgs.length);
 
                     for (ClientCachePluginConfiguration cfg0 : cachePluginCfgs) {
-                        int sizePos = w.reserveInt();
-
                         cfg0.write(w);
-
-                        w.writeInt(sizePos, out.position() - sizePos - 4);
                     }
                 });
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -257,7 +257,7 @@ public final class ClientUtils {
 
             AtomicInteger propCnt = new AtomicInteger(0);
 
-            BiConsumer<CfgItem, Consumer<BinaryRawWriter>> itemWriter = (cfgItem, cfgWriter) -> {
+            BiConsumer<CfgItem, Consumer<BinaryRawWriterEx>> itemWriter = (cfgItem, cfgWriter) -> {
                 writer.writeShort(cfgItem.code());
 
                 cfgWriter.accept(writer);
@@ -381,8 +381,13 @@ public final class ClientUtils {
                 itemWriter.accept(CfgItem.PLUGIN_CONFIGURATIONS, w -> {
                     w.writeInt(cachePluginCfgs.length);
 
-                    for (ClientCachePluginConfiguration cfg0 : cachePluginCfgs)
+                    for (ClientCachePluginConfiguration cfg0 : cachePluginCfgs) {
+                        int sizePos = w.reserveInt();
+
                         cfg0.write(w);
+
+                        w.writeInt(sizePos, out.position() - sizePos - 4);
+                    }
                 });
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -49,6 +49,7 @@ import org.apache.ignite.cache.QueryIndex;
 import org.apache.ignite.cache.QueryIndexType;
 import org.apache.ignite.cache.query.SqlFieldsQuery;
 import org.apache.ignite.client.ClientCacheConfiguration;
+import org.apache.ignite.client.ClientCachePluginConfiguration;
 import org.apache.ignite.internal.binary.BinaryContext;
 import org.apache.ignite.internal.binary.BinaryFieldMetadata;
 import org.apache.ignite.internal.binary.BinaryMetadata;
@@ -66,7 +67,6 @@ import org.apache.ignite.internal.binary.streams.BinaryOutputStream;
 import org.apache.ignite.internal.processors.platform.cache.expiry.PlatformExpiryPolicy;
 import org.apache.ignite.internal.util.MutableSingletonList;
 import org.apache.ignite.internal.util.typedef.internal.U;
-import org.apache.ignite.plugin.CachePluginConfiguration;
 import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.internal.client.thin.ProtocolVersionFeature.EXPIRY_POLICY;
@@ -374,15 +374,15 @@ public final class ClientUtils {
                         "version %s, required version %s", protocolCtx.version(), EXPIRY_POLICY.verIntroduced()));
             }
 
-            CachePluginConfiguration[] cachePluginCfgs = cfg.getPluginConfigurations();
+            ClientCachePluginConfiguration[] cachePluginCfgs = cfg.getPluginConfigurations();
             if (cachePluginCfgs != null && cachePluginCfgs.length > 0) {
                 protocolCtx.checkFeatureSupported(ProtocolBitmaskFeature.CACHE_PLUGIN_CONFIGURATIONS);
 
                 itemWriter.accept(CfgItem.PLUGIN_CONFIGURATIONS, w -> {
                     w.writeInt(cachePluginCfgs.length);
 
-                    for (CachePluginConfiguration cfg0 : cachePluginCfgs)
-                        cfg0.serializeFromClient(w);
+                    for (ClientCachePluginConfiguration cfg0 : cachePluginCfgs)
+                        cfg0.write(w);
                 });
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -381,7 +381,8 @@ public final class ClientUtils {
                 itemWriter.accept(CfgItem.PLUGIN_CONFIGURATIONS, w -> {
                     w.writeInt(cachePluginCfgs.length);
 
-                    // TODO: Cast to some interface for serialization.
+                    for (CachePluginConfiguration cfg0 : cachePluginCfgs)
+                        cfg0.serializeFromClient(w);
                 });
             }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -37,7 +37,6 @@ import java.util.stream.Collectors;
 import javax.cache.expiry.ExpiryPolicy;
 
 import org.apache.ignite.binary.BinaryObject;
-import org.apache.ignite.binary.BinaryRawWriter;
 import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.cache.CacheKeyConfiguration;
 import org.apache.ignite.cache.CacheMode;

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientUtils.java
@@ -381,6 +381,7 @@ public final class ClientUtils {
                     w.writeInt(cachePluginCfgs.length);
 
                     for (ClientCachePluginConfiguration cfg0 : cachePluginCfgs) {
+                        w.writeString(cfg0.pluginName());
                         cfg0.write(w);
                     }
                 });

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -70,7 +70,10 @@ public enum ProtocolBitmaskFeature {
     INDEX_QUERY(14),
 
     /** IndexQuery limit. */
-    INDEX_QUERY_LIMIT(15);
+    INDEX_QUERY_LIMIT(15),
+
+    /** Cache plugin configurations. GG-specific, use higher id to avoid conflicts. */
+    CACHE_PLUGIN_CONFIGURATIONS(32);
 
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -65,7 +65,10 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     INDEX_QUERY(14),
 
     /** IndexQuery limit. */
-    INDEX_QUERY_LIMIT(15);
+    INDEX_QUERY_LIMIT(15),
+
+    /** Cache plugin configurations. GG-specific, use higher id to avoid conflicts. */
+    CACHE_PLUGIN_CONFIGURATIONS(32);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -569,10 +569,16 @@ public class ClientMessageParser implements ClientListenerMessageParser {
                 return new ClientCacheGetConfigurationRequest(reader, protocolCtx);
 
             case OP_CACHE_CREATE_WITH_CONFIGURATION:
-                return new ClientCacheCreateWithConfigurationRequest(reader, protocolCtx);
+                return new ClientCacheCreateWithConfigurationRequest(
+                        reader,
+                        protocolCtx,
+                        ctx.kernalContext().plugins());
 
             case OP_CACHE_GET_OR_CREATE_WITH_CONFIGURATION:
-                return new ClientCacheGetOrCreateWithConfigurationRequest(reader, protocolCtx);
+                return new ClientCacheGetOrCreateWithConfigurationRequest(
+                        reader,
+                        protocolCtx,
+                        ctx.kernalContext().plugins());
 
             case OP_QUERY_SQL:
                 return new ClientCacheSqlQueryRequest(reader, protocolCtx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -455,6 +455,17 @@ public class ClientCacheConfigurationSerializer {
                     // * Pass config size for every plugin (to skip if not present)
                     int pluginCnt = reader.readInt();
 
+                    for (int j = 0; j < pluginCnt; j++) {
+                        // Skip plugin name.
+                        reader.readString();
+
+                        int pluginCfgSize = reader.readInt();
+                        byte[] pluginBytes = reader.readByteArray();
+
+                        // Deserialize as CachePluginConfiguration?
+                        // How do we achieve compatibility?
+                    }
+
                     break;
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -139,6 +139,9 @@ public class ClientCacheConfigurationSerializer {
     /** */
     private static final short EXPIRY_POLICY = 407;
 
+    /** */
+    private static final short PLUGIN_CONFIGURATIONS = 500;
+
     /**
      * Writes the cache configuration.
      * @param writer Writer.
@@ -444,6 +447,14 @@ public class ClientCacheConfigurationSerializer {
 
                         cfg.setQueryEntities(entities);
                     }
+                    break;
+
+                case PLUGIN_CONFIGURATIONS:
+                    // TODO: How do we make this extensible?
+                    // * Pass string name, or code for plugin?
+                    // * Pass config size for every plugin (to skip if not present)
+                    int pluginCnt = reader.readInt();
+
                     break;
             }
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -463,7 +463,8 @@ public class ClientCacheConfigurationSerializer {
                         byte[] pluginBytes = reader.readByteArray();
 
                         // Deserialize as CachePluginConfiguration?
-                        // How do we achieve compatibility?
+                        // How do we achieve compatibility? Use a separate interface ClientCachePluginConfiguration
+                        // with read() method and a similar approach - map of codes and values.
                     }
 
                     break;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -586,9 +586,9 @@ public class ClientCacheConfigurationSerializer {
 
         for (int j = 0; j < pluginCnt; j++) {
             int pluginCfgSize = reader.readInt();
-            String pluginName = reader.readString();
             int pos = reader.in().position();
 
+            String pluginName = reader.readString();
             PluginProvider pluginProvider = pluginProc.pluginProvider(pluginName);
 
             if (pluginProvider != null) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -598,9 +598,7 @@ public class ClientCacheConfigurationSerializer {
                 }
             }
 
-            // Deserialize as CachePluginConfiguration?
-            // How do we achieve compatibility? Use a separate interface ClientCachePluginConfiguration
-            // with read() method and a similar approach - map of codes and values.
+            // Plugin provider is allowed to read fewer bytes than available.
             reader.in().position(pos + pluginCfgSize);
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -450,14 +450,13 @@ public class ClientCacheConfigurationSerializer {
                     break;
 
                 case PLUGIN_CONFIGURATIONS:
-                    // TODO: How do we make this extensible?
-                    // * Pass string name, or code for plugin?
-                    // * Pass config size for every plugin (to skip if not present)
+                    // TODO: New protocol feature.
+                    // TODO: See how plugin configurations are handled in thick cache.
                     int pluginCnt = reader.readInt();
 
                     for (int j = 0; j < pluginCnt; j++) {
-                        // Skip plugin name.
-                        reader.readString();
+                        // Arbitrary class name - potential security risk?
+                        String pluginConfigClassName = reader.readString();
 
                         int pluginCfgSize = reader.readInt();
                         byte[] pluginBytes = reader.readByteArray();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -299,7 +299,10 @@ public class ClientCacheConfigurationSerializer {
      * @param protocolCtx Client protocol context.
      * @return Configuration.
      */
-    static CacheConfiguration read(BinaryReaderExImpl reader, ClientProtocolContext protocolCtx, Plu) {
+    static CacheConfiguration read(
+            BinaryReaderExImpl reader,
+            ClientProtocolContext protocolCtx,
+            IgnitePluginProcessor pluginProc) {
         reader.readInt();  // Skip length.
 
         short propCnt = reader.readShort();
@@ -454,8 +457,7 @@ public class ClientCacheConfigurationSerializer {
                     break;
 
                 case PLUGIN_CONFIGURATIONS:
-                    IgnitePluginProcessor pluginProcessor; // TODO: get from kernal
-                    readCachePluginConfigurations(reader, cfg, pluginProcessor);
+                    readCachePluginConfigurations(reader, cfg, pluginProc);
 
                     break;
             }
@@ -569,12 +571,12 @@ public class ClientCacheConfigurationSerializer {
      * Reads cache plugin configurations.
      * @param reader Reader.
      * @param cfg Configuration.
-     * @param pluginProcessor Plugin processor.
+     * @param pluginProc Plugin processor.
      */
     private static void readCachePluginConfigurations(
             BinaryReaderExImpl reader,
             CacheConfiguration cfg,
-            IgnitePluginProcessor pluginProcessor) {
+            IgnitePluginProcessor pluginProc) {
         int pluginCnt = reader.readInt();
         if (pluginCnt <= 0) {
             return;
@@ -587,7 +589,7 @@ public class ClientCacheConfigurationSerializer {
             int pluginCfgSize = reader.readInt();
             int pos = reader.in().position();
 
-            PluginProvider pluginProvider = pluginProcessor.pluginProvider(pluginName);
+            PluginProvider pluginProvider = pluginProc.pluginProvider(pluginName);
 
             if (pluginProvider != null) {
                 CachePluginConfiguration cachePluginCfg = pluginProvider.readClientCachePluginConfiguration(reader);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -585,8 +585,8 @@ public class ClientCacheConfigurationSerializer {
         ArrayList<CachePluginConfiguration> cachePluginCfgs = new ArrayList<>(pluginCnt);
 
         for (int j = 0; j < pluginCnt; j++) {
-            String pluginName = reader.readString();
             int pluginCfgSize = reader.readInt();
+            String pluginName = reader.readString();
             int pos = reader.in().position();
 
             PluginProvider pluginProvider = pluginProc.pluginProvider(pluginName);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheConfigurationSerializer.java
@@ -37,10 +37,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.ignite.internal.binary.BinaryReaderExImpl;
-import org.apache.ignite.internal.processors.platform.client.ClientProtocolContext;
-import org.apache.ignite.internal.processors.platform.client.ClientProtocolVersionFeature;
-import org.apache.ignite.internal.processors.platform.client.ClientStatus;
-import org.apache.ignite.internal.processors.platform.client.IgniteClientException;
+import org.apache.ignite.internal.processors.platform.client.*;
 import org.apache.ignite.internal.processors.platform.utils.PlatformConfigurationUtils;
 import org.apache.ignite.internal.processors.plugin.IgnitePluginProcessor;
 import org.apache.ignite.plugin.CachePluginConfiguration;
@@ -459,6 +456,8 @@ public class ClientCacheConfigurationSerializer {
                     break;
 
                 case PLUGIN_CONFIGURATIONS:
+                    assert protocolCtx.isFeatureSupported(ClientBitmaskFeature.CACHE_PLUGIN_CONFIGURATIONS);
+
                     readCachePluginConfigurations(reader, cfg, pluginProc);
 
                     break;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheCreateWithConfigurationRequest.java
@@ -16,9 +16,9 @@
 
 package org.apache.ignite.internal.processors.platform.client.cache;
 
-import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.cache.CacheExistsException;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientProtocolContext;
 import org.apache.ignite.internal.processors.platform.client.ClientRequest;
@@ -40,7 +40,7 @@ public class ClientCacheCreateWithConfigurationRequest extends ClientRequest {
      * @param reader Reader.
      * @param protocolCtx Client protocol context.
      */
-    public ClientCacheCreateWithConfigurationRequest(BinaryRawReader reader, ClientProtocolContext protocolCtx) {
+    public ClientCacheCreateWithConfigurationRequest(BinaryReaderExImpl reader, ClientProtocolContext protocolCtx) {
         super(reader);
 
         cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheCreateWithConfigurationRequest.java
@@ -25,6 +25,7 @@ import org.apache.ignite.internal.processors.platform.client.ClientRequest;
 import org.apache.ignite.internal.processors.platform.client.ClientResponse;
 import org.apache.ignite.internal.processors.platform.client.ClientStatus;
 import org.apache.ignite.internal.processors.platform.client.IgniteClientException;
+import org.apache.ignite.internal.processors.plugin.IgnitePluginProcessor;
 
 /**
  * Cache create with configuration request.
@@ -39,11 +40,15 @@ public class ClientCacheCreateWithConfigurationRequest extends ClientRequest {
      *
      * @param reader Reader.
      * @param protocolCtx Client protocol context.
+     * @param pluginProc Plugin processor.
      */
-    public ClientCacheCreateWithConfigurationRequest(BinaryReaderExImpl reader, ClientProtocolContext protocolCtx) {
+    public ClientCacheCreateWithConfigurationRequest(
+            BinaryReaderExImpl reader,
+            ClientProtocolContext protocolCtx,
+            IgnitePluginProcessor pluginProc) {
         super(reader);
 
-        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);
+        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx, pluginProc);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
@@ -48,7 +48,7 @@ public class ClientCacheGetOrCreateWithConfigurationRequest extends ClientReques
             IgnitePluginProcessor pluginProc) {
         super(reader);
 
-        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);
+        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx, pluginProc);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
@@ -25,6 +25,7 @@ import org.apache.ignite.internal.processors.platform.client.ClientRequest;
 import org.apache.ignite.internal.processors.platform.client.ClientResponse;
 import org.apache.ignite.internal.processors.platform.client.ClientStatus;
 import org.apache.ignite.internal.processors.platform.client.IgniteClientException;
+import org.apache.ignite.internal.processors.plugin.IgnitePluginProcessor;
 
 /**
  * Cache get or create with configuration request.
@@ -39,8 +40,12 @@ public class ClientCacheGetOrCreateWithConfigurationRequest extends ClientReques
      *
      * @param reader Reader.
      * @param protocolCtx Client protocol context.
+     * @param pluginProc Plugin processor.
      */
-    public ClientCacheGetOrCreateWithConfigurationRequest(BinaryReaderExImpl reader, ClientProtocolContext protocolCtx) {
+    public ClientCacheGetOrCreateWithConfigurationRequest(
+            BinaryReaderExImpl reader,
+            ClientProtocolContext protocolCtx,
+            IgnitePluginProcessor pluginProc) {
         super(reader);
 
         cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
@@ -16,9 +16,9 @@
 
 package org.apache.ignite.internal.processors.platform.client.cache;
 
-import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.cache.CacheExistsException;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientProtocolContext;
 import org.apache.ignite.internal.processors.platform.client.ClientRequest;
@@ -40,7 +40,7 @@ public class ClientCacheGetOrCreateWithConfigurationRequest extends ClientReques
      * @param reader Reader.
      * @param protocolCtx Client protocol context.
      */
-    public ClientCacheGetOrCreateWithConfigurationRequest(BinaryRawReader reader, ClientProtocolContext protocolCtx) {
+    public ClientCacheGetOrCreateWithConfigurationRequest(BinaryReaderExImpl reader, ClientProtocolContext protocolCtx) {
         super(reader);
 
         cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);

--- a/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
@@ -32,12 +32,16 @@ public interface CachePluginConfiguration<K, V> extends Serializable {
      *
      * @param writer Writer.
      */
-    void serializeFromClient(BinaryRawWriter writer);
+    default void serializeFromClient(BinaryRawWriter writer) {
+        throw new UnsupportedOperationException("CachePluginConfiguration does not support thin client: " + getClass());
+    }
 
     /**
      * Deserializes the configuration from the client side.
      *
      * @param reader Reader.
      */
-    void deserializeFromClient(BinaryRawReader reader);
+    default void deserializeFromClient(BinaryRawReader reader) {
+        throw new UnsupportedOperationException("CachePluginConfiguration does not support thin client: " + getClass());
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
@@ -17,6 +17,9 @@
 package org.apache.ignite.plugin;
 
 import java.io.Serializable;
+
+import org.apache.ignite.binary.BinaryRawReader;
+import org.apache.ignite.binary.BinaryRawWriter;
 import org.apache.ignite.configuration.CacheConfiguration;
 
 /**
@@ -24,4 +27,17 @@ import org.apache.ignite.configuration.CacheConfiguration;
  * and extend existing functionality of cache.
  */
 public interface CachePluginConfiguration<K, V> extends Serializable {
+    /**
+     * Serializes the configuration on the client side.
+     *
+     * @param writer Writer.
+     */
+    void serializeFromClient(BinaryRawWriter writer);
+
+    /**
+     * Deserializes the configuration from the client side.
+     *
+     * @param reader Reader.
+     */
+    void deserializeFromClient(BinaryRawReader reader);
 }

--- a/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
@@ -16,9 +16,8 @@
 
 package org.apache.ignite.plugin;
 
-import org.apache.ignite.configuration.CacheConfiguration;
-
 import java.io.Serializable;
+import org.apache.ignite.configuration.CacheConfiguration;
 
 /**
  * Cache plugin configuration. It is a point to extend existing {@link CacheConfiguration} 

--- a/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/CachePluginConfiguration.java
@@ -16,11 +16,9 @@
 
 package org.apache.ignite.plugin;
 
-import java.io.Serializable;
-
-import org.apache.ignite.binary.BinaryRawReader;
-import org.apache.ignite.binary.BinaryRawWriter;
 import org.apache.ignite.configuration.CacheConfiguration;
+
+import java.io.Serializable;
 
 /**
  * Cache plugin configuration. It is a point to extend existing {@link CacheConfiguration} 

--- a/modules/core/src/main/java/org/apache/ignite/plugin/PluginProvider.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/PluginProvider.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.binary.BinaryRawReaderEx;
 
 /**
  * Pluggable Ignite component.
@@ -82,6 +83,18 @@ public interface PluginProvider<C extends PluginConfiguration> {
      * @param ctx Plugin context.
      */
     public CachePluginProvider createCacheProvider(CachePluginContext ctx);
+
+    /**
+     * Reads client cache plugin configuration.
+     *
+     * @param reader Reader.
+     * @return Cache plugin configuration or null when no configuration is provided.
+     * @param <K> Key type.
+     * @param <V> Value type.
+     */
+    public default <K, V> CachePluginConfiguration<K, V> readClientCachePluginConfiguration(BinaryRawReaderEx reader) {
+        return null;
+    }
 
     /**
      * Starts grid component.


### PR DESCRIPTION
**Public API**
* Add `ClientCacheConfiguration.pluginConfigurations`, which allows plugin authors to attach additional properties to every cache configuration when starting caches from the thin client.
* Add `PluginProvider.readClientCachePluginConfiguration` to deserialize client-provided plugin config on the server.

**Protocol**
* Add `ProtocolBitmaskFeature.CACHE_PLUGIN_CONFIGURATIONS` feature.