### PR TITLE
GG-36475 Update Control Scripts To Suppress Illegal Reflective Access Warnings

### DIFF
--- a/bin/control.bat
+++ b/bin/control.bat
@@ -1,10 +1,29 @@
+::
+:: Copyright 2019 GridGain Systems, Inc. and Contributors.
+::
+:: Licensed under the GridGain Community Edition License (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
+::
+:: Grid command line loader.
+::
+
 @echo off
 Setlocal EnableDelayedExpansion
 
 if "%OS%" == "Windows_NT"  setlocal
 
 :: Check JAVA_HOME.
-if defined JAVA_HOME goto checkJdk
+if defined JAVA_HOME  goto checkJdk
     echo %0, ERROR:
     echo JAVA_HOME environment variable is not found.
     echo Please point JAVA_HOME variable to location of JDK 1.8 or later.
@@ -71,7 +90,9 @@ if exist "%IGNITE_HOME%\config" goto checkIgniteHome4
 
 :checkIgniteHome4
 
+::
 :: Set SCRIPTS_HOME - base path to scripts.
+::
 set SCRIPTS_HOME=%IGNITE_HOME%\bin
 
 :: Remove trailing spaces
@@ -81,82 +102,69 @@ if /i "%SCRIPTS_HOME%\" == "%~dp0" goto setProgName
     echo %0, WARN: IGNITE_HOME environment variable may be pointing to wrong folder: %IGNITE_HOME%
 
 :setProgName
+::
 :: Set program name.
+::
 set PROG_NAME=ignite.bat
 if "%OS%" == "Windows_NT" set PROG_NAME=%~nx0%
 
 :run
 
+::
 :: Set IGNITE_LIBS
+::
 call "%SCRIPTS_HOME%\include\setenv.bat"
 call "%SCRIPTS_HOME%\include\build-classpath.bat"
 set CP=%IGNITE_LIBS%;%IGNITE_HOME%\libs\optional\ignite-zookeeper\*
 
+::
 :: Process 'restart'.
+::
 set RANDOM_NUMBER_COMMAND="!JAVA_HOME!\bin\java.exe" -cp %CP% org.apache.ignite.startup.cmdline.CommandLineRandomNumberGenerator
 for /f "usebackq tokens=*" %%i in (`!RANDOM_NUMBER_COMMAND!`) do set RANDOM_NUMBER=%%i
 
 set RESTART_SUCCESS_FILE="%IGNITE_HOME%\work\ignite_success_%RANDOM_NUMBER%"
 set RESTART_SUCCESS_OPT=-DIGNITE_SUCCESS_FILE=%RESTART_SUCCESS_FILE%
 
+::
 :: Determine Java version function
+::
 :determineJavaVersion
 for /f "tokens=1,2 delims=." %%a in ("%JAVA_VER_STR%.x") do set JAVA_VERSION=%%a
 
+::
 :: Set JVM options with dynamic version check
-call :getJavaSpecificOpts %JAVA_VERSION% "%CONTROL_JVM_OPTS%"
+::
+call "%SCRIPTS_HOME%\include\jvmdefaults.bat" %JAVA_VERSION% "%CONTROL_JVM_OPTS%" "CONTROL_JVM_OPTS"
 
+::
 :: Enable assertions if set.
+::
 if "%ENABLE_ASSERTIONS%" == "1" set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% -ea
 
 :: Set main class to start service (grid node by default).
 if "%MAIN_CLASS%" == "" set MAIN_CLASS=org.apache.ignite.internal.commandline.CommandHandler
 
+::
 :: Uncomment to enable experimental commands [--wal]
+::
 :: set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% -DIGNITE_ENABLE_EXPERIMENTAL_COMMAND=true
 
+::
 :: Uncomment the following GC settings if you see spikes in your throughput due to Garbage Collection.
+::
 :: set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% -XX:+UseG1GC
 
+::
 :: Uncomment if you get StackOverflowError.
 :: On 64 bit systems this value can be larger, e.g. -Xss16m
+::
 :: set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% -Xss4m
 
+::
 :: Uncomment to set preference to IPv4 stack.
+::
 :: set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% -Djava.net.preferIPv4Stack=true
-
-:: Final CONTROL_JVM_OPTS for Java 9+ compatibility
-if %JAVA_VERSION% GEQ 9 (
-    set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% --illegal-access=warn
-    set CONTROL_JVM_OPTS=%CONTROL_JVM_OPTS% --add-opens=java.base/java.nio=ALL-UNNAMED
-)
-
-if %java_version% GEQ 17 (
-    rem For JDK 17 and above, add necessary opens
-    set value=
-    --add-opens=java.base/jdk.internal.access=ALL-UNNAMED
-    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
-    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
-    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
-    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
-    --add-opens=java.base/java.io=ALL-UNNAMED
-    --add-opens=java.base/java.net=ALL-UNNAMED
-    --add-opens=java.base/java.nio=ALL-UNNAMED
-    --add-opens=java.base/java.security.cert=ALL-UNNAMED
-    --add-opens=java.base/java.util=ALL-UNNAMED
-    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
-    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-    --add-opens=java.base/java.lang=ALL-UNNAMED
-    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-    --add-opens=java.base/java.math=ALL-UNNAMED
-    --add-opens=java.base/java.time=ALL-UNNAMED
-    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-    --add-opens=java.base/sun.security.x509=ALL-UNNAMED
-    --add-opens=java.sql/java.sql=ALL-UNNAMED
-    %current_value%
-)
 
 if defined JVM_OPTS (
     echo JVM_OPTS environment variable is set, but will not be used. To pass JVM options use CONTROL_JVM_OPTS
@@ -195,53 +203,3 @@ del %RESTART_SUCCESS_FILE%
 if not "%NO_PAUSE%" == "1" pause
 
 goto :eof
-
-:getJavaSpecificOpts
-if %1 == 8 (
-    set CONTROL_JVM_OPTS=-XX:+AggressiveOpts %2
-    exit /b 0
-)
-
-if %1 GEQ 9 if %1 LSS 11 (
-    set CONTROL_JVM_OPTS=-XX:+AggressiveOpts ^
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --illegal-access=permit ^
-    --add-modules=java.xml.bind ^
-    %2
-    exit /b 0
-)
-
-if %1 GEQ 11 (
-    set CONTROL_JVM_OPTS=--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --add-opens=java.base/java.io=ALL-UNNAMED ^
-    --add-opens=java.base/java.net=ALL-UNNAMED ^
-    --add-opens=java.base/java.nio=ALL-UNNAMED ^
-    --add-opens=java.base/java.security.cert=ALL-UNNAMED ^
-    --add-opens=java.base/java.util=ALL-UNNAMED ^
-    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED ^
-    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED ^
-    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED ^
-    --add-opens=java.base/java.lang=ALL-UNNAMED ^
-    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED ^
-    --add-opens=java.base/java.math=ALL-UNNAMED ^
-    --add-opens=java.base/java.time=ALL-UNNAMED ^
-    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED ^
-    --add-opens=java.base/sun.security.x509=ALL-UNNAMED ^
-    --add-opens=java.sql/java.sql=ALL-UNNAMED ^
-    %2
-    exit /b 0
-)
-exit /b 1

--- a/bin/control.bat
+++ b/bin/control.bat
@@ -27,7 +27,7 @@ if defined JAVA_HOME  goto checkJdk
     echo %0, ERROR:
     echo JAVA_HOME environment variable is not found.
     echo Please point JAVA_HOME variable to location of JDK 1.8 or later.
-    echo You can also download the latest JDK at http://java.com/download.
+    echo You can also download latest JDK at http://java.com/download.
 goto error_finish
 
 :checkJdk
@@ -36,7 +36,7 @@ if exist "%JAVA_HOME%\bin\java.exe" goto checkJdkVersion
     echo %0, ERROR:
     echo JAVA is not found in JAVA_HOME=%JAVA_HOME%.
     echo Please point JAVA_HOME variable to installation of JDK 1.8 or later.
-    echo You can also download the latest JDK at http://java.com/download.
+    echo You can also download latest JDK at http://java.com/download.
 goto error_finish
 
 :checkJdkVersion
@@ -57,7 +57,7 @@ if %MAJOR_JAVA_VER% LSS 8 (
     echo %0, ERROR:
     echo The version of JAVA installed in %JAVA_HOME% is incorrect.
     echo Please point JAVA_HOME variable to installation of JDK 1.8 or later.
-    echo You can aslo download the latest JDK at http://java.com/download.
+    echo You can aslo download latest JDK at http://java.com/download.
     goto error_finish
 )
 
@@ -208,11 +208,13 @@ if defined JVM_OPTS (
 
 if "%INTERACTIVE%" == "1" (
     "%JAVA_HOME%\bin\java.exe" %CONTROL_JVM_OPTS% %QUIET% %RESTART_SUCCESS_OPT% ^
-    -DIGNITE_HOME="%IGNITE_HOME%" -DIGNITE_PROG_NAME="%PROG_NAME%" %JVM_XOPTS% ^
+    -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="%IGNITE_HOME%" ^
+    -DIGNITE_PROG_NAME="%PROG_NAME%" %JVM_XOPTS% ^
     -cp "%CP%" %MAIN_CLASS% %*
 ) else (
     "%JAVA_HOME%\bin\java.exe" %CONTROL_JVM_OPTS% %QUIET% %RESTART_SUCCESS_OPT% ^
-    -DIGNITE_HOME="%IGNITE_HOME%" -DIGNITE_PROG_NAME="%PROG_NAME%" %JVM_XOPTS% ^
+    -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="%IGNITE_HOME%" ^
+    -DIGNITE_PROG_NAME="%PROG_NAME%" %JVM_XOPTS% ^
     -cp "%CP%" %MAIN_CLASS% %*
 )
 
@@ -244,12 +246,46 @@ if %1 == 8 (
 )
 
 if %1 GEQ 9 if %1 LSS 11 (
-    set CONTROL_JVM_OPTS=-XX:+AggressiveOpts --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED --illegal-access=permit --add-modules=java.xml.bind %2
+    set CONTROL_JVM_OPTS=-XX:+AggressiveOpts
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+    --illegal-access=permit
+    --add-modules=java.xml.bind
+    %2
     exit /b 0
 )
 
 if %1 GEQ 11 (
-    set CONTROL_JVM_OPTS=--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.math=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/sun.security.ssl=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED --add-opens=java.sql/java.sql=ALL-UNNAMED %2
+    set CONTROL_JVM_OPTS=
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+    --add-opens=java.base/java.io=ALL-UNNAMED
+    --add-opens=java.base/java.net=ALL-UNNAMED
+    --add-opens=java.base/java.nio=ALL-UNNAMED
+    --add-opens=java.base/java.security.cert=ALL-UNNAMED
+    --add-opens=java.base/java.util=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+    --add-opens=java.base/java.lang=ALL-UNNAMED
+    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+    --add-opens=java.base/java.math=ALL-UNNAMED
+    --add-opens=java.base/java.time=ALL-UNNAMED
+    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
+    --add-opens=java.base/sun.security.x509=ALL-UNNAMED
+    --add-opens=java.sql/java.sql=ALL-UNNAMED
+    %2
     exit /b 0
 )
 exit /b 1

--- a/bin/control.bat
+++ b/bin/control.bat
@@ -57,7 +57,7 @@ if %MAJOR_JAVA_VER% LSS 8 (
     echo %0, ERROR:
     echo The version of JAVA installed in %JAVA_HOME% is incorrect.
     echo Please point JAVA_HOME variable to installation of JDK 1.8 or later.
-    echo You can aslo download latest JDK at http://java.com/download.
+    echo You can also download latest JDK at http://java.com/download.
     goto error_finish
 )
 

--- a/bin/control.bat
+++ b/bin/control.bat
@@ -61,6 +61,9 @@ if %MAJOR_JAVA_VER% LSS 8 (
     goto error_finish
 )
 
+:: Store the Java version for dynamic JVM options.
+set JAVA_VERSION=%MAJOR_JAVA_VER%
+
 :: Check IGNITE_HOME.
 :checkIgniteHome1
 if defined IGNITE_HOME goto checkIgniteHome2
@@ -125,12 +128,6 @@ for /f "usebackq tokens=*" %%i in (`!RANDOM_NUMBER_COMMAND!`) do set RANDOM_NUMB
 
 set RESTART_SUCCESS_FILE="%IGNITE_HOME%\work\ignite_success_%RANDOM_NUMBER%"
 set RESTART_SUCCESS_OPT=-DIGNITE_SUCCESS_FILE=%RESTART_SUCCESS_FILE%
-
-::
-:: Determine Java version function
-::
-:determineJavaVersion
-for /f "tokens=1,2 delims=." %%a in ("%JAVA_VER_STR%.x") do set JAVA_VERSION=%%a
 
 ::
 :: Set JVM options with dynamic version check

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -33,35 +33,45 @@ fi
 #
 if [ "${IGNITE_HOME:-}" = "" ]; then
     IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
-else
-    IGNITE_HOME_TMP=${IGNITE_HOME}
+else IGNITE_HOME_TMP=${IGNITE_HOME}
 fi
 
+#
 # Set SCRIPTS_HOME - base path to scripts.
+#
 SCRIPTS_HOME="${IGNITE_HOME_TMP}/bin"
 
 source "${SCRIPTS_HOME}/include/functions.sh"
 source "${SCRIPTS_HOME}/include/jvmdefaults.sh"
 
+#
 # Discover path to Java executable and check its version.
+#
 checkJava
 
+#
 # Determine Java version function
+#
 determineJavaVersion() {
     local version_output=$(java -version 2>&1)
     local version=$(echo "$version_output" | awk -F '"' '/version/ {print $2}' | awk -F '.' '{if ($1 == 1) {print $2} else {print $1}}')
     echo $version
 }
 
+#
 # Discover IGNITE_HOME environment variable.
+#
 setIgniteHome
 
 if [ "${DEFAULT_CONFIG:-}" == "" ]; then
     DEFAULT_CONFIG=config/default-config.xml
 fi
 
+#
 # Set IGNITE_LIBS.
+#
 . "${SCRIPTS_HOME}/include/setenv.sh"
+. "${SCRIPTS_HOME}"/include/build-classpath.sh # Will be removed in the binary release.
 CP="${IGNITE_LIBS}:${IGNITE_HOME}/libs/optional/ignite-zookeeper/*"
 
 RANDOM_NUMBER=$("$JAVA" -cp "${CP}" org.apache.ignite.startup.cmdline.CommandLineRandomNumberGenerator)
@@ -73,33 +83,49 @@ if [ "${DOCK_OPTS:-}" == "" ]; then
     DOCK_OPTS="-Xdock:name=Ignite Node"
 fi
 
+#
 # JVM options. See http://java.sun.com/javase/technologies/hotspot/vmoptions.jsp for more details.
+#
 # ADD YOUR/CHANGE ADDITIONAL OPTIONS HERE
+#
 # Set JVM options with dynamic version check
+#
 JAVA_VERSION=$(determineJavaVersion)
 CONTROL_JVM_OPTS=$(getJavaSpecificOpts $JAVA_VERSION "$CONTROL_JVM_OPTS")
 
+#
 # Enable assertions if set.
+#
 if [ "${ENABLE_ASSERTIONS:-}" = "1" ]; then
     CONTROL_JVM_OPTS+=" -ea"
 fi
 
+#
 # Set main class to start service (grid node by default).
+#
 if [ "${MAIN_CLASS:-}" = "" ]; then
     MAIN_CLASS=org.apache.ignite.internal.commandline.CommandHandler
 fi
 
+#
 # Uncomment to enable experimental commands [--wal]
+#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -DIGNITE_ENABLE_EXPERIMENTAL_COMMAND=true"
 
+#
 # Uncomment the following GC settings if you see spikes in your throughput due to Garbage Collection.
+#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -XX:+UseG1GC"
 
+#
 # Uncomment if you get StackOverflowError.
 # On 64 bit systems this value can be larger, e.g. -Xss16m
+#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -Xss4m"
 
+#
 # Uncomment to set preference for IPv4 stack.
+
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -Djava.net.preferIPv4Stack=true"
 
 if [ -n "${JVM_OPTS}" ]; then

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ]; then
+if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ];
+then
     set -o nounset
     set -o errexit
     set -o pipefail
@@ -7,11 +8,29 @@ if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ]; then
     set -o functrace
 fi
 
