### PR TITLE
GG-39212 Fixed NullPointerException on reporting IgniteOutOfMemoryException when the system data region is used.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/GridCacheDatabaseSharedManager.java
@@ -1239,6 +1239,7 @@ public class GridCacheDatabaseSharedManager extends IgniteCacheDatabaseSharedMan
             changeTracker = null;
 
         PageMemoryImpl pageMem = new PageMemoryImpl(
+            plcCfg,
             wrapMetricsPersistentMemoryProvider(memProvider, memMetrics),
             calculateFragmentSizes(
                 plcCfg.getName(),

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/BPlusTreePageMemoryImplTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/BPlusTreePageMemoryImplTest.java
@@ -104,6 +104,7 @@ public class BPlusTreePageMemoryImplTest extends BPlusTreeSelfTest {
         };
 
         PageMemory mem = new PageMemoryImpl(
+            cfg.getDataStorageConfiguration().getDefaultDataRegionConfiguration(),
             provider, sizes,
             sharedCtx,
             sharedCtx.pageStore(),

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/BPlusTreeReuseListPageMemoryImplTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/BPlusTreeReuseListPageMemoryImplTest.java
@@ -103,6 +103,7 @@ public class BPlusTreeReuseListPageMemoryImplTest extends BPlusTreeReuseSelfTest
         };
 
         PageMemory mem = new PageMemoryImpl(
+            cfg.getDataStorageConfiguration().getDefaultDataRegionConfiguration(),
             provider, sizes,
             sharedCtx,
             sharedCtx.pageStore(),

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgnitePageMemReplaceDelayedWriteUnitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IgnitePageMemReplaceDelayedWriteUnitTest.java
@@ -251,7 +251,7 @@ public class IgnitePageMemReplaceDelayedWriteUnitTest {
 
         IgniteOutClosure<CheckpointProgress> clo = () -> Mockito.mock(CheckpointProgressImpl.class);
 
-        PageMemoryImpl memory = new PageMemoryImpl(provider, sizes, sctx, sctx.pageStore(), pageSize,
+        PageMemoryImpl memory = new PageMemoryImpl(regCfg, provider, sizes, sctx, sctx.pageStore(), pageSize,
             pageWriter, null, () -> true, memMetrics, PageMemoryImpl.ThrottlingPolicy.DISABLED,
             clo);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IndexStoragePageMemoryImplTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/IndexStoragePageMemoryImplTest.java
@@ -115,6 +115,7 @@ public class IndexStoragePageMemoryImplTest extends IndexStorageSelfTest {
         IgniteOutClosure<CheckpointProgress> clo = () -> Mockito.mock(CheckpointProgressImpl.class);
 
         return new PageMemoryImpl(
+            cfg.getDataStorageConfiguration().getDefaultDataRegionConfiguration(),
             provider, sizes,
             sharedCtx,
             sharedCtx.pageStore(),

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImplNoLoadTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/pagemem/PageMemoryImplNoLoadTest.java
@@ -104,6 +104,7 @@ public class PageMemoryImplNoLoadTest extends PageMemoryNoLoadSelfTest {
         IgniteOutClosure<CheckpointProgress> clo = () -> Mockito.mock(CheckpointProgressImpl.class);
 
         return new PageMemoryImpl(
+            cfg.getDataStorageConfiguration().getDefaultDataRegionConfiguration(),
             provider,
             sizes,
             sharedCtx,


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-39212