### PR TITLE
GG-39421 .NET: Disable TestAsyncMultithreadedKeepBinary

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
@@ -1574,6 +1574,7 @@ namespace Apache.Ignite.Core.Tests.Cache
         [Test]
         [Category(TestUtils.CategoryIntensive)]
         [Timeout(180000)] // 3 minutes
+        [Ignore("GG-39554 TestAsyncMultithreadedKeepBinary fails due to AssertionError")]
         public void TestAsyncMultithreadedKeepBinary()
         {
             var cache = Cache().WithKeepBinary<CacheTestKey, BinarizablePerson>();

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
@@ -1573,7 +1573,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
         [Test]
         [Category(TestUtils.CategoryIntensive)]
-        [Timeout(90000)]
+        [Timeout(180000)] // 3 minutes
         public void TestAsyncMultithreadedKeepBinary()
         {
             var cache = Cache().WithKeepBinary<CacheTestKey, BinarizablePerson>();
@@ -1600,7 +1600,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                     futs.Add(task);
                 }
 
-                Task.WaitAll(futs.ToArray(), TimeSpan.FromSeconds(40));
+                Task.WaitAll(futs.ToArray(), TimeSpan.FromMinutes(1));
             }, threads);
 
             for (int i = 0; i < threads; i++)
@@ -1635,7 +1635,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 }
 
                 // ReSharper disable once CoVariantArrayConversion
-                Task.WaitAll(futs.ToArray(), TimeSpan.FromSeconds(40));
+                Task.WaitAll(futs.ToArray(), TimeSpan.FromMinutes(1));
 
                 for (int i = 0; i < objPerThread; i++)
                 {
@@ -1667,7 +1667,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                 }
 
                 // ReSharper disable once CoVariantArrayConversion
-                Task.WaitAll(futs.ToArray(), TimeSpan.FromSeconds(40));
+                Task.WaitAll(futs.ToArray(), TimeSpan.FromMinutes(1));
 
                 for (int i = 0; i < objPerThread; i++)
                 {

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTest.cs
@@ -1573,6 +1573,7 @@ namespace Apache.Ignite.Core.Tests.Cache
 
         [Test]
         [Category(TestUtils.CategoryIntensive)]
+        [Timeout(90000)]
         public void TestAsyncMultithreadedKeepBinary()
         {
             var cache = Cache().WithKeepBinary<CacheTestKey, BinarizablePerson>();
@@ -1599,8 +1600,7 @@ namespace Apache.Ignite.Core.Tests.Cache
                     futs.Add(task);
                 }
 
-                foreach (var fut in futs)
-                    fut.Wait();
+                Task.WaitAll(futs.ToArray(), TimeSpan.FromSeconds(40));
             }, threads);
 
             for (int i = 0; i < threads; i++)
@@ -1634,6 +1634,9 @@ namespace Apache.Ignite.Core.Tests.Cache
                     futs.Add(portCache.GetAsync(new CacheTestKey(key)));
                 }
 
+                // ReSharper disable once CoVariantArrayConversion
+                Task.WaitAll(futs.ToArray(), TimeSpan.FromSeconds(40));
+
                 for (int i = 0; i < objPerThread; i++)
                 {
                     var fut = futs[i];
@@ -1662,6 +1665,9 @@ namespace Apache.Ignite.Core.Tests.Cache
 
                     futs.Add(cache.RemoveAsync(new CacheTestKey(key)));
                 }
+
+                // ReSharper disable once CoVariantArrayConversion
+                Task.WaitAll(futs.ToArray(), TimeSpan.FromSeconds(40));
 
                 for (int i = 0; i < objPerThread; i++)
                 {


### PR DESCRIPTION
* Disable `TestAsyncMultithreadedKeepBinary` - it fails due to an assertion error in `GridDhtLocalPartition`, will be fixed separately in GG-39554
* Add timeouts to the test as a future improvement