### PR TITLE
GG-38817 Fix building on VS 2022

### DIFF
--- a/modules/platforms/cpp/common/os/win/include/ignite/common/concurrent_os.h
+++ b/modules/platforms/cpp/common/os/win/include/ignite/common/concurrent_os.h
@@ -22,6 +22,8 @@
 #include <cassert>
 #include <map>
 
+#define WIN32_LEAN_AND_MEAN
+#define _WINSOCKAPI_
 #include <windows.h>
 #include <tlhelp32.h>
 

--- a/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
+++ b/modules/platforms/cpp/common/os/win/src/common/platform_utils.cpp
@@ -19,6 +19,7 @@
 #include <sstream>
 #include <iomanip>
 
+#define _WINSOCKAPI_
 #include <windows.h>
 
 #include <ignite/ignite_error.h>

--- a/modules/platforms/cpp/core/src/jni/os/win/utils.cpp
+++ b/modules/platforms/cpp/core/src/jni/os/win/utils.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#define WIN32_LEAN_AND_MEAN
+#define _WINSOCKAPI_
 #include <windows.h>
 
 #include "ignite/common/concurrent.h"

--- a/modules/platforms/cpp/examples/odbc-example/src/odbc_example.cpp
+++ b/modules/platforms/cpp/examples/odbc-example/src/odbc_example.cpp
@@ -15,6 +15,8 @@
  */
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#define _WINSOCKAPI_
 #include <windows.h>
 #endif
 

--- a/modules/platforms/cpp/network/os/win/src/network/utils.cpp
+++ b/modules/platforms/cpp/network/os/win/src/network/utils.cpp
@@ -20,10 +20,10 @@
 #include <set>
 #include <iostream>
 
-#include <winsock2.h>
+#include "network/sockets.h"
+
 #include <ws2ipdef.h>
 #include <ws2tcpip.h>
-#include <windows.h>
 #include <winbase.h>
 #include <iphlpapi.h>
 

--- a/modules/platforms/cpp/odbc/include/ignite/odbc/system/odbc_constants.h
+++ b/modules/platforms/cpp/odbc/include/ignite/odbc/system/odbc_constants.h
@@ -19,6 +19,7 @@
 
 #ifdef _WIN32
 
+#define WIN32_LEAN_AND_MEAN
 #define _WINSOCKAPI_
 #include <windows.h>
 


### PR DESCRIPTION
Make sure that `#define _WINSOCKAPI_` is defined before `#include <windows.h>` so it won't conflict with `winsock2.h`