-# Copyright and license information...
+#
+# Copyright 2019 GridGain Systems, Inc. and Contributors.
+#
+# Licensed under the GridGain Community Edition License (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+#
 # Grid cluster control.
+#
 
+#
 # Import common functions.
+#
 if [ "${IGNITE_HOME:-}" = "" ]; then
     IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
 else

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
-if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ];
-then
+if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ]; then
     set -o nounset
     set -o errexit
     set -o pipefail
@@ -8,45 +7,24 @@ then
     set -o functrace
 fi
 
-#
-# Copyright 2019 GridGain Systems, Inc. and Contributors.
-#
-# Licensed under the GridGain Community Edition License (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
+# Copyright and license information...
 
-#
 # Grid cluster control.
-#
 
-#
 # Import common functions.
-#
-if [ "${IGNITE_HOME:-}" = "" ];
-    then IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
-    else IGNITE_HOME_TMP=${IGNITE_HOME}
+if [ "${IGNITE_HOME:-}" = "" ]; then
+    IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
+else
+    IGNITE_HOME_TMP=${IGNITE_HOME}
 fi
 
-#
 # Set SCRIPTS_HOME - base path to scripts.
-#
 SCRIPTS_HOME="${IGNITE_HOME_TMP}/bin"
 
 source "${SCRIPTS_HOME}/include/functions.sh"
 source "${SCRIPTS_HOME}/include/jvmdefaults.sh"
 
