### PR TITLE
Wrap array with a String or wrap it with a call of Arrays.toString() 

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IndexStorageImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/IndexStorageImpl.java
@@ -580,7 +580,7 @@ public class IndexStorageImpl implements IndexStorage {
     public static void checkIndexName(byte[] idxName) {
         if (idxName.length > MAX_IDX_NAME_LEN) {
             throw new IllegalArgumentException("Too long encoded indexName [maxAllowed=" + MAX_IDX_NAME_LEN +
-                ", currentLength=" + idxName.length + ", name=" + idxName + "]");
+                ", currentLength=" + idxName.length + ", name=" + new String(idxName) + "]");
         }
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/tracing/messages/SpanContainer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/tracing/messages/SpanContainer.java
@@ -74,7 +74,7 @@ public class SpanContainer implements Serializable {
     /** {@inheritDoc} */
     @Override public String toString() {
         return "SpanContainer{" +
-            "serializedSpanBytes=" + serializedSpanBytes +
+            "serializedSpanBytes=" + new String(serializedSpanBytes) +
             ", span=" + span +
             '}';
     }

--- a/modules/h2/src/main/java/org/gridgain/internal/h2/value/ExtTypeInfoEnum.java
+++ b/modules/h2/src/main/java/org/gridgain/internal/h2/value/ExtTypeInfoEnum.java
@@ -156,7 +156,7 @@ public final class ExtTypeInfoEnum extends ExtTypeInfo {
      */
     public ValueEnum getValue(int ordinal) {
         if (ordinal < 0 || ordinal >= enumerators.length) {
-            throw DbException.get(ErrorCode.ENUM_VALUE_NOT_PERMITTED, enumerators.toString(),
+            throw DbException.get(ErrorCode.ENUM_VALUE_NOT_PERMITTED, Arrays.toString(enumerators),
                     Integer.toString(ordinal));
         }
         return new ValueEnum(this, enumerators[ordinal], ordinal);

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/stat/IgniteStatisticsConfigurationManager.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/stat/IgniteStatisticsConfigurationManager.java
@@ -398,7 +398,7 @@ public class IgniteStatisticsConfigurationManager {
      */
     public void updateStatistics(StatisticsObjectConfiguration... targets) {
         if (log.isDebugEnabled())
-            log.debug("Update statistics [targets=" + targets + ']');
+            log.debug("Update statistics [targets=" + Arrays.toString(targets) + ']');
 
         for (StatisticsObjectConfiguration target : targets) {
 


### PR DESCRIPTION
Wrap array with a String or wrap it with a call of Arrays.toString() in order to see array's content instead of memory address