### PR TITLE
GG-40379 CPP: Add BinaryReader::IsNull and BinaryRawReader::SkipIfNull

### DIFF
--- a/modules/platforms/cpp/binary/include/ignite/binary/binary_raw_reader.h
+++ b/modules/platforms/cpp/binary/include/ignite/binary/binary_raw_reader.h
@@ -66,9 +66,9 @@ namespace ignite
             BinaryRawReader(ignite::impl::binary::BinaryReaderImpl* impl);
 
             /**
-             * Skip next value if it is the null.
+             * Skip the next value if it is null.
              *
-             * @return True if the null value has been detected and skipped.
+             * @return @c true if a null value has been detected and skipped, and @c false otherwise.
              */
             bool SkipIfNull();
 

--- a/modules/platforms/cpp/binary/include/ignite/binary/binary_raw_reader.h
+++ b/modules/platforms/cpp/binary/include/ignite/binary/binary_raw_reader.h
@@ -64,7 +64,14 @@ namespace ignite
              * @param impl Implementation.
              */
             BinaryRawReader(ignite::impl::binary::BinaryReaderImpl* impl);
-                        
+
+            /**
+             * Skip next value if it is the null.
+             *
+             * @return True if the null value has been detected and skipped.
+             */
+            bool SkipIfNull();
+
             /**
              * Read 8-byte signed integer. Maps to "byte" type in Java.
              *

--- a/modules/platforms/cpp/binary/include/ignite/binary/binary_reader.h
+++ b/modules/platforms/cpp/binary/include/ignite/binary/binary_reader.h
@@ -63,9 +63,16 @@ namespace ignite
             BinaryReader(ignite::impl::binary::BinaryReaderImpl* impl);
 
             /**
-             * Read 8-byte signed integer. Maps to "byte" type in Java.
+             * Check whether the field is null.
              *
              * @param fieldName Field name.
+             * @return @c true if the field is null or isn't present, and @c false otherwise.
+             */
+            bool IsNull(const char* fieldName);
+
+            /**
+             * Read 8-byte signed integer. Maps to "byte" type in Java.
+             *
              * @param fieldName Field name.
              * @return Result.
              */

--- a/modules/platforms/cpp/binary/include/ignite/impl/binary/binary_reader_impl.h
+++ b/modules/platforms/cpp/binary/include/ignite/impl/binary/binary_reader_impl.h
@@ -805,9 +805,9 @@ namespace ignite
                 bool HasNextElement(int32_t id) const;
 
                 /**
-                 * Skip next value if it is the null.
+                 * Skip the next value if it is null.
                  *
-                 * @return True if the null value has been detected and skipped.
+                 * @return @c true if a null value has been detected and skipped, and @c false otherwise.
                  */
                 bool SkipIfNull();
 