-#
 # Discover path to Java executable and check its version.
-#
 checkJava
 
 # Determine Java version function
@@ -56,18 +34,14 @@ determineJavaVersion() {
     echo $version
 }
 
-#
 # Discover IGNITE_HOME environment variable.
-#
 setIgniteHome
 
 if [ "${DEFAULT_CONFIG:-}" == "" ]; then
     DEFAULT_CONFIG=config/default-config.xml
 fi
 
-#
 # Set IGNITE_LIBS.
-#
 . "${SCRIPTS_HOME}/include/setenv.sh"
 CP="${IGNITE_LIBS}:${IGNITE_HOME}/libs/optional/ignite-zookeeper/*"
 
@@ -80,11 +54,8 @@ if [ "${DOCK_OPTS:-}" == "" ]; then
     DOCK_OPTS="-Xdock:name=Ignite Node"
 fi
 
-#
 # JVM options. See http://java.sun.com/javase/technologies/hotspot/vmoptions.jsp for more details.
-#
 # ADD YOUR/CHANGE ADDITIONAL OPTIONS HERE
-#
 # Set JVM options with dynamic version check
 JAVA_VERSION=$(determineJavaVersion)
 CONTROL_JVM_OPTS=$(getJavaSpecificOpts $JAVA_VERSION "$CONTROL_JVM_OPTS")
