### PR TITLE
GG-38744 [GG-38457] Thin client: Add ClientCacheConfiguration.pluginConfigurations

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCacheConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCacheConfiguration.java
@@ -136,6 +136,11 @@ public final class ClientCacheConfiguration implements Serializable {
      */
     private ExpiryPolicy expiryPlc;
 
+    /**
+     * @serial Cache plugin configurations.
+     */
+    private ClientCachePluginConfiguration[] pluginCfgs;
+
     /** Default constructor. */
     public ClientCacheConfiguration() {
         // No-op.
@@ -178,6 +183,7 @@ public final class ClientCacheConfiguration implements Serializable {
         sqlSchema = ccfg.getSqlSchema();
         statisticsEnabled = ccfg.isStatisticsEnabled();
         writeSynchronizationMode = ccfg.getWriteSynchronizationMode();
+        pluginCfgs = ccfg.getPluginConfigurations();
     }
 
     /**
@@ -716,6 +722,27 @@ public final class ClientCacheConfiguration implements Serializable {
      */
     public ClientCacheConfiguration setExpiryPolicy(ExpiryPolicy expiryPlc) {
         this.expiryPlc = expiryPlc;
+
+        return this;
+    }
+
+    /**
+     * Gets cache plugin configurations.
+     *
+     * @return Cache plugin configurations.
+     */
+    public ClientCachePluginConfiguration[] getPluginConfigurations() {
+        return pluginCfgs != null ? pluginCfgs : new ClientCachePluginConfiguration[0];
+    }
+
+    /**
+     * Sets cache plugin configurations.
+     *
+     * @param pluginCfgs Cache plugin configurations.
+     * @return {@code this} for chaining.
+     */
+    public ClientCacheConfiguration setPluginConfigurations(ClientCachePluginConfiguration... pluginCfgs) {
+        this.pluginCfgs = pluginCfgs;
 
         return this;
     }

--- a/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
+++ b/modules/core/src/main/java/org/apache/ignite/client/ClientCachePluginConfiguration.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.client;
+
+import org.apache.ignite.binary.BinaryRawWriter;
+import org.apache.ignite.plugin.CachePluginConfiguration;
+
+/**
+ * Client cache plugin configuration. Maps to {@link CachePluginConfiguration} on the server side.
+ */
+public interface ClientCachePluginConfiguration {
+    /**
+     * Gets the name of the plugin.
+     *
+     * @return Plugin name.
+     */
+    String pluginName();
+
+    /**
+     * Serializes the configuration on the client side.
+     *
+     * @param writer Writer.
+     */
+    void write(BinaryRawWriter writer);
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/ProtocolBitmaskFeature.java
@@ -62,7 +62,10 @@ public enum ProtocolBitmaskFeature {
     SERVICE_INVOKE_CALLCTX(10),
 
     /** Handle OP_HEARTBEAT and OP_GET_IDLE_TIMEOUT. */
-    HEARTBEAT(11);
+    HEARTBEAT(11),
+
+    /** Cache plugin configurations. GG-specific, use higher id to avoid conflicts. */
+    CACHE_PLUGIN_CONFIGURATIONS(32);
 
     /** */
     private static final EnumSet<ProtocolBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientBitmaskFeature.java
@@ -57,7 +57,10 @@ public enum ClientBitmaskFeature implements ThinProtocolFeature {
     SERVICE_INVOKE_CALLCTX(10),
 
     /** Handle OP_HEARTBEAT and OP_GET_IDLE_TIMEOUT. */
-    HEARTBEAT(11);
+    HEARTBEAT(11),
+
+    /** Cache plugin configurations. GG-specific, use higher id to avoid conflicts. */
+    CACHE_PLUGIN_CONFIGURATIONS(32);
 
     /** */
     private static final EnumSet<ClientBitmaskFeature> ALL_FEATURES_AS_ENUM_SET =

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/ClientMessageParser.java
@@ -560,10 +560,16 @@ public class ClientMessageParser implements ClientListenerMessageParser {
                 return new ClientCacheGetConfigurationRequest(reader, protocolCtx);
 
             case OP_CACHE_CREATE_WITH_CONFIGURATION:
-                return new ClientCacheCreateWithConfigurationRequest(reader, protocolCtx);
+                return new ClientCacheCreateWithConfigurationRequest(
+                        reader,
+                        protocolCtx,
+                        ctx.kernalContext().plugins());
 
             case OP_CACHE_GET_OR_CREATE_WITH_CONFIGURATION:
-                return new ClientCacheGetOrCreateWithConfigurationRequest(reader, protocolCtx);
+                return new ClientCacheGetOrCreateWithConfigurationRequest(
+                        reader,
+                        protocolCtx,
+                        ctx.kernalContext().plugins());
 
             case OP_QUERY_SQL:
                 return new ClientCacheSqlQueryRequest(reader, protocolCtx);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheCreateWithConfigurationRequest.java
@@ -16,15 +16,16 @@
 
 package org.apache.ignite.internal.processors.platform.client.cache;
 
-import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.cache.CacheExistsException;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientProtocolContext;
 import org.apache.ignite.internal.processors.platform.client.ClientRequest;
 import org.apache.ignite.internal.processors.platform.client.ClientResponse;
 import org.apache.ignite.internal.processors.platform.client.ClientStatus;
 import org.apache.ignite.internal.processors.platform.client.IgniteClientException;
+import org.apache.ignite.internal.processors.plugin.IgnitePluginProcessor;
 
 /**
  * Cache create with configuration request.
@@ -39,11 +40,15 @@ public class ClientCacheCreateWithConfigurationRequest extends ClientRequest {
      *
      * @param reader Reader.
      * @param protocolCtx Client protocol context.
+     * @param pluginProc Plugin processor.
      */
-    public ClientCacheCreateWithConfigurationRequest(BinaryRawReader reader, ClientProtocolContext protocolCtx) {
+    public ClientCacheCreateWithConfigurationRequest(
+            BinaryReaderExImpl reader,
+            ClientProtocolContext protocolCtx,
+            IgnitePluginProcessor pluginProc) {
         super(reader);
 
-        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);
+        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx, pluginProc);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/client/cache/ClientCacheGetOrCreateWithConfigurationRequest.java
@@ -16,15 +16,16 @@
 
 package org.apache.ignite.internal.processors.platform.client.cache;
 
-import org.apache.ignite.binary.BinaryRawReader;
 import org.apache.ignite.cache.CacheExistsException;
 import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.internal.binary.BinaryReaderExImpl;
 import org.apache.ignite.internal.processors.platform.client.ClientConnectionContext;
 import org.apache.ignite.internal.processors.platform.client.ClientProtocolContext;
 import org.apache.ignite.internal.processors.platform.client.ClientRequest;
 import org.apache.ignite.internal.processors.platform.client.ClientResponse;
 import org.apache.ignite.internal.processors.platform.client.ClientStatus;
 import org.apache.ignite.internal.processors.platform.client.IgniteClientException;
+import org.apache.ignite.internal.processors.plugin.IgnitePluginProcessor;
 
 /**
  * Cache get or create with configuration request.
@@ -39,11 +40,15 @@ public class ClientCacheGetOrCreateWithConfigurationRequest extends ClientReques
      *
      * @param reader Reader.
      * @param protocolCtx Client protocol context.
+     * @param pluginProc Plugin processor.
      */
-    public ClientCacheGetOrCreateWithConfigurationRequest(BinaryRawReader reader, ClientProtocolContext protocolCtx) {
+    public ClientCacheGetOrCreateWithConfigurationRequest(
+            BinaryReaderExImpl reader,
+            ClientProtocolContext protocolCtx,
+            IgnitePluginProcessor pluginProc) {
         super(reader);
 
-        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx);
+        cacheCfg = ClientCacheConfigurationSerializer.read(reader, protocolCtx, pluginProc);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/plugin/PluginProvider.java
+++ b/modules/core/src/main/java/org/apache/ignite/plugin/PluginProvider.java
@@ -22,6 +22,7 @@ import java.util.UUID;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.binary.BinaryRawReaderEx;
 
 /**
  * Pluggable Ignite component.
@@ -82,6 +83,18 @@ public interface PluginProvider<C extends PluginConfiguration> {
      * @param ctx Plugin context.
      */
     public CachePluginProvider createCacheProvider(CachePluginContext ctx);
+
+    /**
+     * Reads client cache plugin configuration.
+     *
+     * @param reader Reader.
+     * @return Cache plugin configuration or null when no configuration is provided.
+     * @param <K> Key type.
+     * @param <V> Value type.
+     */
+    public default <K, V> CachePluginConfiguration<K, V> readClientCachePluginConfiguration(BinaryRawReaderEx reader) {
+        return null;
+    }
 
     /**
      * Starts grid component.


### PR DESCRIPTION
**Public API**
* Add `ClientCacheConfiguration.pluginConfigurations`, which allows plugin authors to attach additional properties to every cache configuration when starting caches from the thin client.
* Add `PluginProvider.readClientCachePluginConfiguration` to deserialize client-provided plugin config on the server.

**Protocol**
* Add `ProtocolBitmaskFeature.CACHE_PLUGIN_CONFIGURATIONS` feature.

(cherry picked from commit fc133a43348d291ab9a625f06f10ffd7f0a310ea)