### PR TITLE
GG-38851 .NET: Add net8.0 support to executable project

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="NLog" Version="4.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit.Extension.TeamCityEventListener" Version="1.0.7" />
 
     <ProjectReference Include="..\Apache.Ignite.Core\Apache.Ignite.Core.csproj" />

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>Apache.Ignite.Executable</AssemblyName>

--- a/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite/Apache.Ignite.DotNetCore.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -186,7 +186,7 @@ if (!$skipDotNet) {
 }
 
 if(!$skipDotNetCore) {
-    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net6.0"
+    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin"
 }
 
 

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -110,14 +110,14 @@ function Copy-If-Exists([string]$src, [string]$dst) {
     }
 }
 
-function Build-Solution([string]$targetSolution, [string]$targetDir) {
+function Build-Solution([string]$targetSolution, [string]$targetDir, [string]$framework) {
     if ($clean) {
         $cleanCommand = "dotnet clean $targetSolution -c $configuration"
         echo "Starting dotnet clean: '$cleanCommand'"
         Exec $cleanCommand
     }
 
-    $buildCommand = "dotnet publish $targetSolution -c $configuration -o $targetDir"
+    $buildCommand = "dotnet publish $targetSolution -c $configuration -o $targetDir -f $framework"
     echo "Starting dotnet build: '$buildCommand'"
     Exec $buildCommand
 }
@@ -179,14 +179,15 @@ cd $PSScriptRoot
 
 # 2) Build .NET
 if (!$skipDotNet) {
-    Build-Solution ".\Apache.Ignite.sln" "bin\net461"
+    Build-Solution ".\Apache.Ignite.sln" "bin\net461" "net461"
     
     # Overwrite dlls to ensure that net461 versions are used instead of netstandard2. 
     Copy-Item -Force -Recurse ".\Apache.Ignite\bin\$configuration\net461\*" "bin\net461"
 }
 
 if(!$skipDotNetCore) {
-    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin"
+    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net6.0" "net6.0"
+    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net8.0" "net8.0"
 }
 
 

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -117,7 +117,12 @@ function Build-Solution([string]$targetSolution, [string]$targetDir, [string]$fr
         Exec $cleanCommand
     }
 
-    $buildCommand = "dotnet publish $targetSolution -c $configuration -o $targetDir -f $framework"
+    $buildCommand = "dotnet publish $targetSolution -c $configuration -o $targetDir"
+
+    if ($framework) {
+        $buildCommand += " -f $framework"
+    }
+
     echo "Starting dotnet build: '$buildCommand'"
     Exec $buildCommand
 }
@@ -179,7 +184,7 @@ cd $PSScriptRoot
 
 # 2) Build .NET
 if (!$skipDotNet) {
-    Build-Solution ".\Apache.Ignite.sln" "bin\net461" "net461"
+    Build-Solution ".\Apache.Ignite.sln" "bin\net461"
     
     # Overwrite dlls to ensure that net461 versions are used instead of netstandard2. 
     Copy-Item -Force -Recurse ".\Apache.Ignite\bin\$configuration\net461\*" "bin\net461"

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -101,15 +101,6 @@ function Exec([string]$command) {
     }
 }
 
-function Copy-If-Exists([string]$src, [string]$dst) {
-    if ([IO.Directory]::Exists($src)) {
-        echo "Copying files from '$src' to '$dst'..."
-
-        $srcAll = [IO.Path]::Combine($src, "*")
-        Copy-Item -Force -Recurse $srcAll $dst
-    }
-}
-
 function Build-Solution([string]$targetSolution, [string]$targetDir) {
     if ($clean) {
         $cleanCommand = "dotnet clean $targetSolution -c $configuration"
@@ -188,7 +179,9 @@ if (!$skipDotNet) {
 if(!$skipDotNetCore) {
     Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net6.0"
 
-    # Build executable for .NET 8 too.
+    # Build executable for .NET 8 too. Copy all libraries, then build the binaries.
+    Make-Dir("bin\net8.0")
+    Copy-Item -Force -Recurse "bin\net6.0\*" "bin\net8.0"
     dotnet publish .\Apache.Ignite\Apache.Ignite.DotNetCore.csproj -c $configuration -o bin\net8.0
 }
 

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -182,7 +182,7 @@ if(!$skipDotNetCore) {
     # Build executable for .NET 8 too. Copy all libraries, then build the binaries.
     Make-Dir("bin\net8.0")
     Copy-Item -Force -Recurse "bin\net6.0\*" "bin\net8.0"
-    dotnet publish .\Apache.Ignite\Apache.Ignite.DotNetCore.csproj -c $configuration -o bin\net8.0
+    dotnet publish .\Apache.Ignite\Apache.Ignite.DotNetCore.csproj -c $configuration -f net8.0 -o bin\net8.0
 }
 
 

--- a/modules/platforms/dotnet/build.ps1
+++ b/modules/platforms/dotnet/build.ps1
@@ -110,7 +110,7 @@ function Copy-If-Exists([string]$src, [string]$dst) {
     }
 }
 
-function Build-Solution([string]$targetSolution, [string]$targetDir, [string]$framework) {
+function Build-Solution([string]$targetSolution, [string]$targetDir) {
     if ($clean) {
         $cleanCommand = "dotnet clean $targetSolution -c $configuration"
         echo "Starting dotnet clean: '$cleanCommand'"
@@ -118,11 +118,6 @@ function Build-Solution([string]$targetSolution, [string]$targetDir, [string]$fr
     }
 
     $buildCommand = "dotnet publish $targetSolution -c $configuration -o $targetDir"
-
-    if ($framework) {
-        $buildCommand += " -f $framework"
-    }
-
     echo "Starting dotnet build: '$buildCommand'"
     Exec $buildCommand
 }
@@ -191,8 +186,10 @@ if (!$skipDotNet) {
 }
 
 if(!$skipDotNetCore) {
-    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net6.0" "net6.0"
-    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net8.0" "net8.0"
+    Build-Solution ".\Apache.Ignite.DotNetCore.sln" "bin\net6.0"
+
+    # Build executable for .NET 8 too.
+    dotnet publish .\Apache.Ignite\Apache.Ignite.DotNetCore.csproj -c $configuration -o bin\net8.0
 }
 
 


### PR DESCRIPTION
* Add multi-targeting to `Apache.Ignite` executable project
* Update build script to build for .NET 6 and 8
* Extra: update Newtonsoft.Json to fix build error caused by a known vulnerability