### PR TITLE
GG-38778 Java thin: Change the default port range

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientDiscoveryContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ClientDiscoveryContext.java
@@ -231,7 +231,7 @@ public class ClientDiscoveryContext {
                 ranges.add(HostAndPortRange.parse(
                     a,
                     ClientConnectorConfiguration.DFLT_PORT,
-                    ClientConnectorConfiguration.DFLT_PORT + ClientConnectorConfiguration.DFLT_PORT_RANGE,
+                    ClientConnectorConfiguration.DFLT_PORT,
                     "Failed to parse Ignite server address"
                 ));
             }

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ReliableChannel.java
@@ -645,9 +645,13 @@ final class ReliableChannel implements AutoCloseable {
         }
 
         if (dfltChannelIdx == -1) {
-            dfltChannelIdx = ThreadLocalRandom.current().nextInt(reinitHolders.size());
+            if (reinitHolders.isEmpty())
+                throw new ClientException("No nodes available for connection");
 
-            Collections.rotate(reinitHolders, -dfltChannelIdx);
+            dfltChannelIdx = 0;
+            int rotation = ThreadLocalRandom.current().nextInt(reinitHolders.size());
+
+            Collections.rotate(reinitHolders, -rotation);
         }
 
         curChannelsGuard.writeLock().lock();

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ReliableChannelTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ReliableChannelTest.java
@@ -87,7 +87,7 @@ public class ReliableChannelTest {
 
         rc.channelsInit();
 
-        assertEquals(ClientConnectorConfiguration.DFLT_PORT_RANGE + 1, rc.getChannelHolders().size());
+        assertEquals(1, rc.getChannelHolders().size());
 
         assertEquals(ClientConnectorConfiguration.DFLT_PORT,
             F.first(F.first(rc.getChannelHolders()).getAddresses()).getPort());
@@ -100,8 +100,8 @@ public class ReliableChannelTest {
      */
     @Test
     public void testDefaultChannelBalancing() {
-        assertEquals(new HashSet<>(F.asList("127.0.0.2:10800", "127.0.0.3:10800", "127.0.0.4:10800")),
-            usedDefaultChannels("127.0.0.1:10801..10809", "127.0.0.2", "127.0.0.3:10800", "127.0.0.4:10800..10809"));
+        assertEquals(new HashSet<>(F.asList("127.0.0.1:10800", "127.0.0.1:10801", "127.0.0.2:10800", "127.0.0.3:10801")),
+            usedDefaultChannels("127.0.0.1:10800", "127.0.0.1:10801", "127.0.0.2", "127.0.0.3:10801"));
 
         assertEquals(new HashSet<>(F.asList("127.0.0.1:10800", "127.0.0.2:10800", "127.0.0.3:10800", "127.0.0.4:10800")),
             usedDefaultChannels("127.0.0.1:10800", "127.0.0.2:10800", "127.0.0.3:10800", "127.0.0.4:10800"));


### PR DESCRIPTION
Changed the default port range used by the Java Thin Client to form a list of connection addresses. Previously, if the user would specify a single address, e.g. `127.0.0.1` to use for a connection, Java thin client would actually plan 101 addresses for connection (`127.0.0.1:10800`, `127.0.0.1:10801`, ..., `127.0.0.1:10900`), which may lead to a really slow connection, as the most of these addresses is most likely are not actually used.

Changed that, so that specifying `127.0.0.1` will only plan a single address for connection now - `127.0.0.1:10800`.
Also, fixed tests.