### PR TITLE
GG-39383 Using hash set instead of array list to track remapping keys

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicUpdateFuture.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/atomic/GridNearAtomicUpdateFuture.java
@@ -551,7 +551,7 @@ public class GridNearAtomicUpdateFuture extends GridNearAtomicAbstractUpdateFutu
 
                     Collection<Object> failedKeys = cause.failedKeys();
 
-                    remapKeys = new ArrayList<>(failedKeys.size());
+                    remapKeys = U.newHashSet(failedKeys.size());
 
                     for (Object key : failedKeys)
                         remapKeys.add(cctx.toCacheKeyObject(key));


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-39383