### PR TITLE
GG-38496 Externally configure logging for control utility

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/CommandHandler.java
@@ -147,7 +147,7 @@ public class CommandHandler {
      * @return prepared JULs logger.
      */
     private Logger setupJavaLogger() {
-        if(!JavaLogger.isConfigured()) {
+        if (!JavaLogger.isConfigured()) {
             Logger result = initLogger(CommandHandler.class.getName() + "Log");
 
             // Adding logging to file.

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerLoggingTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerLoggingTest.java
@@ -24,6 +24,8 @@ import java.util.logging.Handler;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
 import java.util.logging.StreamHandler;
+import org.apache.ignite.testframework.junits.WithSystemProperty;
+import org.junit.After;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -35,13 +37,16 @@ import static org.junit.Assert.assertTrue;
 public class CommandHandlerLoggingTest {
 
     private static final String DEFAULT_LOGGER_NAME = "org.apache.ignite.internal.commandline.CommandHandlerLog";
+
     private static final String CUSTOM_LOGGER_NAME = "org.apache.ignite.internal.commandline.CommandHandler";
+
     private static final String ROOT_LOGGER_NAME = "";
 
     /**
      * Verifies that custom logging configuration is provided and is not overriden.
      */
     @Test
+    @WithSystemProperty(key = "java.util.logging.config.file", value = "control-utility-logging.properties")
     public void testExternalConfigIsNotOverridden() {
         String resourceName = "control-utility-logging.properties";
         String resourcePath = getClass().getClassLoader().getResource(resourceName).getPath();
@@ -61,8 +66,6 @@ public class CommandHandlerLoggingTest {
         Logger rootLogger = LogManager.getLogManager().getLogger(ROOT_LOGGER_NAME);
         assertEquals(1, rootLogger.getHandlers().length);
         assertEquals(FileHandler.class, rootLogger.getHandlers()[0].getClass());
-
-        System.clearProperty("java.util.logging.config.file");
     }
 
     /**
@@ -77,7 +80,7 @@ public class CommandHandlerLoggingTest {
 
         Logger logger = LogManager.getLogManager().getLogger(DEFAULT_LOGGER_NAME);
 
-        Handler[] handlers =  logger.getHandlers();
+        Handler[] handlers = logger.getHandlers();
 
         FileHandler fileHandler = Arrays.stream(handlers)
             .filter(h -> h instanceof FileHandler)
@@ -90,5 +93,10 @@ public class CommandHandlerLoggingTest {
             .map(h -> (StreamHandler) h)
             .findFirst()
             .orElseThrow(() -> new AssertionError("StreamHandler not found"));
+    }
+
+    @After
+    public void tearDown() {
+        System.clearProperty("java.util.logging.config.file");
     }
 }

--- a/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerLoggingTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/internal/commandline/CommandHandlerLoggingTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2024 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.commandline;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests Command Handler logging configuration.
+ */
+public class CommandHandlerLoggingTest {
+
+    private static final String DEFAULT_LOGGER_NAME = "org.apache.ignite.internal.commandline.CommandHandlerLog";
+    private static final String CUSTOM_LOGGER_NAME = "org.apache.ignite.internal.commandline.CommandHandler";
+    private static final String ROOT_LOGGER_NAME = "";
+
+    /**
+     * Verifies that custom logging configuration is provided and is not overriden.
+     */
+    @Test
+    public void testExternalConfigIsNotOverridden() {
+        String resourceName = "control-utility-logging.properties";
+        String resourcePath = getClass().getClassLoader().getResource(resourceName).getPath();
+
+        System.setProperty("java.util.logging.config.file", resourcePath);
+
+        CommandHandler cmd = new CommandHandler();
+
+        ArrayList<String> loggers = Collections.list(LogManager.getLogManager().getLoggerNames());
+        assertTrue(loggers.contains(CUSTOM_LOGGER_NAME));
+
+        // check that custom logger has no handlers
+        Logger customLogger = LogManager.getLogManager().getLogger(CUSTOM_LOGGER_NAME);
+        assertEquals(0, customLogger.getHandlers().length);
+
+        // check that root logger has exactly one file handler
+        Logger rootLogger = LogManager.getLogManager().getLogger(ROOT_LOGGER_NAME);
+        assertEquals(1, rootLogger.getHandlers().length);
+        assertEquals(FileHandler.class, rootLogger.getHandlers()[0].getClass());
+
+        System.clearProperty("java.util.logging.config.file");
+    }
+
+    /**
+     * Verifies default logging configuration.
+     */
+    @Test
+    public void testLoggingDefaultConfig() {
+        new CommandHandler();
+
+        ArrayList<String> loggers = Collections.list(LogManager.getLogManager().getLoggerNames());
+        assertTrue(loggers.contains(DEFAULT_LOGGER_NAME));
+
+        Logger logger = LogManager.getLogManager().getLogger(DEFAULT_LOGGER_NAME);
+
+        Handler[] handlers =  logger.getHandlers();
+
+        FileHandler fileHandler = Arrays.stream(handlers)
+            .filter(h -> h instanceof FileHandler)
+            .map(h -> (FileHandler) h)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("FileHandler not found"));
+
+        StreamHandler consoleHandler = Arrays.stream(handlers)
+            .filter(h -> h instanceof StreamHandler)
+            .map(h -> (StreamHandler) h)
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("StreamHandler not found"));
+    }
+}

--- a/modules/control-utility/src/test/resources/control-utility-logging.properties
+++ b/modules/control-utility/src/test/resources/control-utility-logging.properties
@@ -1,0 +1,3 @@
+.handlers=java.util.logging.FileHandler
+
+java.util.logging.FileHandler.pattern=control-utility-test-%g.log

--- a/modules/control-utility/src/test/resources/control-utility-logging.properties
+++ b/modules/control-utility/src/test/resources/control-utility-logging.properties
@@ -1,3 +1,19 @@
+#
+# Copyright 2019 GridGain Systems, Inc. and Contributors.
+#
+# Licensed under the GridGain Community Edition License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 .handlers=java.util.logging.FileHandler
 
 java.util.logging.FileHandler.pattern=control-utility-test-%g.log


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-38496

Added a possibility to use custom logging properties file by providing JVM options:

CONTROL_JVM_OPTS=-Djava.util.logging.config.file=<PATH_TO_CONFIG> ./control.sh