### PR TITLE
GG-39314 Fixed an issue that could lead to skipping keys during reconciliation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
@@ -161,7 +161,7 @@ public interface ReconciliationResultCollector {
 
         /**
          * Keys that were detected as inconsistent during the reconciliation process.
-         * Cache name -> {Partition identifier -> set of inconsistent kyes. }
+         * Cache name -> {Partition identifier -> set of inconsistent keys. }
          */
         protected final Map<String, Map<Integer, TreeSet<PartitionReconciliationDataRowMeta>>> inconsistentKeys = new HashMap<>();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
@@ -27,12 +27,14 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -91,6 +93,7 @@ public interface ReconciliationResultCollector {
 
     /**
      * Appends conflicted entries.
+     * When this result collector has a registered conflict for a key, the existing one is updated with a new value.
      *
      * @param cacheName Cache name.
      * @param partId Partition id.
@@ -142,6 +145,8 @@ public interface ReconciliationResultCollector {
      * Represents a collector of inconsistent and repaired entries.
      */
     public static class Simple implements ReconciliationResultCollector {
+        public static final RowMetaComparator ROW_META_COMPARATOR = new RowMetaComparator();
+
         /** Ignite instance. */
         protected final IgniteEx ignite;
 
@@ -154,11 +159,22 @@ public interface ReconciliationResultCollector {
         /** Root folder. */
         protected final File reconciliationDir;
 
-        /** Keys that were detected as inconsistent during the reconciliation process. */
-        protected final Map<String, Map<Integer, List<PartitionReconciliationDataRowMeta>>> inconsistentKeys = new HashMap<>();
+        /**
+         * Keys that were detected as inconsistent during the reconciliation process.
+         * Cache name -> {Partition identifier -> set of inconsistent kyes. }
+         */
+        protected final Map<String, Map<Integer, TreeSet<PartitionReconciliationDataRowMeta>>> inconsistentKeys = new HashMap<>();
 
         /** Entries that were detected as inconsistent but weren't repaired due to some reason. */
         protected final Map<String, Map<Integer, Set<PartitionReconciliationSkippedEntityHolder<PartitionReconciliationKeyMeta>>>> skippedEntries = new HashMap<>();
+
+        /** Custom comparator for {@link PartitionReconciliationDataRowMeta}. It only compares binary representation of keys. */
+        public static class RowMetaComparator implements Comparator<PartitionReconciliationDataRowMeta> {
+            /** {@inheritDoc} */
+            @Override public int compare(PartitionReconciliationDataRowMeta o1, PartitionReconciliationDataRowMeta o2) {
+                return U.compareByteArrays(o1.keyMeta().binaryView(), o2.keyMeta().binaryView());
+            }
+        }
 
         /**
          * Creates a new SimpleCollector.
@@ -250,7 +266,7 @@ public interface ReconciliationResultCollector {
             synchronized (inconsistentKeys) {
                 try {
                     inconsistentKeys.computeIfAbsent(cacheName, k -> new HashMap<>())
-                        .computeIfAbsent(partId, k -> new ArrayList<>())
+                        .computeIfAbsent(partId, k -> new TreeSet<>(ROW_META_COMPARATOR))
                         .addAll(mapPartitionReconciliation(conflicts, actualKeys, ctx));
                 }
                 catch (IgniteCheckedException e) {
@@ -315,7 +331,7 @@ public interface ReconciliationResultCollector {
                     }
 
                     inconsistentKeys.computeIfAbsent(cacheName, k -> new HashMap<>())
-                        .computeIfAbsent(partId, k -> new ArrayList<>())
+                        .computeIfAbsent(partId, k -> new TreeSet<>(ROW_META_COMPARATOR))
                         .addAll(res);
                 }
                 catch (IgniteCheckedException e) {
@@ -333,9 +349,21 @@ public interface ReconciliationResultCollector {
         @Override public ReconciliationAffectedEntries result() {
             synchronized (inconsistentKeys) {
                 synchronized (skippedEntries) {
+                    // This copy is need to avoid RU incompatible changes.
+                    Map<String, Map<Integer, List<PartitionReconciliationDataRowMeta>>> copy = new HashMap<>(inconsistentKeys.size());
+
+                    for (Map.Entry<String, Map<Integer, TreeSet<PartitionReconciliationDataRowMeta>>> e : inconsistentKeys.entrySet()) {
+                        Map<Integer, List<PartitionReconciliationDataRowMeta>> c = new HashMap<>(e.getValue().size());
+
+                        for (Map.Entry<Integer, TreeSet<PartitionReconciliationDataRowMeta>> e0 : e.getValue().entrySet())
+                            c.put(e0.getKey(), new ArrayList<>(e0.getValue()));
+
+                        copy.put(e.getKey(), c);
+                    }
+
                     return new ReconciliationAffectedEntries(
                         collectNodeIdToConsistentIdMapping(ignite),
-                        inconsistentKeys,
+                        copy,
                         skippedEntries
                     );
                 }
@@ -421,11 +449,11 @@ public interface ReconciliationResultCollector {
             if (log.isDebugEnabled())
                 log.debug("Partition has been processed [cacheName=" + cacheName + ", partId=" + partId + ']');
 
-            List<PartitionReconciliationDataRowMeta> meta = null;
+            TreeSet<PartitionReconciliationDataRowMeta> meta = null;
             Set<PartitionReconciliationSkippedEntityHolder<PartitionReconciliationKeyMeta>> skipped = null;
 
             synchronized (inconsistentKeys) {
-                Map<Integer, List<PartitionReconciliationDataRowMeta>> c = inconsistentKeys.get(cacheName);
+                Map<Integer, TreeSet<PartitionReconciliationDataRowMeta>> c = inconsistentKeys.get(cacheName);
                 if (c != null)
                     meta = c.remove(partId);
             }
@@ -528,7 +556,7 @@ public interface ReconciliationResultCollector {
         private void storePartition(
             String cacheName,
             int partId,
-            List<PartitionReconciliationDataRowMeta> meta,
+            TreeSet<PartitionReconciliationDataRowMeta> meta,
             Set<PartitionReconciliationSkippedEntityHolder<PartitionReconciliationKeyMeta>> skipped
         ) {
             String maskId = U.maskForFileName(ignite.context().discovery().localNode().consistentId().toString());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairEntryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairEntryProcessor.java
@@ -37,7 +37,8 @@ public class RepairEntryProcessor implements EntryProcessor {
     /** Map of nodes to corresponding versioned values */
     private Map<UUID, VersionedValue> data;
 
-    /** deferred delete queue max size. */
+    /** This field is not used anymore. */
+    @Deprecated
     private long rmvQueueMaxSize;
 
     /** Force repair flag. */
@@ -69,7 +70,6 @@ public class RepairEntryProcessor implements EntryProcessor {
     /**
      * @param val Value.
      * @param data Data.
-     * @param rmvQueueMaxSize Remove queue max size.
      * @param forceRepair Force repair.
      * @param startTopVer Start topology version.
      */
@@ -77,12 +77,11 @@ public class RepairEntryProcessor implements EntryProcessor {
     public RepairEntryProcessor(
         Object val,
         Map<UUID, VersionedValue> data,
-        long rmvQueueMaxSize,
         boolean forceRepair,
-        AffinityTopologyVersion startTopVer) {
+        AffinityTopologyVersion startTopVer
+    ) {
         this.val = val;
         this.data = data;
-        this.rmvQueueMaxSize = rmvQueueMaxSize;
         this.forceRepair = forceRepair;
         this.startTopVer = startTopVer;
     }
@@ -147,14 +146,14 @@ public class RepairEntryProcessor implements EntryProcessor {
     }
 
     /**
-     *
+     * @return an instance of {@link GridCacheContext} from entry.
      */
     protected GridCacheContext cacheContext(MutableEntry entry) {
         return (GridCacheContext)entry.unwrap(GridCacheContext.class);
     }
 
     /**
-     *
+     * @return {@code true} when affinity topology was changed and does not equal to expected.
      */
     protected boolean topologyChanged(GridCacheContext cctx, AffinityTopologyVersion expTop) {
         AffinityTopologyVersion currTopVer = cctx.affinity().affinityTopologyVersion();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationDataRowMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationDataRowMeta.java
@@ -65,7 +65,8 @@ public class PartitionReconciliationDataRowMeta extends IgniteDataTransferObject
      */
     public PartitionReconciliationDataRowMeta(
         PartitionReconciliationKeyMeta keyMeta,
-        Map<UUID, PartitionReconciliationValueMeta> valMeta) {
+        Map<UUID, PartitionReconciliationValueMeta> valMeta
+    ) {
         this.keyMeta = keyMeta;
         this.valMeta = valMeta;
     }
@@ -85,7 +86,8 @@ public class PartitionReconciliationDataRowMeta extends IgniteDataTransferObject
     public PartitionReconciliationDataRowMeta(
         PartitionReconciliationKeyMeta keyMeta,
         Map<UUID, PartitionReconciliationValueMeta> valMeta,
-        PartitionReconciliationRepairMeta repairMeta) {
+        PartitionReconciliationRepairMeta repairMeta
+    ) {
         this.keyMeta = keyMeta;
         this.valMeta = valMeta;
         this.repairMeta = repairMeta;
@@ -99,8 +101,7 @@ public class PartitionReconciliationDataRowMeta extends IgniteDataTransferObject
     }
 
     /** {@inheritDoc} */
-    @Override protected void readExternalData(byte protoVer, ObjectInput in) throws IOException,
-        ClassNotFoundException {
+    @Override protected void readExternalData(byte protoVer, ObjectInput in) throws IOException, ClassNotFoundException {
         keyMeta = (PartitionReconciliationKeyMeta)in.readObject();
         valMeta = U.readMap(in);
         repairMeta = (PartitionReconciliationRepairMeta)in.readObject();
@@ -131,6 +132,11 @@ public class PartitionReconciliationDataRowMeta extends IgniteDataTransferObject
     /** {@inheritDoc} */
     @Override public String toString() {
         return S.toString(PartitionReconciliationDataRowMeta.class, this);
+    }
+
+    /** {@inheritDoc} */
+    @Override public int hashCode() {
+        return Objects.hash(keyMeta, valMeta, repairMeta);
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationSkippedEntityHolder.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationSkippedEntityHolder.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.processors.cache.verify;
 import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
+import java.util.Objects;
 import org.apache.ignite.internal.dto.IgniteDataTransferObject;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.jetbrains.annotations.Nullable;
@@ -46,8 +47,10 @@ public class PartitionReconciliationSkippedEntityHolder<T> extends IgniteDataTra
      * @param skippedEntity Skipped entity.
      * @param skippingReason Skipping reason.
      */
-    public PartitionReconciliationSkippedEntityHolder(T skippedEntity,
-        SkippingReason skippingReason) {
+    public PartitionReconciliationSkippedEntityHolder(
+        T skippedEntity,
+        SkippingReason skippingReason
+    ) {
         this.skippedEntity = skippedEntity;
         this.skippingReason = skippingReason;
     }
@@ -92,6 +95,25 @@ public class PartitionReconciliationSkippedEntityHolder<T> extends IgniteDataTra
      */
     public void skippingReason(SkippingReason skippingReason) {
         this.skippingReason = skippingReason;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        PartitionReconciliationSkippedEntityHolder<?> that = (PartitionReconciliationSkippedEntityHolder<?>) o;
+
+        return Objects.equals(skippedEntity, that.skippedEntity) && skippingReason == that.skippingReason;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int hashCode() {
+        return Objects.hash(skippedEntity, skippingReason);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAbstractTest.java
@@ -51,6 +51,7 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
         boolean repair,
         @Nullable RepairAlgorithm repairAlgorithm,
         int parallelism,
+        int batchSize,
         String... caches
     ) {
         return partitionReconciliation(
@@ -58,10 +59,22 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
             new VisorPartitionReconciliationTaskArg.Builder()
                 .caches(new HashSet<>(Arrays.asList(caches)))
                 .recheckDelay(1)
+                .batchSize(batchSize)
                 .parallelism(parallelism)
                 .repair(repair)
                 .repairAlg(repairAlgorithm)
         );
+    }
+
+    /** */
+    public static ReconciliationResult partitionReconciliation(
+        Ignite ig,
+        boolean repair,
+        @Nullable RepairAlgorithm repairAlgorithm,
+        int parallelism,
+        String... caches
+    ) {
+        return partitionReconciliation(ig, repair, repairAlgorithm, parallelism, 1000, caches);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationBatchSizeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationBatchSizeTest.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2024 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.checker.processor;
+
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.processors.cache.checker.objects.ReconciliationResult;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.junit.Test;
+
+import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
+import static org.apache.ignite.cache.CacheWriteSynchronizationMode.FULL_SYNC;
+import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.RECONCILIATION_DIR;
+import static org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm.LATEST;
+
+/**
+ * Tests reconciliation with intersecting and non-intersecting values when the batch size is smaller than the gap between partition owners.
+ */
+public class PartitionReconciliationBatchSizeTest extends PartitionReconciliationAbstractTest {
+    /** Nodes. */
+    private static final int NODES_CNT = 3;
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+            .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
+                .setPersistenceEnabled(false)
+                .setMaxSize(300L * 1024 * 1024))
+        );
+
+        cfg.setConsistentId(igniteInstanceName);
+
+        return cfg;
+    }
+
+    @Override
+    protected void beforeTestsStarted() throws Exception {
+        super.beforeTestsStarted();
+
+        stopAllGrids();
+
+        cleanPersistenceDir();
+
+        startGrids(NODES_CNT);
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void beforeTest() throws Exception {
+        CacheConfiguration<Integer, Integer> ccfg = new CacheConfiguration<>();
+
+        ccfg.setName(DEFAULT_CACHE_NAME);
+        ccfg.setAtomicityMode(ATOMIC);
+        ccfg.setWriteSynchronizationMode(FULL_SYNC);
+        ccfg.setAffinity(new RendezvousAffinityFunction(false, 1));
+        ccfg.setBackups(NODES_CNT -1);
+
+        grid(0).getOrCreateCache(ccfg);
+
+        awaitPartitionMapExchange();
+    }
+
+    @Override
+    protected void afterTestsStopped() throws Exception {
+        super.afterTestsStopped();
+
+        stopAllGrids();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        grid(0).destroyCache(DEFAULT_CACHE_NAME);
+
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), RECONCILIATION_DIR, false));
+    }
+
+    /**
+     * Tests detecting and fixing conflicts when partitions have non-intersected values.
+     *
+     * owner0 - [0, ..., 33], owner1 - [34, ..., 66] and owner3 - [67, ..., 99]. batch size - 10.
+     * expected number of conflicts - 100.
+     */
+    @Test
+    public void testNonIntersectingValues() {
+        IgniteCache<Integer, Integer> cache0 = grid(0).cache(DEFAULT_CACHE_NAME);
+        IgniteCache<Integer, Integer> cache1 = grid(1).cache(DEFAULT_CACHE_NAME);
+        IgniteCache<Integer, Integer> cache2 = grid(2).cache(DEFAULT_CACHE_NAME);
+
+        int numberOfKeys = 100;
+        List<Integer> singlePartKeys = partitionKeys(cache0, 0, numberOfKeys, 0);
+
+        Set<Integer> keysToClear0 = new LinkedHashSet<>();
+        Set<Integer> keysToClear1 = new LinkedHashSet<>();
+        Set<Integer> keysToClear2 = new LinkedHashSet<>();
+
+        for (int i = 0; i < singlePartKeys.size(); i++) {
+            Integer key = singlePartKeys.get(i);
+
+            cache0.put(key, key);
+
+            if (i < numberOfKeys / 3)
+                keysToClear0.add(key);
+            else if (i < 2 * numberOfKeys / 3)
+                keysToClear1.add(key);
+            else
+                keysToClear2.add(key);
+        }
+
+        cache0.localClearAll(keysToClear0);
+        cache1.localClearAll(keysToClear1);
+        cache2.localClearAll(keysToClear2);
+
+        detectAndFixConflicts(new HashSet<>(singlePartKeys));
+    }
+
+    /**
+     * Tests detecting and fixing conflicts when partitions have intersected values.
+     *
+     * owner0 - [0, ..., 99], owner1 - [34, ..., 66] and owner3 - [67, ..., 99]. batch size - 10.
+     * expected number of conflicts - 100.
+     */
+    @Test
+    public void testIntersectingValues() {
+        IgniteCache<Integer, Integer> cache0 = grid(0).cache(DEFAULT_CACHE_NAME);
+        IgniteCache<Integer, Integer> cache1 = grid(1).cache(DEFAULT_CACHE_NAME);
+        IgniteCache<Integer, Integer> cache2 = grid(2).cache(DEFAULT_CACHE_NAME);
+
+        int numberOfKeys = 100;
+        List<Integer> singlePartKeys = partitionKeys(cache0, 0, numberOfKeys, 0);
+
+        Set<Integer> keysToClear1 = new LinkedHashSet<>();
+        Set<Integer> keysToClear2 = new LinkedHashSet<>();
+
+        for (int i = 0; i < singlePartKeys.size(); i++) {
+            Integer key = singlePartKeys.get(i);
+
+            cache0.put(key, key);
+
+            if (i < 2 * numberOfKeys / 3)
+                keysToClear1.add(key);
+            else
+                keysToClear2.add(key);
+        }
+
+        cache1.localClearAll(keysToClear1);
+        cache2.localClearAll(keysToClear2);
+
+        detectAndFixConflicts(new HashSet<>(singlePartKeys));
+    }
+
+    private void detectAndFixConflicts(Set<Integer> conflictedKeys) {
+        // Detect conflicts.
+        ReconciliationResult res = partitionReconciliation(grid(0), false, null, 4, 10, DEFAULT_CACHE_NAME);
+
+        assertEquals(conflictedKeys.size(), conflictKeys(res, DEFAULT_CACHE_NAME).size());
+        assertResultContainsConflictKeys(res, DEFAULT_CACHE_NAME, conflictedKeys);
+
+        // Detect and fix conflicts.
+        partitionReconciliation(grid(0), true, LATEST, 4, 10, DEFAULT_CACHE_NAME);
+
+        assertFalse(idleVerify(grid(0), DEFAULT_CACHE_NAME).hasConflicts());
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationBatchSizeTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationBatchSizeTest.java
@@ -57,8 +57,8 @@ public class PartitionReconciliationBatchSizeTest extends PartitionReconciliatio
         return cfg;
     }
 
-    @Override
-    protected void beforeTestsStarted() throws Exception {
+    /** {@inheritDoc} */
+    @Override protected void beforeTestsStarted() throws Exception {
         super.beforeTestsStarted();
 
         stopAllGrids();
@@ -76,15 +76,15 @@ public class PartitionReconciliationBatchSizeTest extends PartitionReconciliatio
         ccfg.setAtomicityMode(ATOMIC);
         ccfg.setWriteSynchronizationMode(FULL_SYNC);
         ccfg.setAffinity(new RendezvousAffinityFunction(false, 1));
-        ccfg.setBackups(NODES_CNT -1);
+        ccfg.setBackups(NODES_CNT - 1);
 
         grid(0).getOrCreateCache(ccfg);
 
         awaitPartitionMapExchange();
     }
 
-    @Override
-    protected void afterTestsStopped() throws Exception {
+    /** {@inheritDoc} */
+    @Override protected void afterTestsStopped() throws Exception {
         super.afterTestsStopped();
 
         stopAllGrids();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationFixStressTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationFixStressTest.java
@@ -35,7 +35,7 @@ public class PartitionReconciliationFixStressTest extends PartitionReconciliatio
      * Makes different variations of input params.
      */
     @Parameterized.Parameters(
-        name = "atomicity = {0}, partitions = {1}, fixModeEnabled = {2}, repairAlgorithm = {3}, parallelism = {4}")
+        name = "atomicity = {0}, partitions = {1}, fixModeEnabled = {2}, repairAlgorithm = {3}, parallelism = {4}, batchSize = {5}")
     public static List<Object[]> parameters() {
         ArrayList<Object[]> params = new ArrayList<>();
 
@@ -48,11 +48,13 @@ public class PartitionReconciliationFixStressTest extends PartitionReconciliatio
         for (CacheAtomicityMode atomicityMode : atomicityModes) {
             for (int parts : partitions)
                 for (RepairAlgorithm repairAlgorithm : repairAlgorithms)
-                    params.add(new Object[] {atomicityMode, parts, true, repairAlgorithm, 4});
+                    params.add(new Object[] {atomicityMode, parts, true, repairAlgorithm, 4, 1000});
+
+            params.add(new Object[] {atomicityMode, partitions[1], true, repairAlgorithms[0], 4, 10});
         }
 
-        params.add(new Object[] {CacheAtomicityMode.ATOMIC, 1, true, LATEST, 1});
-        params.add(new Object[] {CacheAtomicityMode.TRANSACTIONAL, 32, true, PRIMARY, 1});
+        params.add(new Object[] {CacheAtomicityMode.ATOMIC, 1, true, LATEST, 1, 1000});
+        params.add(new Object[] {CacheAtomicityMode.TRANSACTIONAL, 32, true, PRIMARY, 1, 1000});
 
         return params;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationFullFixStressTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationFullFixStressTest.java
@@ -45,7 +45,7 @@ public class PartitionReconciliationFullFixStressTest extends PartitionReconcili
      * Makes different variations of input params.
      */
     @Parameterized.Parameters(
-        name = "atomicity = {0}, partitions = {1}, fixModeEnabled = {2}, repairAlgorithm = {3}, parallelism = {4}")
+        name = "atomicity = {0}, partitions = {1}, fixModeEnabled = {2}, repairAlgorithm = {3}, parallelism = {4}, batchSize = {5}")
     public static List<Object[]> parameters() {
         ArrayList<Object[]> params = new ArrayList<>();
 
@@ -58,11 +58,13 @@ public class PartitionReconciliationFullFixStressTest extends PartitionReconcili
         for (CacheAtomicityMode atomicityMode : atomicityModes) {
             for (int parts : partitions)
                 for (RepairAlgorithm repairAlgorithm : repairAlgorithms)
-                    params.add(new Object[] {atomicityMode, parts, true, repairAlgorithm, 4});
+                    params.add(new Object[] {atomicityMode, parts, true, repairAlgorithm, 4, 1000});
+
+            params.add(new Object[] {atomicityMode, partitions[1], true, repairAlgorithms[0], 4, 10});
         }
 
-        params.add(new Object[] {CacheAtomicityMode.ATOMIC, 1, true, MAJORITY, 1});
-        params.add(new Object[] {CacheAtomicityMode.TRANSACTIONAL, 32, true, REMOVE, 1});
+        params.add(new Object[] {CacheAtomicityMode.ATOMIC, 1, true, MAJORITY, 1, 1000});
+        params.add(new Object[] {CacheAtomicityMode.TRANSACTIONAL, 32, true, REMOVE, 1, 1000});
 
         return params;
     }
@@ -72,8 +74,8 @@ public class PartitionReconciliationFullFixStressTest extends PartitionReconcili
      *
      * @throws Exception If failed.
      */
-    @Override @Test
-    public void testReconciliationOfColdKeysUnderLoad() throws Exception {
+    @Test
+    @Override public void testReconciliationOfColdKeysUnderLoad() throws Exception {
         IgniteCache<Integer, String> clientCache = client.cache(DEFAULT_CACHE_NAME);
 
         GridCacheContext[] nodeCacheCtxs = new GridCacheContext[NODES_CNT];
@@ -110,7 +112,7 @@ public class PartitionReconciliationFullFixStressTest extends PartitionReconcili
             }
         }, 6, "rand-loader");
 
-        ReconciliationResult res = partitionReconciliation(ig, fixMode, repairAlgorithm, parallelism, DEFAULT_CACHE_NAME);
+        ReconciliationResult res = partitionReconciliation(ig, fixMode, repairAlgorithm, parallelism, batchSize, DEFAULT_CACHE_NAME);
 
         log.info(">>>> Partition reconciliation finished");
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/tasks/CollectPartitionKeysByBatchTaskTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/tasks/CollectPartitionKeysByBatchTaskTest.java
@@ -136,7 +136,7 @@ public class CollectPartitionKeysByBatchTaskTest extends CollectPartitionInfoAbs
 
             Map<KeyCacheObject, Map<UUID, GridCacheVersion>> rechecks = reduce.get2();
 
-            assertEquals(Integer.valueOf(200), reduce.get1().value(null, false));
+            assertEquals(Integer.valueOf(100), reduce.get1().value(null, false));
             assertEquals(2, rechecks.size());
             assertTrue(rechecks.containsKey(key(100, ctxo)));
             assertTrue(rechecks.containsKey(key(200, ctxo)));
@@ -180,7 +180,7 @@ public class CollectPartitionKeysByBatchTaskTest extends CollectPartitionInfoAbs
 
             Map<KeyCacheObject, Map<UUID, GridCacheVersion>> rechecks = reduce.get2();
 
-            assertEquals(Integer.valueOf(6), reduce.get1().value(null, false));
+            assertEquals(Integer.valueOf(5), reduce.get1().value(null, false));
 
             assertEquals(6, rechecks.size());
             assertEquals(1, rechecks.get(key(1, ctxo)).size()); // 1

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairEntryProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairEntryProcessorTest.java
@@ -44,27 +44,19 @@ import static org.mockito.Mockito.when;
  * Isolated unit test for {@link RepairEntryProcessor}.
  */
 public class RepairEntryProcessorTest {
-    /**
-     *
-     */
+    /** */
     private static final String OLD_VALUE = "old_value";
 
     /** Old cache value. */
     private static final CacheObject OLD_CACHE_VALUE = new CacheObjectImpl(OLD_VALUE, OLD_VALUE.getBytes());
 
-    /**
-     *
-     */
+    /** */
     private static final String NEW_VALUE = "new_value";
 
-    /**
-     * Value at the recheck phase. It uses to check parallel updates.
-     */
+    /** Value at the recheck phase. It uses to check parallel updates. */
     private static final String RECHECK_VALUE = "updated_value";
 
-    /**
-     *
-     */
+    /** */
     private static final CacheObject RECHECK_CACHE_VALUE = new CacheObjectImpl(RECHECK_VALUE, RECHECK_VALUE.getBytes());
 
     /** Local node id. */
@@ -73,17 +65,10 @@ public class RepairEntryProcessorTest {
     /** Other node id. */
     private static final UUID OTHRER_NODE_ID = UUID.randomUUID();
 
-    /** Remove queue max size. */
-    private static final int RMV_QUEUE_MAX_SIZE = 12;
-
-    /**
-     *
-     */
+    /** */
     private GridCacheContext cctx;
 
-    /**
-     *
-     */
+    /** */
     @Before
     public void setUp() throws Exception {
         cctx = mock(GridCacheContext.class);
@@ -95,9 +80,7 @@ public class RepairEntryProcessorTest {
         System.setProperty(IGNITE_CACHE_REMOVED_ENTRIES_TTL, "10000");
     }
 
-    /**
-     *
-     */
+    /** */
     @After
     public void tearDown() {
         System.clearProperty(IGNITE_CACHE_REMOVED_ENTRIES_TTL);
@@ -121,7 +104,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             forceRepair,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -151,7 +133,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             NEW_VALUE,
             data,
-            RMV_QUEUE_MAX_SIZE,
             forceRepair,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -179,7 +160,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             NEW_VALUE,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(1, 1, 1));
@@ -208,7 +188,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(1, 1, 1));
@@ -237,7 +216,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             NEW_VALUE,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(2, 2, 2));
@@ -249,14 +227,13 @@ public class RepairEntryProcessorTest {
     }
 
     /**
-     * It mean that a partition under load.
+     * It means that a partition under load.
      */
     @Test
     public void testRecheckVersionNullCurrentValueExist() {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             NEW_VALUE,
             new HashMap<>(),
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(1, 1, 1));
@@ -284,7 +261,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -314,7 +290,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             RECHECK_VALUE,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -327,7 +302,7 @@ public class RepairEntryProcessorTest {
     }
 
     /**
-     * If current value other then old, it detects {@link RepairEntryProcessor.RepairStatus.CONCURRENT_MODIFICATION}.
+     * If current value other than old, it detects {@link RepairEntryProcessor.RepairStatus#CONCURRENT_MODIFICATION}.
      */
     @Test
     public void testEntryWasChangedDuringRepairAtOtherValue() {
@@ -342,7 +317,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -354,7 +328,7 @@ public class RepairEntryProcessorTest {
     }
 
     /**
-     * If current value other then old, it detects {@link RepairEntryProcessor.RepairStatus.CONCURRENT_MODIFICATION}.
+     * If current value other than old, it detects {@link RepairEntryProcessor.RepairStatus#CONCURRENT_MODIFICATION}.
      */
     @Test
     public void testEntryWasChangedDuringRepairAtNull() {
@@ -369,7 +343,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -381,7 +354,7 @@ public class RepairEntryProcessorTest {
     }
 
     /**
-     * If current value other then old, it detects {@link RepairEntryProcessor.RepairStatus.CONCURRENT_MODIFICATION}.
+     * If current value other than old, it detects {@link RepairEntryProcessor.RepairStatus#CONCURRENT_MODIFICATION}.
      */
     @Test
     public void testEntryWasChangedDuringRepairFromNullToValue() {
@@ -396,7 +369,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(1, 1, 1));
@@ -409,7 +381,7 @@ public class RepairEntryProcessorTest {
 
     /**
      * If ttl expired for old null value, it can't solve ABA problem and should return {@link
-     * RepairEntryProcessor.RepairStatus.FAIL}.
+     * RepairEntryProcessor.RepairStatus#FAIL}.
      */
     @Test
     public void testRecheckVersionNullAndTtlEntryExpired() {
@@ -424,7 +396,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         ).setKeyVersion(new GridCacheVersion(0, 0, 0));
@@ -436,7 +407,7 @@ public class RepairEntryProcessorTest {
 
     /**
      * If Deleted queue expired for old null value, it can't solve ABA problem and should return {@link
-     * RepairEntryProcessor.RepairStatus.FAIL}.
+     * RepairEntryProcessor.RepairStatus#FAIL}.
      */
     @Test
     public void testRecheckVersionNullAndDefDelQueueExpired() {
@@ -451,7 +422,6 @@ public class RepairEntryProcessorTest {
         RepairEntryProcessor repairProcessor = new RepairEntryProcessorStub(
             null,
             data,
-            RMV_QUEUE_MAX_SIZE,
             false,
             new AffinityTopologyVersion(1)
         )
@@ -467,41 +437,31 @@ public class RepairEntryProcessorTest {
      * Stub for testing approach, mocks methods.
      */
     private class RepairEntryProcessorStub extends RepairEntryProcessor {
-        /**
-         *
-         */
+        /** */
         private GridCacheContext ctx = cctx;
 
-        /**
-         *
-         */
+        /** */
         private boolean topChanged = false;
 
-        /**
-         *
-         */
+        /** */
         private GridCacheVersion keyVer;
 
-        /**
-         *
-         */
+        /** */
         private long updateCntr = 1;
 
         /**
          * @param val Value.
          * @param data Data.
-         * @param rmvQueueMaxSize Remove queue max size.
          * @param forceRepair Force repair.
          * @param startTopVer Start topology version.
          */
         public RepairEntryProcessorStub(
             Object val,
             Map<UUID, VersionedValue> data,
-            long rmvQueueMaxSize,
             boolean forceRepair,
             AffinityTopologyVersion startTopVer
         ) {
-            super(val, data, rmvQueueMaxSize, forceRepair, startTopVer);
+            super(val, data, forceRepair, startTopVer);
         }
 
         /**

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/PartitionReconciliationTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/PartitionReconciliationTestSuite.java
@@ -23,6 +23,7 @@ import org.apache.ignite.internal.processors.cache.checker.ConsistencyCheckUtils
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationAtomicLongDataStructureTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationAtomicLongFixStressTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationAtomicLongStressTest;
+import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationBatchSizeTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationBinaryObjectsTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationCompactCollectorTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationFastCheckTest;
@@ -86,6 +87,7 @@ public class PartitionReconciliationTestSuite {
         GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationAtomicLongStressTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationSystemFastCheckTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationLostPartitionsTest.class, ignoredTests);
+        GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationBatchSizeTest.class, ignoredTests);
 
         return suite;
     }


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-39314

The main goal of this patch is to fix an issue that could lead to skipping keys during partition reconciliation.
Let's consider the following example:
 the primary partition contains all keys `[1, ..., 200]` and the backup only has half of the keys `[100, ..., 200]`,
 and the batch size is `50`. In this case, the primary node will return `[1, ..., 50]` and backup will return `[100, ..., 150]`.
 The range of keys to re-check is `[1, ..., 50, 100, ..., 150]` and the next batch should start from `150`
 because `150` is the last observed key. It means that the range [51, ..., 99] will be skipped.
 So, the `lastKey` should be the minimum key of all the last observed keys. This may lead to re-checking the same keys several times, but it is better than skipping keys.
 
 Also, this patch includes the following updates:
  - `PartitionReconciliationStressTest`. Now, this test does not require restarting the entire cluster before every test.
  - `PartitionReconciliationSkippedEntityHolder` implements `hashCode` and `equals` to properly use it as a key for HashSet
  - removed code related to deferred delete queue max size.
