### PR TITLE
GG-40809 Bump commons.io version to 2.17.0 (#3299)

### DIFF
--- a/modules/zookeeper/pom.xml
+++ b/modules/zookeeper/pom.xml
@@ -123,8 +123,22 @@
                     <groupId>ch.qos.logback</groupId>
                     <artifactId>logback-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-io</groupId>
+                    <artifactId>commons-io</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
+
+        <!-- zookeeper transitive deps -->
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>${commons.io.version}</version>
+        </dependency>
+
+        <!-- end of zookeeper transitive deps -->
 
         <dependency>
             <groupId>org.apache.zookeeper</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -63,7 +63,7 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compress.version>1.20</commons.compress.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
-        <commons.io.version>2.6</commons.io.version>
+        <commons.io.version>2.17</commons.io.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <cron4j.version>2.2.5</cron4j.version>
         <curator.version>5.5.0</curator.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -63,7 +63,7 @@
         <commons.collections.version>3.2.2</commons.collections.version>
         <commons.compress.version>1.20</commons.compress.version>
         <commons.lang3.version>3.12.0</commons.lang3.version>
-        <commons.io.version>2.17</commons.io.version>
+        <commons.io.version>2.17.0</commons.io.version>
         <commons.dbcp.version>1.4</commons.dbcp.version>
         <cron4j.version>2.2.5</cron4j.version>
         <curator.version>5.5.0</curator.version>


### PR DESCRIPTION
(cherry picked from commit 593d25665ff2655e48d841370653d5f4e4b0d65e)