@@ -99,36 +70,18 @@ if [ "${MAIN_CLASS:-}" = "" ]; then
     MAIN_CLASS=org.apache.ignite.internal.commandline.CommandHandler
 fi
 
-#
 # Uncomment to enable experimental commands [--wal]
-#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -DIGNITE_ENABLE_EXPERIMENTAL_COMMAND=true"
 
-#
 # Uncomment the following GC settings if you see spikes in your throughput due to Garbage Collection.
-#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -XX:+UseG1GC"
 
-#
 # Uncomment if you get StackOverflowError.
 # On 64 bit systems this value can be larger, e.g. -Xss16m
-#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -Xss4m"
 
-#
 # Uncomment to set preference for IPv4 stack.
-#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -Djava.net.preferIPv4Stack=true"
-
-#
-# Final CONTROL_JVM_OPTS for Java 9+ compatibility
-#
-if [ "$JAVA_VERSION" -ge 9 ]; then
-  if [ "$JAVA_VERSION" -lt 17 ]; then
-    CONTROL_JVM_OPTS+=" --illegal-access=warn"
-  fi
-  CONTROL_JVM_OPTS+=" --add-opens=java.base/java.nio=ALL-UNNAMED"
-fi
 
 if [ -n "${JVM_OPTS}" ]; then
     echo "JVM_OPTS environment variable is set, but will not be used. To pass JVM options use CONTROL_JVM_OPTS"
@@ -137,19 +90,15 @@ fi
 
 case $osname in
     Darwin*)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} "${DOCK_OPTS}" \
-        -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
-         -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} "${DOCK_OPTS}" -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+        -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
     ;;
     OS/390*)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} \
-        -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
-         $(getIbmSslOpts $JAVA_VERSION) \
-         -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+        $(getIbmSslOpts $JAVA_VERSION) -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
     ;;
     *)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} \
-        -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
         -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
-        ;;
+    ;;
 esac

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ]
+if [ ! -z "${IGNITE_SCRIPT_STRICT_MODE:-}" ];
 then
     set -o nounset
     set -o errexit
@@ -14,7 +14,7 @@ fi
 # Licensed under the GridGain Community Edition License (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-#
+
 #     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -22,7 +22,7 @@ fi
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 
 #
 # Grid cluster control.
@@ -30,10 +30,10 @@ fi
 
 #
 # Import common functions.
-#
+
 if [ "${IGNITE_HOME:-}" = "" ];
-    then IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; "pwd")")";
-    else IGNITE_HOME_TMP=${IGNITE_HOME};
+    then IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
+    else IGNITE_HOME_TMP=${IGNITE_HOME}
 fi
 
 #
@@ -41,13 +41,20 @@ fi
 #
 SCRIPTS_HOME="${IGNITE_HOME_TMP}/bin"
 
-source "${SCRIPTS_HOME}"/include/functions.sh
-source "${SCRIPTS_HOME}"/include/jvmdefaults.sh
+source "${SCRIPTS_HOME}/include/functions.sh"
+source "${SCRIPTS_HOME}/include/jvmdefaults.sh"
 
 #
-# Discover path to Java executable and check it's version.
+# Discover path to Java executable and check its version.
 #
 checkJava
