### PR TITLE
GG-38941 Added additional logging for the partition reconciliation tool

### DIFF
--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
@@ -133,17 +133,21 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
     @Test
     @WithSystemProperty(key = "RECONCILIATION_WORK_PROGRESS_PRINT_INTERVAL", value = "0")
     public void testProgressLogPrinted() throws Exception {
+        int nodeCnt = 3;
+
         LogListener lsnr1 = LogListener.matches(s -> s.startsWith("Partition reconciliation status [sesId=")).atLeast(1).build();
-        LogListener lsnr2 = LogListener.matches(s -> s.startsWith("Partition reconciliation has started [sesionId")).atLeast(1).build();
-        LogListener lsnr3 = LogListener.matches(s -> s.startsWith("Partition reconciliation has finished locally [sessionId="))
-            .atLeast(1)
+        LogListener lsnr2 = LogListener.matches(s -> s.startsWith("Partition reconciliation has started [sesId="))
+            .times(nodeCnt)
+            .build();
+        LogListener lsnr3 = LogListener.matches(s -> s.startsWith("Partition reconciliation has finished locally [sesId="))
+            .times(nodeCnt)
             .build();
 
         log.registerListener(lsnr1);
         log.registerListener(lsnr2);
         log.registerListener(lsnr3);
 
-        startGrids(3);
+        startGrids(nodeCnt);
 
         IgniteEx ignite = grid(0);
         ignite.cluster().active(true);

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
@@ -28,6 +28,7 @@ import java.util.logging.StreamHandler;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteDataStreamer;
 import org.apache.ignite.configuration.CacheConfiguration;
@@ -47,9 +48,11 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.ListeningTestLogger;
 import org.apache.ignite.testframework.LogListener;
 import org.apache.ignite.testframework.junits.GridAbstractTest;
+import org.apache.ignite.testframework.junits.WithSystemProperty;
 import org.junit.Test;
 
 import static java.util.stream.Collectors.toList;
+import static org.apache.ignite.cluster.ClusterState.ACTIVE;
 import static org.apache.ignite.internal.commandline.CommandHandler.EXIT_CODE_OK;
 import static org.apache.ignite.internal.processors.cache.GridCacheUtils.UTILITY_CACHE_NAME;
 import static org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationProcessor.SESSION_CHANGE_MSG;
@@ -127,19 +130,46 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
     }
 
     /**
-     * Checks that the start message exist.
+     * Checks that start, status and finished messages exist.
+     * Also, checks that finished messages contain correct number of conflicted and repaired keys.
      */
     @Test
