### PR TITLE
GG-40718 Fix LocalWalModeChangeDuringRebalancingSelfTest.testWalDisabledDuringRebalancing test

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/LocalWalModeChangeDuringRebalancingSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/LocalWalModeChangeDuringRebalancingSelfTest.java
@@ -277,7 +277,7 @@ public class LocalWalModeChangeDuringRebalancingSelfTest extends GridCommonAbstr
         assertTrue(
             "Failed to wait for the actual rebalance future.",
             waitForCondition(() -> {
-                GridDhtPartitionDemander.RebalanceFuture rebFut =(GridDhtPartitionDemander.RebalanceFuture) newIgnite
+                GridDhtPartitionDemander.RebalanceFuture rebFut = (GridDhtPartitionDemander.RebalanceFuture) newIgnite
                     .context()
                     .cache()
                     .utilityCache()
@@ -330,7 +330,7 @@ public class LocalWalModeChangeDuringRebalancingSelfTest extends GridCommonAbstr
         assertEquals(disableWalDuringRebalancing ? 1 : 0, checkpointsBeforeRebalance); // checkpoint related to rebalanced system cache.
 
         // Expecting a checkpoint for each group.
-        assertEquals(disableWalDuringRebalancing ? newIgnite.context().cache().cacheGroups().size() - 1: 0,
+        assertEquals(disableWalDuringRebalancing ? newIgnite.context().cache().cacheGroups().size() - 1 : 0,
             checkpointsAfterRebalance); // checkpoint if WAL was re-activated
     }
 


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-40718

This patch includes: 
 - a fix for the flaky test
 - removing redundant test [testWalDisabledDuringRebalancingWithPendingTxTracker]
    The pending transactions tracker does not affect the rebalancing in any way [GG-39629](https://ggsystems.atlassian.net/browse/GG-39629)

[GG-39629]: https://ggsystems.atlassian.net/browse/GG-39629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