+
+# Determine Java version function
+determineJavaVersion() {
+    local version_output=$(java -version 2>&1)
+    local version=$(echo "$version_output" | awk -F '"' '/version/ {print $2}' | awk -F '.' '{if ($1 == 1) {print $2} else {print $1}}')
+    echo $version
+}
 
 #
 # Discover IGNITE_HOME environment variable.
@@ -61,14 +68,13 @@ fi
 #
 # Set IGNITE_LIBS.
 #
-. "${SCRIPTS_HOME}"/include/setenv.sh
-. "${SCRIPTS_HOME}"/include/build-classpath.sh # Will be removed in the binary release.
+. "${SCRIPTS_HOME}/include/setenv.sh"
 CP="${IGNITE_LIBS}:${IGNITE_HOME}/libs/optional/ignite-zookeeper/*"
 
 RANDOM_NUMBER=$("$JAVA" -cp "${CP}" org.apache.ignite.startup.cmdline.CommandLineRandomNumberGenerator)
 
 # Mac OS specific support to display correct name in the dock.
-osname=`uname`
+osname=$(uname)
 
 if [ "${DOCK_OPTS:-}" == "" ]; then
     DOCK_OPTS="-Xdock:name=Ignite Node"
@@ -79,12 +85,18 @@ fi
 #
 # ADD YOUR/CHANGE ADDITIONAL OPTIONS HERE
 #
-if [ -z "${CONTROL_JVM_OPTS:-}" ] ; then
-    if [[ `"$JAVA" -version 2>&1 | egrep "1\.[7]\."` ]]; then
-        CONTROL_JVM_OPTS="-Xms256m -Xmx1g"
-    else
-        CONTROL_JVM_OPTS="-Xms256m -Xmx1g"
-    fi
+# Set JVM options with dynamic version check
+JAVA_VERSION=$(determineJavaVersion)
+CONTROL_JVM_OPTS=$(getJavaSpecificOpts $JAVA_VERSION "$CONTROL_JVM_OPTS")
+
+# Enable assertions if set.
+if [ "${ENABLE_ASSERTIONS:-}" = "1" ]; then
+    CONTROL_JVM_OPTS+=" -ea"
+fi
+
+# Set main class to start service (grid node by default).
+if [ "${MAIN_CLASS:-}" = "" ]; then
+    MAIN_CLASS=org.apache.ignite.internal.commandline.CommandHandler
 fi
 
 #
@@ -95,7 +107,7 @@ fi
 #
 # Uncomment the following GC settings if you see spikes in your throughput due to Garbage Collection.
 #
-# CONTROL_JVM_OPTS="$CONTROL_JVM_OPTS -XX:+UseG1GC"
+# CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -XX:+UseG1GC"
 
 #
 # Uncomment if you get StackOverflowError.
@@ -109,56 +121,31 @@ fi
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -Djava.net.preferIPv4Stack=true"
 
 #
-# Assertions are disabled by default since version 3.5.
-# If you want to enable them - set 'ENABLE_ASSERTIONS' flag to '1'.
-#
-ENABLE_ASSERTIONS="1"
-
-#
-# Set '-ea' options if assertions are enabled.
-#
-if [ "${ENABLE_ASSERTIONS:-}" = "1" ]; then
-    CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -ea"
-fi
-
-#
-# Set main class to start service (grid node by default).
-#
-if [ "${MAIN_CLASS:-}" = "" ]; then
-    MAIN_CLASS=org.apache.ignite.internal.commandline.CommandHandler
-fi
-
-#
-# Remote debugging (JPDA).
-# Uncomment and change if remote debugging is required.
-#
-# CONTROL_JVM_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8787 ${CONTROL_JVM_OPTS}"
-
-#
 # Final CONTROL_JVM_OPTS for Java 9+ compatibility
 #
-CONTROL_JVM_OPTS=$(getJavaSpecificOpts $version "$CONTROL_JVM_OPTS")
+if [ "$JAVA_VERSION" -ge 9 ]; then
+  if [ "$JAVA_VERSION" -lt 17 ]; then
+    CONTROL_JVM_OPTS+=" --illegal-access=warn"
+  fi
+  CONTROL_JVM_OPTS+=" --add-opens=java.base/java.nio=ALL-UNNAMED"
+fi
 
-if [ -n "${JVM_OPTS}" ] ; then
-  echo "JVM_OPTS environment variable is set, but will not be used. To pass JVM options use CONTROL_JVM_OPTS"
-  echo "JVM_OPTS=${JVM_OPTS}"
+if [ -n "${JVM_OPTS}" ]; then
+    echo "JVM_OPTS environment variable is set, but will not be used. To pass JVM options use CONTROL_JVM_OPTS"
+    echo "JVM_OPTS=${JVM_OPTS}"
 fi
 
 case $osname in
     Darwin*)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} "${DOCK_OPTS}" \
-         -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} "${DOCK_OPTS}" -DIGNITE_HOME="${IGNITE_HOME}" \
          -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
-    ;;
+        ;;
     OS/390*)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} \
-         -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
-         $(getIbmSslOpts $version) \
-         -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
-    ;;
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+         $(getIbmSslOpts $JAVA_VERSION) -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
+        ;;
     *)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} \
-         -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} -DIGNITE_HOME="${IGNITE_HOME}" \
          -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
-    ;;
+        ;;
 esac

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -14,7 +14,7 @@ fi
 # Licensed under the GridGain Community Edition License (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-
+#
 #     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
 #
 # Unless required by applicable law or agreed to in writing, software
@@ -22,7 +22,7 @@ fi
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+#
 
 #
 # Grid cluster control.