+    @WithSystemProperty(key = "RECONCILIATION_WORK_PROGRESS_PRINT_INTERVAL_SEC", value = "1")
     public void testProgressLogPrinted() throws Exception {
         int nodeCnt = 3;
 
+        startGrids(nodeCnt);
+
+        IgniteEx ignite = grid(0);
+        ignite.cluster().state(ACTIVE);
+
+        testProgressLogPrinted(nodeCnt, true);
+        testProgressLogPrinted(nodeCnt, false);
+    }
+
+    /**
+     * @param nodeCnt Number of nodes.
+     * @param simpleCollector {@code true} if simple collector should be used.
+     * @throws Exception If failed.
+     */
+    private void testProgressLogPrinted(int nodeCnt, boolean simpleCollector) throws Exception {
         LogListener lsnr1 = LogListener.matches(s -> s.startsWith("Partition reconciliation status [sesId="))
             .atLeast(nodeCnt)
             .build();
+
         LogListener lsnr2 = LogListener.matches(s -> s.startsWith("Partition reconciliation has started [sesId="))
             .times(nodeCnt)
             .build();
-        LogListener lsnr3 = LogListener.matches(s -> s.startsWith("Partition reconciliation has finished locally [sesId="))
+
+        List<String> finishMsgs = new ArrayList<>();
+        LogListener lsnr3 = LogListener.matches(s -> {
+                if (s.startsWith("Partition reconciliation has finished locally [sesId=")) {
+                    finishMsgs.add(s);
+
+                    return true;
+                }
+                return false;
+            })
             .times(nodeCnt)
             .build();
 
@@ -147,16 +177,70 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
         log.registerListener(lsnr2);
         log.registerListener(lsnr3);
 
-        startGrids(nodeCnt);
+        IgniteCache<Integer, Integer> cache = grid(0).cache(DEFAULT_CACHE_NAME);
 
-        IgniteEx ignite = grid(0);
-        ignite.cluster().active(true);
+        int keysCnt = 100;
+        int expectedConflicts = 0;
+        for (int i = 0; i < keysCnt; i++) {
+            cache.put(i, i);
 
-        assertEquals(EXIT_CODE_OK, execute("--cache", "partition_reconciliation", "--repair", "MAJORITY", "--recheck-attempts", "1"));
+            if (i % 10 == 0) {
+                corruptDataEntry(grid(0).cachex(DEFAULT_CACHE_NAME).context(), i);
+                expectedConflicts++;
+            }
+        }
 
-        assertTrue(lsnr1.check(10_000));
-        assertTrue(lsnr2.check(10_000));
-        assertTrue(lsnr3.check(10_000));
+        try {
+            List<String> args = new ArrayList<>(Arrays.asList(
+                "--cache",
+                "partition_reconciliation",
+                DEFAULT_CACHE_NAME,
+                "--repair",
+                "MAJORITY",
+                "--recheck-attempts",
+                "1",
+                "--batch-size",
+                "10",
+                "--recheck-delay",
+                "1"
+            ));
+
+            if (simpleCollector)
+                args.add("--local-output");
+
+            assertEquals(EXIT_CODE_OK, execute(args.toArray(new String[0])));
+
+            assertTrue(lsnr1.check(10_000));
+            assertTrue(lsnr2.check(10_000));
+            assertTrue(lsnr3.check(10_000));
+
+            Pattern pattern = Pattern.compile(".*finished locally.*conflicts=(\\d+).*repaired=(\\d+).*");
+
+            int totalConflicts = 0;
+            int totalRepaired = 0;
+            for (String msg : finishMsgs) {
+                Matcher matcher = pattern.matcher(msg);
+
+                assertTrue(matcher.matches());
+
+                int conflicts = Integer.parseInt(matcher.group(1));
+                int repaired = Integer.parseInt(matcher.group(2));
+
+                assertTrue(expectedConflicts >= conflicts);
+                assertTrue(expectedConflicts >= repaired);
+
+                totalConflicts += conflicts;
+                totalRepaired += repaired;
+            }
+
+            assertEquals(expectedConflicts, totalConflicts);
+            assertEquals(expectedConflicts, totalRepaired);
+        }
+        finally {
+            log.unregisterListener(lsnr1);
+            log.unregisterListener(lsnr2);
+            log.unregisterListener(lsnr3);
+        }
     }
 
     /**

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
@@ -133,8 +133,15 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
     @Test
     @WithSystemProperty(key = "RECONCILIATION_WORK_PROGRESS_PRINT_INTERVAL", value = "0")
     public void testProgressLogPrinted() throws Exception {
-        LogListener lsnr = LogListener.matches(s -> s.startsWith("Partition reconciliation task [sesId=")).atLeast(1).build();
-        log.registerListener(lsnr);
+        LogListener lsnr1 = LogListener.matches(s -> s.startsWith("Partition reconciliation status [sesId=")).atLeast(1).build();
+        LogListener lsnr2 = LogListener.matches(s -> s.startsWith("Partition reconciliation has started [sesionId")).atLeast(1).build();
+        LogListener lsnr3 = LogListener.matches(s -> s.startsWith("Partition reconciliation has finished locally [sessionId="))
+            .atLeast(1)
+            .build();
+
+        log.registerListener(lsnr1);
+        log.registerListener(lsnr2);
+        log.registerListener(lsnr3);
 
         startGrids(3);
 
@@ -143,7 +150,9 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
 
         assertEquals(EXIT_CODE_OK, execute("--cache", "partition_reconciliation", "--repair", "MAJORITY", "--recheck-attempts", "1"));
 
-        assertTrue(lsnr.check(10_000));
+        assertTrue(lsnr1.check(10_000));
+        assertTrue(lsnr2.check(10_000));
+        assertTrue(lsnr3.check(10_000));
     }
 
     /**

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
@@ -133,7 +133,9 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
     public void testProgressLogPrinted() throws Exception {
         int nodeCnt = 3;
 
-        LogListener lsnr1 = LogListener.matches(s -> s.startsWith("Partition reconciliation status [sesId=")).atLeast(1).build();
+        LogListener lsnr1 = LogListener.matches(s -> s.startsWith("Partition reconciliation status [sesId="))
+            .atLeast(nodeCnt)
+            .build();
         LogListener lsnr2 = LogListener.matches(s -> s.startsWith("Partition reconciliation has started [sesId="))
             .times(nodeCnt)
             .build();

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationExtendedTest.java
@@ -47,7 +47,6 @@ import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.ListeningTestLogger;
 import org.apache.ignite.testframework.LogListener;
 import org.apache.ignite.testframework.junits.GridAbstractTest;
-import org.apache.ignite.testframework.junits.WithSystemProperty;
 import org.junit.Test;
 
 import static java.util.stream.Collectors.toList;
@@ -131,7 +130,6 @@ public class GridCommandHandlerPartitionReconciliationExtendedTest extends
      * Checks that the start message exist.
      */
     @Test
