### PR TITLE
GG-40973 Warn about EOL from Update Notifier

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -366,7 +366,6 @@ public class GridUpdateNotifier {
             }
         else if (!reportOnlyNew)
             throttle(log, false, "Update status is not available.");
-
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -27,7 +27,6 @@ import org.apache.ignite.internal.util.typedef.internal.SB;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.util.worker.GridWorker;
 import org.apache.ignite.plugin.PluginProvider;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -37,6 +36,7 @@ import java.io.UnsupportedEncodingException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -391,7 +391,7 @@ public class GridUpdateNotifier {
         return params;
     }
 
-    String getUpdates() throws IOException {
+    List<String> getUpdates() throws IOException {
         Map<String, Object> params = getUpdateCheckerParams();
 
         return updatesChecker.getUpdates(params);
@@ -420,10 +420,9 @@ public class GridUpdateNotifier {
             try {
                 if (!isCancelled()) {
                     try {
-                        String updatesRes = getUpdates();
-                        String[] lines = updatesRes.split("\n");
+                        List<String> updatesRes = getUpdates();
 
-                        for (String line : lines) {
+                        for (String line : updatesRes) {
                             if (line.contains("version"))
                                 latestVer = regularize(obtainVersionFrom(line));
                             else if (line.contains("downloadUrl"))

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -349,18 +349,24 @@ public class GridUpdateNotifier {
                 if (!reportOnlyNew)
                     throttle(log, false, "Your version is up to date.");
             }
-            else
-                throttle(log, true, "New version is available at " + downloadUrl + ": " + latestVer);
+            else {
+                String msg = "New version is available at " + downloadUrl + ": " + latestVer;
+
+                if (endOfLifeDate != null && endOfLifeDate.minusMonths(6).isBefore(LocalDate.now())) {
+                    String eolMsg = "End of life for current version " + ver + " is on " + endOfLifeDate;
+
+                    if (endOfLifeComment != null && !endOfLifeComment.isEmpty()) {
+                        eolMsg += " (" + endOfLifeComment + ")";
+                    }
+
+                    msg += ". " + eolMsg + ".";
+                }
+
+                throttle(log, true, msg);
+            }
         else if (!reportOnlyNew)
             throttle(log, false, "Update status is not available.");
 
-        if (endOfLifeDate != null) {
-            // If closer than 6 months, log a warning.
-            if (endOfLifeDate.minusMonths(6).isBefore(LocalDate.now())) {
-                String msg = "End of life for current version " + ver + " is on " + endOfLifeDate + ". " + endOfLifeComment;
-                throttle(log, true, msg);
-            }
-        }
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -296,6 +296,14 @@ public class GridUpdateNotifier {
         return latestVer;
     }
 
+    LocalDate endOfLifeDate() {
+        return endOfLifeDate;
+    }
+
+    String endOfLifeComment() {
+        return endOfLifeComment;
+    }
+
     /**
      * @return Error.
      */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -444,16 +444,16 @@ public class GridUpdateNotifier {
                     try {
                         Map<String, String> updatesRes = getUpdates();
 
-                        String ver = updatesRes.get("version");
+                        String ver = updatesRes.get("latest_version");
                         if (ver != null) {
                             latestVer = regularize(ver);
                         }
 
-                        downloadUrl = updatesRes.get("downloadUrl");
+                        downloadUrl = updatesRes.get("download_url");
 
-                        String eol = updatesRes.get("endOfLifeDate");
+                        String eol = updatesRes.get("eol_date");
 
-                        if (eol != null) {
+                        if (eol != null && !eol.isEmpty()) {
                             try {
                                 endOfLifeDate = LocalDate.parse(eol, DateTimeFormatter.ISO_DATE);
                             } catch (DateTimeParseException e) {
@@ -463,7 +463,8 @@ public class GridUpdateNotifier {
                                 endOfLifeDate = null;
                             }
                         }
-                        endOfLifeComment = updatesRes.get("endOfLifeComment");
+
+                        endOfLifeComment = updatesRes.get("eol_comment");
 
                         err = null;
                     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -76,7 +76,7 @@ public class GridUpdateNotifier {
     private static final int WORKER_THREAD_SLEEP_TIME = 5000;
 
     /** Default url for request GridGain updates. */
-    public static final String DEFAULT_GRIDGAIN_UPDATES_URL = "https://www.gridgain.com/notifier/update";
+    public static final String DEFAULT_GRIDGAIN_UPDATES_URL = "https://www.gridgain.com/notifier/update/v2";
 
     /** Grid version. */
     private final String ver;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -91,6 +93,12 @@ public class GridUpdateNotifier {
 
     /** Download url for latest version. */
     private volatile String downloadUrl;
+
+    /** End of life date. */
+    private volatile LocalDate endOfLifeDate;
+
+    /** End of life comment. */
+    private volatile String endOfLifeComment;
 
     /** Ignite instance name. */
     private final String igniteInstanceName;
@@ -423,8 +431,11 @@ public class GridUpdateNotifier {
                         String ver = updatesRes.get("version");
                         if (ver != null) {
                             latestVer = regularize(ver);
-                            downloadUrl = updatesRes.get("downloadUrl");
                         }
+
+                        downloadUrl = updatesRes.get("downloadUrl");
+                        endOfLifeDate = LocalDate.parse(updatesRes.get("endOfLifeDate"), DateTimeFormatter.ISO_DATE);
+                        endOfLifeComment = updatesRes.get("endOfLifeComment");
 
                         err = null;
                     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -16,17 +16,6 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.io.UnsupportedEncodingException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.atomic.AtomicReference;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteLogger;
 import org.apache.ignite.IgniteSystemProperties;
@@ -34,12 +23,25 @@ import org.apache.ignite.internal.GridKernalGateway;
 import org.apache.ignite.internal.IgniteKernal;
 import org.apache.ignite.internal.IgniteProperties;
 import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
-import org.apache.ignite.internal.util.typedef.F;
 import org.apache.ignite.internal.util.typedef.internal.SB;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.internal.util.worker.GridWorker;
 import org.apache.ignite.plugin.PluginProvider;
 import org.jetbrains.annotations.Nullable;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static java.net.URLEncoder.encode;
 
@@ -395,18 +397,18 @@ public class GridUpdateNotifier {
 
                 srvNodes = discoSpi.serverNodes(discoSpi.topologyVersionEx()).size();
 
-                String postParams =
-                    "igniteInstanceName=" + encode(igniteInstanceName, CHARSET) +
-                        (!F.isEmpty(updStatusParams) ? "&" + updStatusParams : "") +
-                        "&srvNodes=" + srvNodes +
-                        "&product=" + product +
-                        (!F.isEmpty(stackTrace) ? "&stackTrace=" + encode(stackTrace, CHARSET) : "") +
-                        (!F.isEmpty(vmProps) ? "&vmProps=" + encode(vmProps, CHARSET) : "") +
-                        pluginsVers;
+                Map<String, Object> params = new HashMap<>();
+                params.put("igniteInstanceName", igniteInstanceName);
+                params.put("params", updStatusParams);
+                params.put("srvNodes", srvNodes);
+                params.put("product", product);
+                params.put("stackTrace", stackTrace);
+                params.put("vmProps", vmProps);
+                params.put("pluginsVers", pluginsVers);
 
                 if (!isCancelled()) {
                     try {
-                        String updatesRes = updatesChecker.getUpdates(postParams);
+                        String updatesRes = updatesChecker.getUpdates(params);
 
                         String[] lines = updatesRes.split("\n");
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -417,7 +417,7 @@ public class GridUpdateNotifier {
     Map<String, String> getUpdates() throws IOException {
         Map<String, Object> params = getUpdateCheckerParams();
 
-        return updatesChecker.getUpdates(params);
+        return updatesChecker.getUpdates(ver, params);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -16,18 +16,6 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
-import org.apache.ignite.IgniteCheckedException;
-import org.apache.ignite.IgniteLogger;
-import org.apache.ignite.IgniteSystemProperties;
-import org.apache.ignite.internal.GridKernalGateway;
-import org.apache.ignite.internal.IgniteKernal;
-import org.apache.ignite.internal.IgniteProperties;
-import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
-import org.apache.ignite.internal.util.typedef.internal.SB;
-import org.apache.ignite.internal.util.typedef.internal.U;
-import org.apache.ignite.internal.util.worker.GridWorker;
-import org.apache.ignite.plugin.PluginProvider;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -44,6 +32,17 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.ignite.IgniteCheckedException;
+import org.apache.ignite.IgniteLogger;
+import org.apache.ignite.IgniteSystemProperties;
+import org.apache.ignite.internal.GridKernalGateway;
+import org.apache.ignite.internal.IgniteKernal;
+import org.apache.ignite.internal.IgniteProperties;
+import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
+import org.apache.ignite.internal.util.typedef.internal.SB;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.internal.util.worker.GridWorker;
+import org.apache.ignite.plugin.PluginProvider;
 
 import static java.net.URLEncoder.encode;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifier.java
@@ -20,9 +20,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -94,11 +91,8 @@ public class GridUpdateNotifier {
     /** Download url for latest version. */
     private volatile String downloadUrl;
 
-    /** End of life date. */
-    private volatile LocalDate endOfLifeDate;
-
-    /** End of life comment. */
-    private volatile String endOfLifeComment;
+    /** End of life message. */
+    private volatile String endOfLifeMessage;
 
     /** Ignite instance name. */
     private final String igniteInstanceName;
@@ -295,12 +289,8 @@ public class GridUpdateNotifier {
         return latestVer;
     }
 
-    LocalDate endOfLifeDate() {
-        return endOfLifeDate;
-    }
-
-    String endOfLifeComment() {
-        return endOfLifeComment;
+    String endOfLifeMessage() {
+        return endOfLifeMessage;
     }
 
     /**
@@ -350,16 +340,10 @@ public class GridUpdateNotifier {
                     throttle(log, false, "Your version is up to date.");
             }
             else {
-                String msg = "New version is available at " + downloadUrl + ": " + latestVer;
+                String msg = "New version is available at " + downloadUrl + ": " + latestVer + ".";
 
-                if (endOfLifeDate != null && endOfLifeDate.minusMonths(6).isBefore(LocalDate.now())) {
-                    String eolMsg = "End of life for current version " + ver + " is on " + endOfLifeDate;
-
-                    if (endOfLifeComment != null && !endOfLifeComment.isEmpty()) {
-                        eolMsg += " (" + endOfLifeComment + ")";
-                    }
-
-                    msg += ". " + eolMsg + ".";
+                if (endOfLifeMessage != null && !endOfLifeMessage.isEmpty()) {
+                    msg = endOfLifeMessage + " " + msg;
                 }
 
                 throttle(log, true, msg);
@@ -455,21 +439,7 @@ public class GridUpdateNotifier {
                         }
 
                         downloadUrl = updatesRes.get("download_url");
-
-                        String eol = updatesRes.get("eol_date");
-
-                        if (eol != null && !eol.isEmpty()) {
-                            try {
-                                endOfLifeDate = LocalDate.parse(eol, DateTimeFormatter.ISO_DATE);
-                            } catch (DateTimeParseException e) {
-                                if (log.isDebugEnabled())
-                                    log.debug("Failed to parse end of life date '" + eol + "': " + e.getMessage());
-
-                                endOfLifeDate = null;
-                            }
-                        }
-
-                        endOfLifeComment = updatesRes.get("eol_comment");
+                        endOfLifeMessage = updatesRes.get("eol_message");
 
                         err = null;
                     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -16,6 +16,8 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
+import org.apache.ignite.internal.IgniteVersionUtils;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -23,6 +25,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.Map;
 
 /**
  * This class is responsible for getting GridGain updates information via HTTP
@@ -50,7 +53,7 @@ public class HttpIgniteUpdatesChecker {
      * @return Information about Ignite updates separated by line endings
      * @throws IOException If HTTP request was failed
      */
-    public String getUpdates(String updateReq) throws IOException {
+    public String getUpdates(Map<String, Object> updateReq) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
 
         conn.setDoOutput(true);
@@ -63,11 +66,9 @@ public class HttpIgniteUpdatesChecker {
         conn.setReadTimeout(5000);
 
         try (OutputStream os = conn.getOutputStream()) {
-            // TODO: ?
-            // os.write(updateReq.getBytes(charset));
-
-            // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
-            String requestBody = "{\"product\": \"gg\", \"version\": \"8.9.12\"}";
+            // TODO: Add updateReq as "instanceData" field
+            // TODO: JSON escaping
+            String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
             os.write(requestBody.getBytes(charset));
             os.flush();
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -54,7 +54,7 @@ public class HttpIgniteUpdatesChecker {
      * @return Information about Ignite updates separated by line endings
      * @throws IOException If HTTP request was failed
      */
-    public Map<String, String> getUpdates(Map<String, Object> updateReq) throws IOException {
+    public Map<String, String> getUpdates(String version, Map<String, Object> updateReq) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
 
         conn.setDoOutput(true);
@@ -69,7 +69,7 @@ public class HttpIgniteUpdatesChecker {
         try (OutputStream os = conn.getOutputStream()) {
             StringBuilder bodyBuilder = new StringBuilder("{");
             bodyBuilder.append("\"product\": \"gg\", \"version\": \"")
-                    .append(IgniteVersionUtils.VER_STR)
+                    .append(version)
                     .append("\", \"instanceData\": {");
 
             for (Map.Entry<String, Object> entry : updateReq.entrySet()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -16,6 +16,8 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
+import org.apache.ignite.internal.IgniteVersionUtils;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -57,9 +59,8 @@ public class HttpIgniteUpdatesChecker {
         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=" + charset);
         conn.setRequestProperty("user-agent", "");
 
-        // TODO: Current version.
         conn.setDoInput(true);
-        String requestBody = "{\"product\": \"gg\", \"version\": \"8.9.12\"}";
+        String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
         conn.getOutputStream().write(requestBody.getBytes(charset));
 
         conn.setConnectTimeout(5000);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -78,12 +78,7 @@ public class HttpIgniteUpdatesChecker {
 
             byte[] requestBytes = requestBody.getBytes(charset);
 
-            String path = url1.getPath();
-
-            if (path.isEmpty())
-                path = "/";
-
-            String request = "GET " + path + " HTTP/1.1\r\n" +
+            String request = "GET /" + url1.getPath() + " HTTP/1.1\r\n" +
                     "Host: " + url1.getHost() + "\r\n" +
                     "Connection: close\r\n" +
                     "Content-Length: " + requestBytes.length + "\r\n" +

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -73,9 +73,17 @@ public class HttpIgniteUpdatesChecker {
 
             for (Map.Entry<String, Object> entry : updateReq.entrySet()) {
                 bodyBuilder
-                        .append("\"").append(entry.getKey()).append("\": \"")
-                        .append(escapeJson(entry.getValue().toString()))
-                        .append("\", ");
+                        .append("\"").append(entry.getKey()).append("\": ");
+
+                if (entry.getValue() == null) {
+                    bodyBuilder.append("null, ");
+                }
+                else {
+                    bodyBuilder
+                            .append("\"")
+                            .append(escapeJson(entry.getValue().toString()))
+                            .append("\", ");
+                }
             }
 
             bodyBuilder.delete(bodyBuilder.length() - 2, bodyBuilder.length());

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -69,15 +69,16 @@ public class HttpIgniteUpdatesChecker {
             StringBuilder bodyBuilder = new StringBuilder("{");
             bodyBuilder.append("\"product\": \"gg\", \"version\": \"")
                     .append(IgniteVersionUtils.VER_STR)
-                    .append("\"");
+                    .append("\", \"instanceData\": {");
 
             for (Map.Entry<String, Object> entry : updateReq.entrySet()) {
-                bodyBuilder.append(", \"").append(entry.getKey()).append("\": \"")
+                bodyBuilder.append(entry.getKey()).append("\": \"")
                         .append(escapeJson(entry.getValue().toString()))
-                        .append("\"");
+                        .append("\", ");
             }
 
-            bodyBuilder.append("}");
+            bodyBuilder.deleteCharAt(bodyBuilder.length() - 1);
+            bodyBuilder.append("}}");
 
             os.write(bodyBuilder.toString().getBytes(charset));
             os.flush();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -78,7 +78,12 @@ public class HttpIgniteUpdatesChecker {
 
             byte[] requestBytes = requestBody.getBytes(charset);
 
-            String request = "GET /" + url1.getPath() + " HTTP/1.1\r\n" +
+            String path = url1.getPath();
+
+            if (path.isEmpty())
+                path = "/";
+
+            String request = "GET " + path + " HTTP/1.1\r\n" +
                     "Host: " + url1.getHost() + "\r\n" +
                     "Connection: close\r\n" +
                     "Content-Length: " + requestBytes.length + "\r\n" +

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -74,16 +74,19 @@ public class HttpIgniteUpdatesChecker {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
             // Send HTTP GET request
+            String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
+
+            byte[] requestBytes = requestBody.getBytes(charset);
+
             String request = "GET /" + url1.getPath() + " HTTP/1.1\r\n" +
                     "Host: " + url1.getHost() + "\r\n" +
                     "Connection: close\r\n" +
-                    "{\"product\": \"gg\", \"version\": \"8.9.12\"}" +
+                    "Content-Length: " + requestBytes.length + "\r\n" +
                     "\r\n";
 
-            // TODO
-            // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
-
-            os.write(request.getBytes());
+            os.write(request.getBytes(charset));
+            os.write(requestBytes);
+            os.write("\r\n".getBytes(charset));
             os.flush();
 
             // Read the response

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 
@@ -53,14 +54,18 @@ public class HttpIgniteUpdatesChecker {
      * @throws IOException If HTTP request was failed
      */
     public String getUpdates(String updateReq) throws IOException {
-        URLConnection conn = new URL(url).openConnection();
+        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+
         conn.setDoOutput(true);
         conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "application/json");
-        conn.setRequestProperty("user-agent", "");
+        conn.setRequestProperty("Accept", "*/*");
+        conn.setRequestProperty("user-agent", "Foo");
 
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
+
+        // TODO: This does not work - why?
+        conn.setRequestMethod("GET");
 
         try (OutputStream os = conn.getOutputStream()) {
             // TODO: ?
@@ -69,6 +74,7 @@ public class HttpIgniteUpdatesChecker {
             // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
             String requestBody = "{\"product\": \"gg\", \"version\": \"8.9.12\"}";
             os.write(requestBody.getBytes(charset));
+            os.flush();
         }
 
         try (InputStream in = conn.getInputStream()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -16,8 +16,6 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
-import org.apache.ignite.internal.IgniteVersionUtils;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -74,7 +74,7 @@ public class HttpIgniteUpdatesChecker {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
             // Send HTTP GET request
-            String request = "GET /" + url1.getPath() + " HTTP/1.1\r\n" +
+            String request = "GET " + url1.getPath() + " HTTP/1.1\r\n" +
                     "Host: " + url1.getHost() + "\r\n" +
                     "Connection: close\r\n" +
                     "{\"product\": \"gg\", \"version\": \"8.9.12\"}" +

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -101,12 +101,12 @@ public class HttpIgniteUpdatesChecker {
     }
 
     private static String escapeJson(String str) {
-        // TODO: Escape control characters.
         // https://www.ietf.org/rfc/rfc4627.txt
-        // All Unicode characters may be placed within the
-        //   quotation marks except for the characters that must be escaped:
-        //   quotation mark, reverse solidus, and the control characters (U+0000
-        //   through U+001F).
-        return str.replace("\\", "\\\\").replace("\"", "\\\"");
+        // All Unicode characters may be placed within the quotation marks except for the characters that must be escaped:
+        // quotation mark, reverse solidus, and the control characters (U+0000 through U+001F).
+        return str
+                .replaceAll("[\u0000-\u001F]", "")
+                .replace("\\", "\\\\")
+                .replace("\"", "\\\"");
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -16,8 +16,6 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
-import org.apache.ignite.internal.IgniteVersionUtils;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,7 +23,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 
 /**
  * This class is responsible for getting GridGain updates information via HTTP

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -74,19 +74,16 @@ public class HttpIgniteUpdatesChecker {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
             // Send HTTP GET request
-            String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
-
-            byte[] requestBytes = requestBody.getBytes(charset);
-
             String request = "GET /" + url1.getPath() + " HTTP/1.1\r\n" +
                     "Host: " + url1.getHost() + "\r\n" +
                     "Connection: close\r\n" +
-                    "Content-Length: " + requestBytes.length + "\r\n" +
+                    "{\"product\": \"gg\", \"version\": \"8.9.12\"}" +
                     "\r\n";
 
-            os.write(request.getBytes(charset));
-            os.write(requestBytes);
-            os.write("\r\n".getBytes(charset));
+            // TODO
+            // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
+
+            os.write(request.getBytes());
             os.flush();
 
             // Read the response

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -72,12 +72,13 @@ public class HttpIgniteUpdatesChecker {
                     .append("\", \"instanceData\": {");
 
             for (Map.Entry<String, Object> entry : updateReq.entrySet()) {
-                bodyBuilder.append(entry.getKey()).append("\": \"")
+                bodyBuilder
+                        .append("\"").append(entry.getKey()).append("\": \"")
                         .append(escapeJson(entry.getValue().toString()))
                         .append("\", ");
             }
 
-            bodyBuilder.deleteCharAt(bodyBuilder.length() - 1);
+            bodyBuilder.delete(bodyBuilder.length() - 2, bodyBuilder.length());
             bodyBuilder.append("}}");
 
             os.write(bodyBuilder.toString().getBytes(charset));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -58,8 +58,6 @@ public class HttpIgniteUpdatesChecker {
         conn.setDoOutput(true);
 
         conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "*/*");
-        conn.setRequestProperty("user-agent", "Foo");
 
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -103,6 +103,9 @@ public class HttpIgniteUpdatesChecker {
             Map<String, String> res = new HashMap<>();
 
             for (String line; (line = reader.readLine()) != null; ) {
+                if (line.isEmpty())
+                    continue;
+
                 String[] parts = line.split("=", 2);
 
                 if (parts.length == 2) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -55,19 +55,20 @@ public class HttpIgniteUpdatesChecker {
     public String getUpdates(String updateReq) throws IOException {
         URLConnection conn = new URL(url).openConnection();
         conn.setDoOutput(true);
-        conn.setRequestProperty("Accept-Charset", charset);
-        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=" + charset);
+        conn.setRequestProperty("Content-Type", "application/json");
+        conn.setRequestProperty("Accept", "application/json");
         conn.setRequestProperty("user-agent", "");
-
-        conn.setDoInput(true);
-        String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
-        conn.getOutputStream().write(requestBody.getBytes(charset));
 
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
 
         try (OutputStream os = conn.getOutputStream()) {
-            os.write(updateReq.getBytes(charset));
+            // TODO: ?
+            // os.write(updateReq.getBytes(charset));
+
+            // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
+            String requestBody = "{\"product\": \"gg\", \"version\": \"8.9.12\"}";
+            os.write(requestBody.getBytes(charset));
         }
 
         try (InputStream in = conn.getInputStream()) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -25,9 +25,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -90,6 +90,7 @@ public class HttpIgniteUpdatesChecker {
     }
 
     private static String escapeJson(String str) {
+        // TODO: Escape control characters.
         // https://www.ietf.org/rfc/rfc4627.txt
         // All Unicode characters may be placed within the
         //   quotation marks except for the characters that must be escaped:

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -57,6 +57,10 @@ public class HttpIgniteUpdatesChecker {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
 
         conn.setDoOutput(true);
+
+        // TODO: This does not work - why?
+        conn.setRequestMethod("GET");
+
         conn.setRequestProperty("Content-Type", "application/json");
         conn.setRequestProperty("Accept", "*/*");
         conn.setRequestProperty("user-agent", "Foo");
@@ -64,9 +68,7 @@ public class HttpIgniteUpdatesChecker {
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
 
-        // TODO: This does not work - why?
-        conn.setRequestMethod("GET");
-
+        // TODO: getOutputStream forces a POST request.
         try (OutputStream os = conn.getOutputStream()) {
             // TODO: ?
             // os.write(updateReq.getBytes(charset));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -70,6 +70,7 @@ public class HttpIgniteUpdatesChecker {
             // TODO: JSON escaping
             String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
             os.write(requestBody.getBytes(charset));
+
             os.flush();
         }
 
@@ -86,5 +87,14 @@ public class HttpIgniteUpdatesChecker {
 
             return res.toString();
         }
+    }
+
+    private static String escapeJson(String str) {
+        // https://www.ietf.org/rfc/rfc4627.txt
+        // All Unicode characters may be placed within the
+        //   quotation marks except for the characters that must be escaped:
+        //   quotation mark, reverse solidus, and the control characters (U+0000
+        //   through U+001F).
+        return str.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -18,6 +18,8 @@ package org.apache.ignite.internal.processors.cluster;
 
 import org.apache.ignite.internal.IgniteVersionUtils;
 
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,37 +56,37 @@ public class HttpIgniteUpdatesChecker {
      * @throws IOException If HTTP request was failed
      */
     public String getUpdates(String updateReq) throws IOException {
-        HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
+        return getUpdates2();
+    }
 
-        conn.setDoOutput(true);
+    private String getUpdates2() throws IOException {
+        URL url1 = new URL(url);
+        int port = url1.getPort();
 
-        // TODO: This does not work - why?
-        conn.setRequestMethod("GET");
-
-        conn.setRequestProperty("Content-Type", "application/json");
-        conn.setRequestProperty("Accept", "*/*");
-        conn.setRequestProperty("user-agent", "Foo");
-
-        conn.setConnectTimeout(5000);
-        conn.setReadTimeout(5000);
-
-        // TODO: getOutputStream forces a POST request.
-        try (OutputStream os = conn.getOutputStream()) {
-            // TODO: ?
-            // os.write(updateReq.getBytes(charset));
-
-            // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
-            String requestBody = "{\"product\": \"gg\", \"version\": \"8.9.12\"}";
-            os.write(requestBody.getBytes(charset));
-            os.flush();
+        if (port == -1) {
+            port = url1.getDefaultPort();
         }
 
-        try (InputStream in = conn.getInputStream()) {
-            if (in == null)
-                return null;
+        SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+        try (
+                SSLSocket socket = (SSLSocket) factory.createSocket(url1.getHost(), port);
+                OutputStream os = socket.getOutputStream();
+                BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
-            BufferedReader reader = new BufferedReader(new InputStreamReader(in, charset));
+            // Send HTTP GET request
+            String request = "GET " + url1.getPath() + " HTTP/1.1\r\n" +
+                    "Host: " + url1.getHost() + "\r\n" +
+                    "Connection: close\r\n" +
+                    "{\"product\": \"gg\", \"version\": \"8.9.12\"}" +
+                    "\r\n";
 
+            // TODO
+            // String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
+
+            os.write(request.getBytes());
+            os.flush();
+
+            // Read the response
             StringBuilder res = new StringBuilder();
 
             for (String line; (line = reader.readLine()) != null; )

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -55,7 +56,7 @@ public class HttpIgniteUpdatesChecker {
      * @return Information about Ignite updates separated by line endings
      * @throws IOException If HTTP request was failed
      */
-    public List<String> getUpdates(Map<String, Object> updateReq) throws IOException {
+    public Map<String, String> getUpdates(Map<String, Object> updateReq) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
 
         conn.setDoOutput(true);
@@ -101,10 +102,17 @@ public class HttpIgniteUpdatesChecker {
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(in, charset));
 
-            List<String> res = new ArrayList<>();
+            Map<String, String> res = new HashMap<>();
 
-            for (String line; (line = reader.readLine()) != null; )
-                res.add(line);
+            for (String line; (line = reader.readLine()) != null; ) {
+                String[] parts = line.split("=", 2);
+
+                if (parts.length == 2) {
+                    res.put(parts[0].trim(), parts[1].trim());
+                } else {
+                    res.put(line.trim(), null);
+                }
+            }
 
             return res;
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -58,9 +58,6 @@ public class HttpIgniteUpdatesChecker {
 
         conn.setDoOutput(true);
 
-        // TODO: This does not work - why?
-        conn.setRequestMethod("GET");
-
         conn.setRequestProperty("Content-Type", "application/json");
         conn.setRequestProperty("Accept", "*/*");
         conn.setRequestProperty("user-agent", "Foo");
@@ -68,7 +65,6 @@ public class HttpIgniteUpdatesChecker {
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
 
-        // TODO: getOutputStream forces a POST request.
         try (OutputStream os = conn.getOutputStream()) {
             // TODO: ?
             // os.write(updateReq.getBytes(charset));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -57,6 +57,11 @@ public class HttpIgniteUpdatesChecker {
         conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded;charset=" + charset);
         conn.setRequestProperty("user-agent", "");
 
+        // TODO: Current version.
+        conn.setDoInput(true);
+        String requestBody = "{\"product\": \"gg\", \"version\": \"8.9.12\"}";
+        conn.getOutputStream().write(requestBody.getBytes(charset));
+
         conn.setConnectTimeout(5000);
         conn.setReadTimeout(5000);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -25,6 +25,8 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -53,7 +55,7 @@ public class HttpIgniteUpdatesChecker {
      * @return Information about Ignite updates separated by line endings
      * @throws IOException If HTTP request was failed
      */
-    public String getUpdates(Map<String, Object> updateReq) throws IOException {
+    public List<String> getUpdates(Map<String, Object> updateReq) throws IOException {
         HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
 
         conn.setDoOutput(true);
@@ -99,12 +101,12 @@ public class HttpIgniteUpdatesChecker {
 
             BufferedReader reader = new BufferedReader(new InputStreamReader(in, charset));
 
-            StringBuilder res = new StringBuilder();
+            List<String> res = new ArrayList<>();
 
             for (String line; (line = reader.readLine()) != null; )
-                res.append(line).append('\n');
+                res.add(line);
 
-            return res.toString();
+            return res;
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -74,7 +74,7 @@ public class HttpIgniteUpdatesChecker {
                 BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()))) {
 
             // Send HTTP GET request
-            String request = "GET " + url1.getPath() + " HTTP/1.1\r\n" +
+            String request = "GET /" + url1.getPath() + " HTTP/1.1\r\n" +
                     "Host: " + url1.getHost() + "\r\n" +
                     "Connection: close\r\n" +
                     "{\"product\": \"gg\", \"version\": \"8.9.12\"}" +

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cluster/HttpIgniteUpdatesChecker.java
@@ -66,11 +66,20 @@ public class HttpIgniteUpdatesChecker {
         conn.setReadTimeout(5000);
 
         try (OutputStream os = conn.getOutputStream()) {
-            // TODO: Add updateReq as "instanceData" field
-            // TODO: JSON escaping
-            String requestBody = "{\"product\": \"gg\", \"version\": \"" + IgniteVersionUtils.VER_STR +  "\"}";
-            os.write(requestBody.getBytes(charset));
+            StringBuilder bodyBuilder = new StringBuilder("{");
+            bodyBuilder.append("\"product\": \"gg\", \"version\": \"")
+                    .append(IgniteVersionUtils.VER_STR)
+                    .append("\"");
 
+            for (Map.Entry<String, Object> entry : updateReq.entrySet()) {
+                bodyBuilder.append(", \"").append(entry.getKey()).append("\": \"")
+                        .append(escapeJson(entry.getValue().toString()))
+                        .append("\"");
+            }
+
+            bodyBuilder.append("}");
+
+            os.write(bodyBuilder.toString().getBytes(charset));
             os.flush();
         }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -16,15 +16,6 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Properties;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteSystemProperties;
 import org.apache.ignite.cluster.ClusterNode;
@@ -41,8 +32,16 @@ import org.apache.ignite.testframework.junits.common.GridCommonTest;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Matchers.anyString;
 
 /**
  * Update notifier test.

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -42,6 +42,7 @@ import java.util.Map;
 import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Update notifier test.
@@ -98,7 +99,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         updates.put("endOfLifeDate", "2023-10-21");
         updates.put("endOfLifeComment", "EOL comment");
 
-        Mockito.when(updatesCheckerMock.getUpdates(any())).thenReturn(updates);
+        Mockito.when(updatesCheckerMock.getUpdates(anyString(), any())).thenReturn(updates);
 
         GridKernalContext ctx = Mockito.mock(GridKernalContext.class);
         GridDiscoveryManager discovery = Mockito.mock(GridDiscoveryManager.class);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -164,12 +164,27 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
     }
 
     @Test
-    public void testGetUpdates() throws Exception {
+    public void testGetUpdatesCurrentVersion() throws Exception {
+        Map<String, String> updates = getUpdates(IgniteVersionUtils.VER_STR);
+
+        assertEquals("", updates.get("eol_date"));
+        assertEquals("", updates.get("eol_comment"));
+    }
+
+    @Test
+    public void testGetUpdatesOldVersion() throws Exception {
+        Map<String, String> updates = getUpdates("8.7.1");
+
+        assertEquals("2025-01-31", updates.get("eol_date"));
+        assertEquals("test comment text", updates.get("eol_comment"));
+    }
+
+    private static Map<String, String> getUpdates(String ver) throws Exception {
         HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
         GridUpdateNotifier notifier = new GridUpdateNotifier(
             "test-instance",
-                IgniteVersionUtils.VER_STR,
+            ver,
             Mockito.mock(GridKernalGateway.class),
             Mockito.mock(GridDiscoveryManager.class),
             Collections.emptyList(),
@@ -182,5 +197,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         assertTrue(updates.containsKey("latest_version"));
         assertTrue(updates.containsKey("eol_date"));
         assertTrue(updates.containsKey("eol_comment"));
+
+        return updates;
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -95,6 +95,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         updates.put("meta", "meta");
         updates.put("version", nodeVer);
         updates.put("downloadUrl", "url");
+        updates.put("endOfLifeDate", "2023-10-21");
+        updates.put("endOfLifeComment", "EOL comment");
 
         Mockito.when(updatesCheckerMock.getUpdates(any())).thenReturn(updates);
 
@@ -131,6 +133,9 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
             (nodeMaintenance == 0 && lastMaintenance == 0) || (nodeMaintenance > 0 && lastMaintenance > 0));
 
         ntf.reportStatus(log);
+
+        assertEquals("EOL comment", ntf.endOfLifeComment());
+        assertEquals("2023-10-21", ntf.endOfLifeDate().toString());
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.internal.processors.cluster;
 
+import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
@@ -148,5 +149,14 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         vers.setAccessible(true);
         String versionsString = (String)vers.get(notifier);
         assertTrue(versionsString.contains("my-cool-name-plugin-version=UNKNOWN"));
+    }
+
+    @Test
+    public void testGetUpdates() throws IOException {
+        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
+
+        String updates = checker.getUpdates("");
+
+        assertEquals("x", updates);
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -22,6 +22,7 @@ import org.apache.ignite.cluster.ClusterNode;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.GridKernalGateway;
 import org.apache.ignite.internal.IgniteProperties;
+import org.apache.ignite.internal.IgniteVersionUtils;
 import org.apache.ignite.internal.managers.discovery.GridDiscoveryManager;
 import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -32,13 +33,10 @@ import org.apache.ignite.testframework.junits.common.GridCommonTest;
 import org.junit.Test;
 import org.mockito.Mockito;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -155,14 +153,20 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
     }
 
     @Test
-    public void testGetUpdates() throws IOException {
+    public void testGetUpdates() throws Exception {
         HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
-        Map<String, Object> props = new HashMap<>();
-        props.put("foo", "bar");
-        props.put("baz", "qux");
+        GridUpdateNotifier notifier = new GridUpdateNotifier(
+            "test-instance",
+                IgniteVersionUtils.VER_STR,
+            Mockito.mock(GridKernalGateway.class),
+            Mockito.mock(GridDiscoveryManager.class),
+            Collections.emptyList(),
+            true,
+            checker
+        );
 
-        String updates = checker.getUpdates(props);
+        String updates = notifier.getUpdates();
 
         assertTrue(updates, updates.startsWith("{\"latest_version\":"));
         assertTrue(updates, updates.contains("\"end_of_life\":{\"date\":null,\"comment\":null}"));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -100,7 +100,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
         GridKernalContext ctx = Mockito.mock(GridKernalContext.class);
         GridDiscoveryManager discovery = Mockito.mock(GridDiscoveryManager.class);
-        List<ClusterNode> srvNodes = Collections.emptyList();
+        List<ClusterNode> srvNodes = Mockito.mock(List.class);
 
         Mockito.when(srvNodes.size()).thenReturn(SERVER_NODES);
         Mockito.when(discovery.serverNodes(Mockito.any(AffinityTopologyVersion.class))).thenReturn(srvNodes);

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -96,10 +96,10 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         // Return current node version and some other info
         Map<String, String> updates = new HashMap<>();
         updates.put("meta", "meta");
-        updates.put("version", nodeVer);
-        updates.put("downloadUrl", "url");
-        updates.put("endOfLifeDate", "2023-10-21");
-        updates.put("endOfLifeComment", "EOL comment");
+        updates.put("latest_version", nodeVer);
+        updates.put("download_url", "url");
+        updates.put("eol_date", "2023-10-21");
+        updates.put("eol_comment", "EOL comment");
 
         Mockito.when(updatesCheckerMock.getUpdates(anyString(), any())).thenReturn(updates);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -153,11 +153,11 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
     @Test
     public void testGetUpdates() throws IOException {
-        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
-        // HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
+        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
         String updates = checker.getUpdates("");
 
-        assertEquals("x", updates);
+        assertTrue(updates, updates.startsWith("{\"latest_version\":"));
+        assertTrue(updates, updates.contains("\"end_of_life\":{\"date\":null,\"comment\":null}"));
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -173,7 +173,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         );
 
         // TODO
-        String updates = notifier.getUpdates().get(0);
+        String updates = notifier.getUpdates().keySet().iterator().next();
 
         assertTrue(updates, updates.startsWith("{\"latest_version\":"));
         assertTrue(updates, updates.contains("\"end_of_life\":{\"date\":null,\"comment\":null}"));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -177,10 +177,10 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
             checker
         );
 
-        // TODO
-        String updates = notifier.getUpdates().keySet().iterator().next();
+        Map<String, String> updates = notifier.getUpdates();
 
-        assertTrue(updates, updates.startsWith("{\"latest_version\":"));
-        assertTrue(updates, updates.contains("\"end_of_life\":{\"date\":null,\"comment\":null}"));
+        assertTrue(updates.containsKey("latest_version"));
+        assertTrue(updates.containsKey("eol_date"));
+        assertTrue(updates.containsKey("eol_comment"));
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -178,6 +180,11 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
         assertEquals("2025-01-31", updates.get("eol_date"));
         assertEquals("test comment text", updates.get("eol_comment"));
+
+        LocalDate eolDate = LocalDate.parse(updates.get("eol_date"), DateTimeFormatter.ISO_DATE);
+        assertEquals(2025, eolDate.getYear());
+        assertEquals(1, eolDate.getMonthValue());
+        assertEquals(31, eolDate.getDayOfMonth());
     }
 
     private static Map<String, String> getUpdates(String ver) throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -89,12 +90,16 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         HttpIgniteUpdatesChecker updatesCheckerMock = Mockito.mock(HttpIgniteUpdatesChecker.class);
 
         // Return current node version and some other info
-        Mockito.when(updatesCheckerMock.getUpdates(any()))
-            .thenReturn("meta=meta" + "\n" + "version=" + nodeVer + "\n" + "downloadUrl=url");
+        List<String> updates = new ArrayList<>();
+        updates.add("meta=meta");
+        updates.add("version=" + nodeVer);
+        updates.add("downloadUrl=url");
+
+        Mockito.when(updatesCheckerMock.getUpdates(any())).thenReturn(updates);
 
         GridKernalContext ctx = Mockito.mock(GridKernalContext.class);
         GridDiscoveryManager discovery = Mockito.mock(GridDiscoveryManager.class);
-        List<ClusterNode> srvNodes = Mockito.mock(List.class);
+        List<ClusterNode> srvNodes = Collections.emptyList();
 
         Mockito.when(srvNodes.size()).thenReturn(SERVER_NODES);
         Mockito.when(discovery.serverNodes(Mockito.any(AffinityTopologyVersion.class))).thenReturn(srvNodes);
@@ -166,7 +171,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
             checker
         );
 
-        String updates = notifier.getUpdates();
+        // TODO
+        String updates = notifier.getUpdates().get(0);
 
         assertTrue(updates, updates.startsWith("{\"latest_version\":"));
         assertTrue(updates, updates.contains("\"end_of_life\":{\"date\":null,\"comment\":null}"));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -34,10 +34,11 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -90,10 +91,10 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         HttpIgniteUpdatesChecker updatesCheckerMock = Mockito.mock(HttpIgniteUpdatesChecker.class);
 
         // Return current node version and some other info
-        List<String> updates = new ArrayList<>();
-        updates.add("meta=meta");
-        updates.add("version=" + nodeVer);
-        updates.add("downloadUrl=url");
+        Map<String, String> updates = new HashMap<>();
+        updates.put("meta", "meta");
+        updates.put("version", nodeVer);
+        updates.put("downloadUrl", "url");
 
         Mockito.when(updatesCheckerMock.getUpdates(any())).thenReturn(updates);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -96,8 +96,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         // Return current node version and some other info
         Map<String, String> updates = new HashMap<>();
         updates.put("meta", "meta");
-        updates.put("latest_version", nodeVer);
-        updates.put("download_url", "url");
+        updates.put("latest_version", "99.88.77");
+        updates.put("download_url", "http://example.com/gg");
         updates.put("eol_date", "2023-10-21");
         updates.put("eol_comment", "EOL comment");
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -20,7 +20,10 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteSystemProperties;
@@ -38,6 +41,7 @@ import org.apache.ignite.testframework.junits.common.GridCommonTest;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.anyString;
 
 /**
@@ -88,7 +92,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         HttpIgniteUpdatesChecker updatesCheckerMock = Mockito.mock(HttpIgniteUpdatesChecker.class);
 
         // Return current node version and some other info
-        Mockito.when(updatesCheckerMock.getUpdates(anyString()))
+        Mockito.when(updatesCheckerMock.getUpdates(any()))
             .thenReturn("meta=meta" + "\n" + "version=" + nodeVer + "\n" + "downloadUrl=url");
 
         GridKernalContext ctx = Mockito.mock(GridKernalContext.class);
@@ -155,7 +159,11 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
     public void testGetUpdates() throws IOException {
         HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
-        String updates = checker.getUpdates("");
+        Map<String, Object> props = new HashMap<>();
+        props.put("foo", "bar");
+        props.put("baz", "qux");
+
+        String updates = checker.getUpdates(props);
 
         assertTrue(updates, updates.startsWith("{\"latest_version\":"));
         assertTrue(updates, updates.contains("\"end_of_life\":{\"date\":null,\"comment\":null}"));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -192,8 +192,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         Map<String, String> updates = notifier.getUpdates();
 
         assertTrue(updates.containsKey("latest_version"));
-        assertTrue(updates.containsKey("eol_date"));
-        assertTrue(updates.containsKey("eol_comment"));
+        assertTrue(updates.containsKey("eol_message"));
 
         return updates;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -153,7 +153,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
     @Test
     public void testGetUpdates() throws IOException {
-        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
+        // https://echo.free.beeceptor.com
+        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
 
         String updates = checker.getUpdates("");
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -166,14 +166,19 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
     public void testGetUpdatesCurrentVersion() throws Exception {
         Map<String, String> updates = getUpdates(IgniteVersionUtils.VER_STR);
 
-        assertNull(updates.get("eol_message"));
+        assertEquals("", updates.get("eol_message"));
     }
 
     @Test
     public void testGetUpdatesOldVersion() throws Exception {
         Map<String, String> updates = getUpdates("8.7.1");
 
-        assertEquals("test comment text", updates.get("eol_message"));
+        assertEquals(
+                "The GridGain 8.7.x End of Life is approaching on 2025-01-31. " +
+                        "Test comment text. " +
+                        "Learn more on the Versioning, Support Lifecycle, and upgrade options: " +
+                        "https://www.gridgain.com/docs/latest/installation-guide/versioning-and-support-lifecycle",
+                updates.get("eol_message"));
     }
 
     private static Map<String, String> getUpdates(String ver) throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -153,8 +153,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
     @Test
     public void testGetUpdates() throws IOException {
-        // https://echo.free.beeceptor.com
         HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
+        // HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
         String updates = checker.getUpdates("");
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -34,8 +34,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.lang.reflect.Field;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -98,8 +96,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
         updates.put("meta", "meta");
         updates.put("latest_version", "99.88.77");
         updates.put("download_url", "http://example.com/gg");
-        updates.put("eol_date", "2023-10-21");
-        updates.put("eol_comment", "EOL comment");
+        updates.put("eol_message", "EOL MESSAGE");
 
         Mockito.when(updatesCheckerMock.getUpdates(anyString(), any())).thenReturn(updates);
 
@@ -137,8 +134,7 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
         ntf.reportStatus(log);
 
-        assertEquals("EOL comment", ntf.endOfLifeComment());
-        assertEquals("2023-10-21", ntf.endOfLifeDate().toString());
+        assertEquals("EOL MESSAGE", ntf.endOfLifeMessage());
     }
 
     /**
@@ -170,21 +166,14 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
     public void testGetUpdatesCurrentVersion() throws Exception {
         Map<String, String> updates = getUpdates(IgniteVersionUtils.VER_STR);
 
-        assertEquals("", updates.get("eol_date"));
-        assertEquals("", updates.get("eol_comment"));
+        assertNull(updates.get("eol_message"));
     }
 
     @Test
     public void testGetUpdatesOldVersion() throws Exception {
         Map<String, String> updates = getUpdates("8.7.1");
 
-        assertEquals("2025-01-31", updates.get("eol_date"));
-        assertEquals("test comment text", updates.get("eol_comment"));
-
-        LocalDate eolDate = LocalDate.parse(updates.get("eol_date"), DateTimeFormatter.ISO_DATE);
-        assertEquals(2025, eolDate.getYear());
-        assertEquals(1, eolDate.getMonthValue());
-        assertEquals(31, eolDate.getDayOfMonth());
+        assertEquals("test comment text", updates.get("eol_message"));
     }
 
     private static Map<String, String> getUpdates(String ver) throws Exception {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -153,8 +153,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
     @Test
     public void testGetUpdates() throws IOException {
-        // HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
-        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
+        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
+        // HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
         String updates = checker.getUpdates("");
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cluster/GridUpdateNotifierSelfTest.java
@@ -153,8 +153,8 @@ public class GridUpdateNotifierSelfTest extends GridCommonAbstractTest {
 
     @Test
     public void testGetUpdates() throws IOException {
-        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
-        // HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
+        // HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker("https://echo.free.beeceptor.com", "UTF-8");
+        HttpIgniteUpdatesChecker checker = new HttpIgniteUpdatesChecker(GridUpdateNotifier.DEFAULT_GRIDGAIN_UPDATES_URL, "UTF-8");
 
         String updates = checker.getUpdates("");
 


### PR DESCRIPTION
* Use new notifier endpoint at https://www.gridgain.com/notifier/update/v2 to get EOL information
* Include EOL info in "new version available" message.

Example log message: 
```
The GridGain 8.7.x End of Life is approaching on 2025-01-31. Learn more on the Versioning, Support Lifecycle, and upgrade options: https://www.gridgain.com/docs/latest/installation-guide/versioning-and-support-lifecycle . New version is available at gridgain.com: 8.7.43
```