--- a/modules/platforms/cpp/binary/include/ignite/impl/binary/binary_reader_impl.h
+++ b/modules/platforms/cpp/binary/include/ignite/impl/binary/binary_reader_impl.h
@@ -789,6 +789,14 @@ namespace ignite
                 int32_t ReadCollectionSize(const char* fieldName);
 
                 /**
+                 * Check whether the field is null.
+                 *
+                 * @param fieldName Field name.
+                 * @return @c true if the field is null or isn't present, and @c false otherwise.
+                 */
+                bool IsNull(const char* fieldName);
+
+                /**
                  * Check whether next value exists.
                  *
                  * @param id Session ID.

--- a/modules/platforms/cpp/binary/src/binary/binary_raw_reader.cpp
+++ b/modules/platforms/cpp/binary/src/binary/binary_raw_reader.cpp
@@ -27,7 +27,12 @@ namespace ignite
         {
             // No-op.
         }
-        
+
+        bool BinaryRawReader::SkipIfNull()
+        {
+            return impl->SkipIfNull();
+        }
+
         int8_t BinaryRawReader::ReadInt8()
         {
             return impl->ReadInt8();

--- a/modules/platforms/cpp/binary/src/binary/binary_reader.cpp
+++ b/modules/platforms/cpp/binary/src/binary/binary_reader.cpp
@@ -27,6 +27,11 @@ namespace ignite
         {
             // No-op.
         }
+
+        bool BinaryReader::IsNull(const char* fieldName)
+        {
+            return impl->IsNull(fieldName);
+        }
         
         int8_t BinaryReader::ReadInt8(const char* fieldName)
         {

--- a/modules/platforms/cpp/binary/src/impl/binary/binary_reader_impl.cpp
+++ b/modules/platforms/cpp/binary/src/impl/binary/binary_reader_impl.cpp
@@ -777,6 +777,24 @@ namespace ignite
                 return ReadCollectionSizeUnprotected();
             }
 
+            bool BinaryReaderImpl::IsNull(const char* fieldName)
+            {
+                CheckRawMode(false);
+                CheckSingleMode(true);
+
+                InteropStreamPositionGuard<InteropInputStream> positionGuard(*stream);
+
+                int32_t fieldId = idRslvr->GetFieldId(typeId, fieldName);
+                int32_t fieldPos = FindField(fieldId);
+
+                if (fieldPos <= 0)
+                    return true;
+
+                stream->Position(fieldPos);
+
+                return SkipIfNull();
+            }
+
             bool BinaryReaderImpl::HasNextElement(int32_t id) const
             {
                 return elemId == id && elemRead < elemCnt;

--- a/modules/platforms/cpp/core-test/src/binary_reader_writer_raw_test.cpp
+++ b/modules/platforms/cpp/core-test/src/binary_reader_writer_raw_test.cpp
@@ -778,6 +778,25 @@ BOOST_AUTO_TEST_CASE(TestTimestampNull)
     BOOST_REQUIRE(actualVal == expVal);
 }
 
+BOOST_AUTO_TEST_CASE(TestNullSkip)
+{
+    InteropUnpooledMemory mem(1024);
+
+    InteropOutputStream out(&mem);
+    BinaryWriterImpl writer(&out, NULL);
+    BinaryRawWriter rawWriter(&writer);
+
+    rawWriter.WriteNull();
+
+    out.Synchronize();
+
+    InteropInputStream in(&mem);
+    BinaryReaderImpl reader(&in);
+    BinaryRawReader rawReader(&reader);
+
+    BOOST_CHECK(rawReader.SkipIfNull());
+}
+
 BOOST_AUTO_TEST_CASE(TestString)
 {
     InteropUnpooledMemory mem(1024);

--- a/modules/platforms/cpp/core-test/src/binary_reader_writer_test.cpp
+++ b/modules/platforms/cpp/core-test/src/binary_reader_writer_test.cpp
@@ -819,7 +819,9 @@ BOOST_AUTO_TEST_CASE(TestGuidNull)
     Guid expVal;
     Guid actualVal = reader.ReadGuid("test");
 
-    BOOST_REQUIRE(actualVal == expVal);
+    BOOST_CHECK(actualVal == expVal);
+    BOOST_CHECK(reader.IsNull("test"));
+    BOOST_CHECK(reader.IsNull("unknown"));
 }
 
 BOOST_AUTO_TEST_CASE(TestDateNull)
@@ -858,7 +860,9 @@ BOOST_AUTO_TEST_CASE(TestDateNull)
     Date expVal;
     Date actualVal = reader.ReadDate("test");
 
-    BOOST_REQUIRE(actualVal == expVal);
+    BOOST_CHECK(actualVal == expVal);
+    BOOST_CHECK(reader.IsNull("test"));
+    BOOST_CHECK(reader.IsNull("unknown"));
 }
 
 BOOST_AUTO_TEST_CASE(TestTimeNull)
@@ -897,7 +901,9 @@ BOOST_AUTO_TEST_CASE(TestTimeNull)
     Time expVal;
     Time actualVal = reader.ReadTime("test");
 
-    BOOST_REQUIRE(actualVal == expVal);
+    BOOST_CHECK(actualVal == expVal);
+    BOOST_CHECK(reader.IsNull("test"));
+    BOOST_CHECK(reader.IsNull("unknown"));
 }
 
 BOOST_AUTO_TEST_CASE(TestTimestampNull)
@@ -936,7 +942,9 @@ BOOST_AUTO_TEST_CASE(TestTimestampNull)
     Timestamp expVal;
     Timestamp actualVal = reader.ReadTimestamp("test");
 
-    BOOST_REQUIRE(actualVal == expVal);
+    BOOST_CHECK(actualVal == expVal);
+    BOOST_CHECK(reader.IsNull("test"));
+    BOOST_CHECK(reader.IsNull("unknown"));
 }
 
 BOOST_AUTO_TEST_CASE(TestString) {
@@ -1009,6 +1017,9 @@ BOOST_AUTO_TEST_CASE(TestString) {
 
     BOOST_REQUIRE(reader.ReadString("field4", readVal1, 9) == -1);
     BOOST_REQUIRE(reader.ReadString("field5", readVal1, 9) == -1);
+
+    BOOST_CHECK(reader.IsNull("field4"));
+    BOOST_CHECK(reader.IsNull("field5"));
 }
 
 BOOST_AUTO_TEST_CASE(TestStringArrayNull)


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-40379

- Added `BinaryReader::IsNull` and `BinaryRawReader::SkipIfNull` methods to check for `null`s;
- Modified tests to check new methods.