-    @WithSystemProperty(key = "RECONCILIATION_WORK_PROGRESS_PRINT_INTERVAL", value = "0")
     public void testProgressLogPrinted() throws Exception {
         int nodeCnt = 3;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/AbstractPipelineProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/AbstractPipelineProcessor.java
@@ -39,6 +39,7 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.lang.IgniteInClosure;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.ignite.IgniteSystemProperties.getLong;
 import static org.apache.ignite.internal.processors.cache.checker.processor.ReconciliationEventListener.WorkLoadStage.BEFORE_PROCESSING;
 import static org.apache.ignite.internal.processors.cache.checker.processor.ReconciliationEventListener.WorkLoadStage.FINISHED;
@@ -51,7 +52,7 @@ import static org.apache.ignite.internal.processors.cache.checker.processor.Reco
  */
 public class AbstractPipelineProcessor {
     /** Work progress print interval. The default values is 1 min. */
-    protected final long workProgressPrintInterval = getLong("WORK_PROGRESS_PRINT_INTERVAL", 1000 * 60);
+    protected final long workProgressPrintIntervalSec = getLong("RECONCILIATION_WORK_PROGRESS_PRINT_INTERVAL_SEC", 60);
 
     /** Session identifier that allows identifying particular data flow and workload. */
     protected final long sesId;
@@ -218,7 +219,7 @@ public class AbstractPipelineProcessor {
         boolean acquired = false;
 
         while (!acquired) {
-            acquired = liveListeners.tryAcquire(workProgressPrintInterval / 5, MILLISECONDS);
+            acquired = liveListeners.tryAcquire(workProgressPrintIntervalSec / 5, SECONDS);
 
             if (!acquired)
                 printStatistics();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/AbstractPipelineProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/AbstractPipelineProcessor.java
@@ -312,12 +312,12 @@ public class AbstractPipelineProcessor {
         // No-op.
     }
 
-        /**
-         * Returns a cluster group represents a set od nodes that own the given partition.
-         * Returned group can be {@code null} in case of there are no owners for the given partition.
-         *
-         * @return Cluster group of owners.
-         */
+    /**
+     * Returns a cluster group represents a set od nodes that own the given partition.
+     * Returned group can be {@code null} in case of there are no owners for the given partition.
+     *
+     * @return Cluster group of owners.
+     */
     private ClusterGroup partOwners(String cacheName, int partId) {
         Collection<ClusterNode> nodes = ignite.cachex(cacheName).context().topology().owners(partId, startTopVer);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/AbstractPipelineProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/AbstractPipelineProcessor.java
@@ -224,8 +224,6 @@ public class AbstractPipelineProcessor {
                 printStatistics();
         }
 
-        liveListeners.acquire();
-
         ClusterGroup grp = partOwners(workload.cacheName(), workload.partitionId());
 
         if (grp == null) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
@@ -71,11 +71,11 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
     public static final String TOPOLOGY_CHANGE_MSG = "Topology has changed. Partition reconciliation task was stopped.";
 
     /** Start execution message. */
-    private static final String START_EXECUTION_MSG = "Partition reconciliation has started [sesionId=%s, repair=%s, repairAlgorithm=%s, " +
+    private static final String START_EXECUTION_MSG = "Partition reconciliation has started [sesId=%s, repair=%s, repairAlgorithm=%s, " +
         "fastCheck=%s, batchSize=%s, recheckAttempts=%s, parallelismLevel=%s, caches=%s]";
 
     /** Stop execution message. */
-    private static final String STOP_EXECUTION_MSG = "Partition reconciliation has finished locally [sessionId=%s, conflicts=%s, " +
+    private static final String STOP_EXECUTION_MSG = "Partition reconciliation has finished locally [sesId=%s, conflicts=%s, " +
         "repaired=%s, totalTime=%s(sec)]";
 
     /** Session progress message. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
@@ -57,7 +57,6 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 
 import static java.util.Collections.EMPTY_SET;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.ignite.IgniteSystemProperties.getLong;
 import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.checkConflicts;
 import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.unmarshalKey;
 
@@ -567,8 +566,8 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
             }
         }
 
-        @Override
-        public void updateScannedPartition(long sesId, String cacheName, int partId, boolean primary, long keysCnt) {
+        /** {@inheritDoc} */
+        @Override public void updateScannedPartition(long sesId, String cacheName, int partId, boolean primary, long keysCnt) {
             assert sesId == sessionId() : "Update partition scan metrics does not correspond to the current session " +
                 "[currSesId=" + sessionId() + ", updateSesId=" + sesId + ']';
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
@@ -56,7 +56,7 @@ import org.apache.ignite.internal.processors.diagnostic.ReconciliationExecutionC
 import org.apache.ignite.internal.util.typedef.internal.U;
 
 import static java.util.Collections.EMPTY_SET;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.checkConflicts;
 import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.unmarshalKey;
 
@@ -258,7 +258,7 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
                     continue;
                 }
 
-                PipelineWorkload workload = pollTask(workProgressPrintInterval / 5, MILLISECONDS);
+                PipelineWorkload workload = pollTask(workProgressPrintIntervalSec / 5, SECONDS);
                 if (workload == null)
                     continue;
 
@@ -319,7 +319,7 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
 
         long lastUpdate = lastWorkProgressUpdateTime.get();
 
-        if (currTimeMillis < lastUpdate + workProgressPrintInterval || !log.isInfoEnabled())
+        if (currTimeMillis < lastUpdate + SECONDS.toMillis(workProgressPrintIntervalSec) || !log.isInfoEnabled())
             return;
 
         if (!lastWorkProgressUpdateTime.compareAndSet(lastUpdate, currTimeMillis))

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
@@ -533,11 +533,6 @@ public interface ReconciliationResultCollector {
         }
 
         /** {@inheritDoc} */
-        @Override public long conflictedEntriesSize() {
-            return totalInconsistentKeys.get() + super.conflictedEntriesSize();
-        }
-
-        /** {@inheritDoc} */
         @Override public long conflictedEntriesSize(String cacheName) {
             synchronized (inconsistentKeys) {
                 Long conflicts = inconsistentKeysPerCache.getOrDefault(cacheName, 0L);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
@@ -27,6 +27,8 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -107,6 +109,21 @@ public interface ReconciliationResultCollector {
         Map<KeyCacheObject, Map<UUID, VersionedValue>> actualKeys);
 
     /**
+     * Returns the total number of conflicts.
+     *
+     * @return The total number of conflicts.
+     */
+    long conflictedEntriesSize();
+
+    /**
+     * Returns the total number of conflicts for the specified cache.
+     *
+     * @param cacheName Cache name.
+     * @return The total number of conflicts for the specified cache.
+     */
+    long conflictedEntriesSize(String cacheName);
+
+    /**
      * Appends repaired entries.
      *
      * @param cacheName Cache name.
@@ -117,6 +134,21 @@ public interface ReconciliationResultCollector {
         String cacheName,
         int partId,
         Map<VersionedKey, RepairMeta> repairedKeys);
+
+    /**
+     * Returns the total number of repaired entries.
+     *
+     * @return The total number of repaired entries.
+     */
+    long repairedEntriesSize();
+
+    /**
+     * Returns the total number of repaired entries for the specified cache.
+     *
+     * @param cacheName Cache name.
+     * @return The total number of repaired entries for the specified cache.
+     */
+    long repairedEntriesSize(String cacheName);
 
     /**
      * This method is called when the given partition is completely processed.
@@ -144,7 +176,7 @@ public interface ReconciliationResultCollector {
     /**
      * Represents a collector of inconsistent and repaired entries.
      */
-    public static class Simple implements ReconciliationResultCollector {
+    static class Simple implements ReconciliationResultCollector {
         public static final RowMetaComparator ROW_META_COMPARATOR = new RowMetaComparator();
 
         /** Ignite instance. */
@@ -272,6 +304,53 @@ public interface ReconciliationResultCollector {
                 catch (IgniteCheckedException e) {
                     log.error("Broken key can't be added to result. ", e);
                 }
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public long conflictedEntriesSize() {
+            synchronized (inconsistentKeys) {
+                return inconsistentKeys
+                    .keySet()
+                    .stream()
+                    .mapToLong(this::conflictedEntriesSize)
+                    .sum();
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public long conflictedEntriesSize(String cacheName) {
+            synchronized (inconsistentKeys) {
+                return inconsistentKeys
+                    .getOrDefault(cacheName, Collections.emptyMap())
+                    .values()
+                    .stream()
+                    .mapToLong(Set::size)
+                    .sum();
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public long repairedEntriesSize() {
+            synchronized (inconsistentKeys) {
+                return inconsistentKeys
+                    .keySet()
+                    .stream()
+                    .mapToLong(this::repairedEntriesSize)
+                    .sum();
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public long repairedEntriesSize(String cacheName) {
+            synchronized (inconsistentKeys) {
+                return inconsistentKeys
+                    .getOrDefault(cacheName, Collections.emptyMap())
+                    .values()
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .filter(r -> r.repairMeta() != null && r.repairMeta().fixed())
+                    .count();
             }
         }
 
@@ -408,9 +487,18 @@ public interface ReconciliationResultCollector {
     /**
      * Represents a collector of inconsistent and repaired entries that persists temporary results (per partition).
      */
-    public static class Compact extends Simple {
+    static class Compact extends Simple {
         /** Total number of inconsistent keys. */
-        private final AtomicInteger totalKeysCnt = new AtomicInteger();
+        private final AtomicInteger totalInconsistentKeys = new AtomicInteger();
+
+        /** Total number of repaired keys. */
+        private final AtomicInteger totalRepairedKeys = new AtomicInteger();
+
+        /** Mapping of cache name to the number of inconsistent keys. */
+        private final Map<String, Long> inconsistentKeysPerCache = new HashMap<>();
+
+        /** Mapping of cache name to the number of repaired keys. */
+        private final Map<String, Long> repairedKeysPerCache = new HashMap<>();
 
         /** Total number of skipped entities. */
         private final AtomicInteger totalSkippedCnt = new AtomicInteger();
@@ -445,6 +533,34 @@ public interface ReconciliationResultCollector {
         }
 
         /** {@inheritDoc} */
+        @Override public long conflictedEntriesSize() {
+            return totalInconsistentKeys.get() + super.conflictedEntriesSize();
+        }
+
+        /** {@inheritDoc} */
+        @Override public long conflictedEntriesSize(String cacheName) {
+            synchronized (inconsistentKeys) {
+                Long conflicts = inconsistentKeysPerCache.getOrDefault(cacheName, 0L);
+
+                return conflicts + super.conflictedEntriesSize(cacheName);
+            }
+        }
+
+        /** {@inheritDoc} */
+        @Override public long repairedEntriesSize() {
+            return totalRepairedKeys.get() + super.repairedEntriesSize();
+        }
+
+        /** {@inheritDoc} */
+        @Override public long repairedEntriesSize(String cacheName) {
+            synchronized (inconsistentKeys) {
+                Long repaired = repairedKeysPerCache.getOrDefault(cacheName, 0L);
+
+                return repaired + super.repairedEntriesSize(cacheName);
+            }
+        }
+
+        /** {@inheritDoc} */
         @Override public void onPartitionProcessed(String cacheName, int partId) {
             if (log.isDebugEnabled())
                 log.debug("Partition has been processed [cacheName=" + cacheName + ", partId=" + partId + ']');
@@ -456,20 +572,29 @@ public interface ReconciliationResultCollector {
                 Map<Integer, TreeSet<PartitionReconciliationDataRowMeta>> c = inconsistentKeys.get(cacheName);
                 if (c != null)
                     meta = c.remove(partId);
+
+                if  (!F.isEmpty(meta)) {
+                    totalInconsistentKeys.addAndGet(meta.size());
+
+                    inconsistentKeysPerCache.merge(cacheName, (long) meta.size(), Long::sum);
+
+                    long repairedKeysCnt = meta.stream().filter(m -> m.repairMeta() != null && m.repairMeta().fixed()).count();
+
+                    repairedKeysPerCache.merge(cacheName, repairedKeysCnt, Long::sum);
+                }
             }
 
             synchronized (skippedEntries) {
                 Map<Integer, Set<PartitionReconciliationSkippedEntityHolder<PartitionReconciliationKeyMeta>>> c = skippedEntries.get(cacheName);
                 if (c != null)
                     skipped = c.remove(partId);
+
+                if (!F.isEmpty(skipped))
+                    totalSkippedCnt.addAndGet(skipped.size());
             }
 
-            if (!F.isEmpty(meta) || !F.isEmpty(skipped)) {
-                totalKeysCnt.addAndGet(F.isEmpty(meta) ? 0 : meta.size());
-                totalSkippedCnt.addAndGet(F.isEmpty(skipped) ? 0 : skipped.size());
-
+            if (!F.isEmpty(meta) || !F.isEmpty(skipped))
                 storePartition(cacheName, partId, meta, skipped);
-            }
         }
 
         /** {@inheritDoc} */
@@ -478,7 +603,7 @@ public interface ReconciliationResultCollector {
                 synchronized (skippedEntries) {
                     return new ReconciliationAffectedEntriesExtended(
                         collectNodeIdToConsistentIdMapping(ignite),
-                        totalKeysCnt.get(),
+                        totalInconsistentKeys.get(),
                         0, // skipped caches count which is not tracked/used.
                         totalSkippedCnt.get());
                 }
@@ -492,7 +617,7 @@ public interface ReconciliationResultCollector {
                     File file = createLocalResultFile(ignite.context().discovery().localNode(), startTime);
 
                     try (PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(file)))) {
-                        printFileHead(out, totalKeysCnt.get(), totalSkippedCnt.get());
+                        printFileHead(out, totalInconsistentKeys.get(), totalSkippedCnt.get());
 
                         for (Map.Entry<String, String> e : tmpFiles.entrySet()) {
                             out.println(e.getKey());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
@@ -573,7 +573,7 @@ public interface ReconciliationResultCollector {
                 if (c != null)
                     meta = c.remove(partId);
 
-                if  (!F.isEmpty(meta)) {
+                if (!F.isEmpty(meta)) {
                     totalInconsistentKeys.addAndGet(meta.size());
 
                     inconsistentKeysPerCache.merge(cacheName, (long) meta.size(), Long::sum);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/CollectPartitionKeysByBatchTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/CollectPartitionKeysByBatchTask.java
@@ -129,7 +129,7 @@ public class CollectPartitionKeysByBatchTask extends ComputeTaskAdapter<Partitio
             if (nodeRes.errorMessage() != null)
                 return new ExecutionResult<>(nodeRes.errorMessage());
 
-            // This variable is used to store the last key observed key for results.get(i).getNode().
+            // This variable is used to store the last observed key for results.get(i).getNode().
             KeyCacheObject lastNodeKey = null;
             for (VersionedKey partKeyVer : nodeRes.result()) {
                 try {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/diagnostic/ReconciliationExecutionContext.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/diagnostic/ReconciliationExecutionContext.java
@@ -230,8 +230,7 @@ public class ReconciliationExecutionContext {
             this.listener = listener;
         }
 
-        @Override
-        public void updateScannedPartition(long sesId, String cacheName, int partId, boolean primary, long keysCnt) {
+        @Override public void updateScannedPartition(long sesId, String cacheName, int partId, boolean primary, long keysCnt) {
             // Just ignore invalid session updates.
             if (sesId == this.sesId)
                 listener.updateScannedPartition(sesId, cacheName, partId, primary, keysCnt);

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/checker/VisorPartitionReconciliationTaskArg.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/checker/VisorPartitionReconciliationTaskArg.java
@@ -358,7 +358,6 @@ public class VisorPartitionReconciliationTaskArg extends IgniteDataTransferObjec
             partsToRepair = cpFrom.partsToRepair;
             parallelism = cpFrom.parallelism;
             batchSize = cpFrom.batchSize;
-            recheckAttempts = cpFrom.batchSize;
             recheckAttempts = cpFrom.recheckAttempts;
             recheckDelay = cpFrom.recheckDelay;
             repairAlg = cpFrom.repairAlg;


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-38941

The proposed changes:
 - when the tool starts its execution on the locale node it prints the `start execution message`:
```
Partition reconciliation has started 
    [sesionId=123, repair=false, repairAlgorithm=PRINT_ONLY, fastCheck=false, batchSize=1000, recheckAttempts=1, parallelismLevel=8, caches=[cacheA, cacheB]]
```
 - progress message that is printed one time in a minute:
```
Partition reconciliation status [
    sesId=123,       // session identifier
    caches=2,        // total number of caches to be scanned, this number may be less than the number of caches requested
                     // by the tool due to the fact that some caches might be skipped because of the expiration policy or
                     // the node does not own primary partitions of the cache
    parts= 12345     // total number of primary partitions to be scanned    
    conflicts=12     // total number of conflicts found
    repaired=0       // total number of fixed conflicts
    caches=[
        name=cacheA, primaryParts=7123, processedPrimaryKeys=12345, currPrimaryKeysSize=30000, processedBackupKeys=23456, currBackupKeysSize=15000, conflicts=5, repaired=0, completed=false]
        name=cacheB, primaryParts=5222, processedPrimaryKeys=12345, currPrimaryKeysSize=30000, processedBackupKeys=23456, currBackupKeysSize=15000, conflicts=7, repaired=0, completed=false]
    ]
```
where
    `primaryParts` - number of primary partitions owned by this node
    `processedPrimaryKeys` - number of primary keys scanned [owned by this node]
    `currPrimaryKeysSize` - total number of primary keys [owned by this node]
    `processedBackupKeys` - number of backup keys scanned [owned by this node]
    `currBackupKeysSize` - total number of backup keys [owned by this node]
    `conflicts` - number of conflicts found for the cache
    `repaired` - number of fixed conflicts for the cache
    `completed` - true if primary partitions are fully scanned
 - when the tool finished on the locale node it prints the `stop execution message`:
```
Partition reconciliation has finished locally [sessionId=123, conflicts=15, repaired=0, totalTime=123(sec)]
```

Also, the `RECONCILIATION_WORK_PROGRESS_PRINT_INTERVAL_SEC` default value changed to 1 min instead of 3.