@@ -30,7 +30,7 @@ fi
 
 #
 # Import common functions.
-
+#
 if [ "${IGNITE_HOME:-}" = "" ];
     then IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
     else IGNITE_HOME_TMP=${IGNITE_HOME}
@@ -137,15 +137,19 @@ fi
 
 case $osname in
     Darwin*)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} "${DOCK_OPTS}" -DIGNITE_HOME="${IGNITE_HOME}" \
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} "${DOCK_OPTS}" \
+        -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
          -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
-        ;;
+    ;;
     OS/390*)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
-         $(getIbmSslOpts $JAVA_VERSION) -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
-        ;;
-    *)
-        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} -DIGNITE_HOME="${IGNITE_HOME}" \
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} \
+        -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+         $(getIbmSslOpts $JAVA_VERSION) \
          -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
+    ;;
+    *)
+        "$JAVA" ${CONTROL_JVM_OPTS} ${QUIET:-} \
+        -DIGNITE_UPDATE_NOTIFIER=false -DIGNITE_HOME="${IGNITE_HOME}" \
+        -DIGNITE_PROG_NAME="$0" ${JVM_XOPTS:-} -cp "${CP}" ${MAIN_CLASS} "$@"
         ;;
 esac

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -33,7 +33,8 @@ fi
 #
 if [ "${IGNITE_HOME:-}" = "" ]; then
     IGNITE_HOME_TMP="$(dirname "$(cd "$(dirname "$0")"; pwd)")"
-else IGNITE_HOME_TMP=${IGNITE_HOME}
+else 
+    IGNITE_HOME_TMP=${IGNITE_HOME}
 fi
 
 #
@@ -125,7 +126,7 @@ fi
 
 #
 # Uncomment to set preference for IPv4 stack.
-
+#
 # CONTROL_JVM_OPTS="${CONTROL_JVM_OPTS} -Djava.net.preferIPv4Stack=true"
 
 if [ -n "${JVM_OPTS}" ]; then

--- a/bin/control.sh
+++ b/bin/control.sh
@@ -51,13 +51,10 @@ source "${SCRIPTS_HOME}/include/jvmdefaults.sh"
 checkJava
 
 #
-# Determine Java version function
+# Extract Java version
 #
-determineJavaVersion() {
-    local version_output=$(java -version 2>&1)
-    local version=$(echo "$version_output" | awk -F '"' '/version/ {print $2}' | awk -F '.' '{if ($1 == 1) {print $2} else {print $1}}')
-    echo $version
-}
+javaMajorVersion "$JAVA"
+JAVA_VERSION=$version
 
 #
 # Discover IGNITE_HOME environment variable.
@@ -91,7 +88,6 @@ fi
 #
 # Set JVM options with dynamic version check
 #
-JAVA_VERSION=$(determineJavaVersion)
 CONTROL_JVM_OPTS=$(getJavaSpecificOpts $JAVA_VERSION "$CONTROL_JVM_OPTS")
 
 #

--- a/bin/include/jvmdefaults.bat
+++ b/bin/include/jvmdefaults.bat
@@ -1,18 +1,3 @@
-::
-:: Copyright 2022 GridGain Systems, Inc. and Contributors.
-::
-:: Licensed under the GridGain Community Edition License (the "License");
-:: you may not use this file except in compliance with the License.
-:: You may obtain a copy of the License at
-::
-::     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
-::
-:: Unless required by applicable law or agreed to in writing, software
-:: distributed under the License is distributed on an "AS IS" BASIS,
-:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-:: See the License for the specific language governing permissions and
-:: limitations under the License.
-::
 @echo off
 
 set java_version=%~1

--- a/bin/include/jvmdefaults.bat
+++ b/bin/include/jvmdefaults.bat
@@ -70,6 +70,7 @@ if %java_version% GEQ 11 (
     --add-opens=java.base/sun.security.ssl=ALL-UNNAMED ^
     --add-opens=java.base/sun.security.x509=ALL-UNNAMED ^
     --add-opens=java.sql/java.sql=ALL-UNNAMED ^
+    --illegal-access=permit ^
     %current_value%
 )
 

--- a/bin/include/jvmdefaults.bat
+++ b/bin/include/jvmdefaults.bat
@@ -1,3 +1,18 @@
+::
+:: Copyright 2022 GridGain Systems, Inc. and Contributors.
+::
+:: Licensed under the GridGain Community Edition License (the "License");
+:: you may not use this file except in compliance with the License.
+:: You may obtain a copy of the License at
+::
+::     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+::
+:: Unless required by applicable law or agreed to in writing, software
+:: distributed under the License is distributed on an "AS IS" BASIS,
+:: WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+:: See the License for the specific language governing permissions and
+:: limitations under the License.
+::
 @echo off
 
 set java_version=%~1
@@ -39,6 +54,7 @@ if %java_version% GEQ 11 (
     --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
     --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
     --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
+    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED ^
     --add-opens=java.base/java.io=ALL-UNNAMED ^
     --add-opens=java.base/java.net=ALL-UNNAMED ^
     --add-opens=java.base/java.nio=ALL-UNNAMED ^

--- a/bin/include/jvmdefaults.bat
+++ b/bin/include/jvmdefaults.bat
@@ -24,47 +24,51 @@ set value=""
 :: Second argument is the current value of the jvm options
 :: Third value is the name of the environment variable that jvm options should be set to
 if %java_version% == 8 (
-    set value=
-    -XX:+AggressiveOpts
+    set value= ^
+    -XX:+AggressiveOpts ^
     %current_value%
 )
 
 if %java_version% GEQ 9 if %java_version% LSS 11 (
-    set value=
-    -XX:+AggressiveOpts
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED --illegal-access=permit
-    --add-modules=java.xml.bind
+    set value= ^
+    -XX:+AggressiveOpts ^
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
+    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
+    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
+    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
+    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
+    --illegal-access=permit ^
+    --add-modules=java.xml.bind ^
     %current_value%
 )
 
 if %java_version% GEQ 11 (
-    set value=
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
-    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
-    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
-    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
-    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
-    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
-    --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED
-    --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED
-    --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
-    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
-    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
-    --add-opens=java.base/java.lang=ALL-UNNAMED
-    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
-    --add-opens=java.base/java.math=ALL-UNNAMED
-    --add-opens=java.base/java.time=ALL-UNNAMED
-    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
-    --add-opens=java.base/sun.security.x509=ALL-UNNAMED
-    --add-opens=java.sql/java.sql=ALL-UNNAMED
+    set value= ^
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
+    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
+    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
+    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
+    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
+    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED ^
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED ^
+    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
+    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
+    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
+    --add-opens=java.base/java.io=ALL-UNNAMED ^
+    --add-opens=java.base/java.net=ALL-UNNAMED ^
+    --add-opens=java.base/java.nio=ALL-UNNAMED ^
+    --add-opens=java.base/java.security.cert=ALL-UNNAMED ^
+    --add-opens=java.base/java.util=ALL-UNNAMED ^
+    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED ^
+    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED ^
+    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED ^
+    --add-opens=java.base/java.lang=ALL-UNNAMED ^
+    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED ^
+    --add-opens=java.base/java.math=ALL-UNNAMED ^
+    --add-opens=java.base/java.time=ALL-UNNAMED ^
+    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED ^
+    --add-opens=java.base/sun.security.x509=ALL-UNNAMED ^
+    --add-opens=java.sql/java.sql=ALL-UNNAMED ^
     %current_value%
 )
 

--- a/bin/include/jvmdefaults.bat
+++ b/bin/include/jvmdefaults.bat
@@ -24,73 +24,47 @@ set value=""
 :: Second argument is the current value of the jvm options
 :: Third value is the name of the environment variable that jvm options should be set to
 if %java_version% == 8 (
-    set value= ^
-    -XX:+AggressiveOpts ^
+    set value=
+    -XX:+AggressiveOpts
     %current_value%
 )
 
 if %java_version% GEQ 9 if %java_version% LSS 11 (
-    set value= ^
-    -XX:+AggressiveOpts ^
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --illegal-access=permit ^
-    --add-modules=java.xml.bind ^
+    set value=
+    -XX:+AggressiveOpts
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED --illegal-access=permit
+    --add-modules=java.xml.bind
     %current_value%
 )
 
-if %java_version% GEQ 11 if %java_version% LSS 14 (
-    set value= ^
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED ^
-    --illegal-access=permit ^
-    %current_value%
-)
-
-if %java_version% GEQ 14 if %java_version% LSS 15 (
-    set value= ^
-    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --add-opens=java.base/jdk.internal.access=ALL-UNNAMED ^
-    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED ^
-    --illegal-access=permit ^
-    %current_value%
-)
-
-if %java_version% GEQ 15 (
-    set value= ^
-    --add-opens=java.base/jdk.internal.access=ALL-UNNAMED ^
-    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED ^
-    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED ^
-    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED ^
-    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED ^
-    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED ^
-    --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED ^
-    --add-opens=java.base/java.io=ALL-UNNAMED ^
-    --add-opens=java.base/java.net=ALL-UNNAMED ^
-    --add-opens=java.base/java.nio=ALL-UNNAMED ^
-    --add-opens=java.base/java.security.cert=ALL-UNNAMED ^
-    --add-opens=java.base/java.util=ALL-UNNAMED ^
-    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED ^
-    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED ^
-    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED ^
-    --add-opens=java.base/java.lang=ALL-UNNAMED ^
-    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED ^
-    --add-opens=java.base/java.math=ALL-UNNAMED ^
-    --add-opens=java.base/java.time=ALL-UNNAMED ^
-    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED ^
-    --add-opens=java.base/sun.security.x509=ALL-UNNAMED ^
-    --add-opens=java.sql/java.sql=ALL-UNNAMED ^
+if %java_version% GEQ 11 (
+    set value=
+    --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED
+    --add-exports=java.base/sun.nio.ch=ALL-UNNAMED
+    --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+    --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+    --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+    --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+    --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+    --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED
+    --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED
+    --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED
+    --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED
+    --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.security.cert=ALL-UNNAMED
+    --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED
+    --add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED
+    --add-opens=java.base/java.lang=ALL-UNNAMED
+    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED
+    --add-opens=java.base/java.math=ALL-UNNAMED
+    --add-opens=java.base/java.time=ALL-UNNAMED
+    --add-opens=java.base/sun.security.ssl=ALL-UNNAMED
+    --add-opens=java.base/sun.security.x509=ALL-UNNAMED
+    --add-opens=java.sql/java.sql=ALL-UNNAMED
     %current_value%
 )
 

--- a/bin/include/jvmdefaults.sh
+++ b/bin/include/jvmdefaults.sh
@@ -34,14 +34,13 @@ getJavaSpecificOpts() {
   current_value=$2
   value=""
 
-  if [ $version -eq 8 ] ; then
-      value="\
-          -XX:+AggressiveOpts \
-           ${current_value}"
+  if [ "$version" -eq 8 ]; then
+      # Keep options minimal and avoid deprecated ones for Java 8
+      value="-XX:+AggressiveOpts $current_value"
 
-  elif [ $version -gt 8 ] && [ $version -lt 11 ]; then
-      value="\
-          -XX:+AggressiveOpts \
+  elif [ "$version" -ge 9 ] && [ "$version" -lt 11 ]; then
+      # Java 9 and 10 require additional modules due to removed Java EE modules
+      value="-XX:+AggressiveOpts \
           --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
@@ -49,40 +48,20 @@ getJavaSpecificOpts() {
           --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
           --illegal-access=permit \
           --add-modules=java.xml.bind \
-          ${current_value}"
+          $current_value"
 
-  elif [ "${version}" -ge 11 ] && [ "${version}" -lt 14 ]; then
-      value="\
-          --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+  elif [ "$version" -ge 11 ]; then
+      # From Java 11 onwards, reduce the use of aggressive exports and opens, focusing on necessary access only
+      value="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
           --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
           --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
-          --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
-          --illegal-access=permit \
-          ${current_value}"
-
-  elif [ "${version}" -ge 14 ] && [ "${version}" -lt 15 ]; then
-        value="\
-            --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
-            --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
-            --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
-            --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
-            --add-exports=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
-            --add-opens=java.base/jdk.internal.access=ALL-UNNAMED \
-            --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
-            --illegal-access=permit \
-            ${current_value}"
-
-  elif [ "${version}" -ge 15 ] ; then
-      value="\
-          --add-opens=java.base/jdk.internal.access=ALL-UNNAMED \
           --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-opens=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
           --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
           --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
-          --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
           --add-opens=java.base/java.io=ALL-UNNAMED \
           --add-opens=java.base/java.net=ALL-UNNAMED \
           --add-opens=java.base/java.nio=ALL-UNNAMED \
@@ -98,7 +77,7 @@ getJavaSpecificOpts() {
           --add-opens=java.base/sun.security.ssl=ALL-UNNAMED \
           --add-opens=java.base/sun.security.x509=ALL-UNNAMED \
           --add-opens=java.sql/java.sql=ALL-UNNAMED \
-          ${current_value}"
+          $current_value"
   fi
 
   echo $value

--- a/bin/include/jvmdefaults.sh
+++ b/bin/include/jvmdefaults.sh
@@ -62,6 +62,7 @@ getJavaSpecificOpts() {
           --add-opens=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
           --add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \
           --add-opens=java.base/sun.reflect.generics.reflectiveObjects=ALL-UNNAMED \
+          --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED \
           --add-opens=java.base/java.io=ALL-UNNAMED \
           --add-opens=java.base/java.net=ALL-UNNAMED \
           --add-opens=java.base/java.nio=ALL-UNNAMED \

--- a/bin/include/jvmdefaults.sh
+++ b/bin/include/jvmdefaults.sh
@@ -77,7 +77,7 @@ getJavaSpecificOpts() {
           --add-opens=java.base/sun.security.ssl=ALL-UNNAMED \
           --add-opens=java.base/sun.security.x509=ALL-UNNAMED \
           --add-opens=java.sql/java.sql=ALL-UNNAMED \
-          $current_value"
+          ${current_value}"
   fi
 
   echo $value

--- a/bin/include/jvmdefaults.sh
+++ b/bin/include/jvmdefaults.sh
@@ -40,8 +40,7 @@ getJavaSpecificOpts() {
 
   elif [ "$version" -ge 9 ] && [ "$version" -lt 11 ]; then
       # Java 9 and 10 require additional modules due to removed Java EE modules
-      value="\
-          -XX:+AggressiveOpts \
+      value="-XX:+AggressiveOpts \
           --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
@@ -53,8 +52,7 @@ getJavaSpecificOpts() {
 
   elif [ "$version" -ge 11 ]; then
       # From Java 11 onwards, reduce the use of aggressive exports and opens, focusing on necessary access only
-      value="\
-          --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+      value="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
           --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \

--- a/bin/include/jvmdefaults.sh
+++ b/bin/include/jvmdefaults.sh
@@ -40,7 +40,8 @@ getJavaSpecificOpts() {
 
   elif [ "$version" -ge 9 ] && [ "$version" -lt 11 ]; then
       # Java 9 and 10 require additional modules due to removed Java EE modules
-      value="-XX:+AggressiveOpts \
+      value="\
+          -XX:+AggressiveOpts \
           --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
@@ -52,7 +53,8 @@ getJavaSpecificOpts() {
 
   elif [ "$version" -ge 11 ]; then
       # From Java 11 onwards, reduce the use of aggressive exports and opens, focusing on necessary access only
-      value="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
+      value="\
+          --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED \
           --add-exports=java.base/sun.nio.ch=ALL-UNNAMED \
           --add-exports=java.management/com.sun.jmx.mbeanserver=ALL-UNNAMED \
           --add-exports=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED \


### PR DESCRIPTION
This pull request addresses the issue of illegal reflective access warnings encountered when using the 'control.sh' and 'control.bat' scripts in GridGain Community Edition.

Changes Made

1. Suppress Illegal Reflective Access Warnings:

- Added necessary JVM options to suppress illegal reflective access warnings for JDK 9 and above.
- Included specific --add-opens and --illegal-access flags for JDK 17 and above to handle the warnings.
- Updated 'control.sh' and 'control.bat' scripts to dynamically set JVM options based on the detected JDK version.
- Added functions to determine Java version and apply appropriate JVM options.

Testing

- Verified the changes by running 'control.sh' on a local Mac machine; the illegal reflective access warnings are suppressed, and the script executes without errors and performs as expected.
- Although 'control.bat' could not be directly tested on a Mac machine, the changes follow the same logic as control.sh and are expected to work correctly on Windows environments.
