### PR TITLE
GG-41716 Fix integer overflow in avegare CP write speed calculation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/Checkpointer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/Checkpointer.java
@@ -513,8 +513,6 @@ public class Checkpointer extends GridWorker {
 
             if (chp.hasDelta() || destroyedPartitionsCnt > 0) {
                 if (log.isInfoEnabled()) {
-                    float avgWriteSpeedInBytes = storageCfg.getPageSize() * chp.pagesSize / tracker.totalDurationInSeconds();
-
                     log.info(String.format("Checkpoint finished [cpId=%s, pages=%d, markPos=%s, " +
                             "walSegmentsCovered=%s, markDuration=%dms, pagesWrite=%dms, fsync=%dms, total=%dms, avgWriteSpeed=%sMB/s]",
                         chp.cpEntry != null ? chp.cpEntry.checkpointId() : "",
@@ -525,7 +523,7 @@ public class Checkpointer extends GridWorker {
                         tracker.pagesWriteDuration(),
                         tracker.fsyncDuration(),
                         tracker.totalDuration(),
-                        WriteSpeedFormatter.formatWriteSpeed(avgWriteSpeedInBytes)
+                        WriteSpeedFormatter.calculateAndFormatWriteSpeed(chp.pagesSize, storageCfg.getPageSize(), tracker.totalDurationInSeconds())
                     ));
                 }
             }
@@ -1137,6 +1135,11 @@ public class Checkpointer extends GridWorker {
         /** Constructor */
         private WriteSpeedFormatter() {
             // no-op
+        }
+
+        /** Calculate write speed and return it formatted */
+        public static String calculateAndFormatWriteSpeed(long pages, long pageSize, float durationSeconds) {
+            return formatWriteSpeed(pages * pageSize / durationSeconds);
         }
 
         /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointerTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/persistence/checkpoint/CheckpointerTest.java
@@ -16,10 +16,11 @@
 
 package org.apache.ignite.internal.processors.cache.persistence.checkpoint;
 
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class CheckpointerTest {
 
@@ -38,6 +39,19 @@ public class CheckpointerTest {
         assertEquals("0.88", speedInKb(896));           // 0.875
         assertEquals("0.0625", speedInKb(64));          // 0.0625
         assertEquals("0.0078", speedInKb(8));           // 0.0078125
+    }
+
+    /** Since {@link Checkpoint#pagesSize} and {@link DataStorageConfiguration#getPageSize()} are <code>ints</code>,
+     * <code>cp.pagesSize * ds.pageSize</code> can produce Integer overflow thus leading to incorrect
+     * CP write speed calculation
+      */
+    @Test
+    public void assertNoOverflow() {
+        int pages = Integer.MAX_VALUE / 1024;
+        int pageSize = 4096;
+        float duration = 5.05f;
+
+        assertEquals("1622", Checkpointer.WriteSpeedFormatter.calculateAndFormatWriteSpeed(pages, pageSize, duration));
     }
 
     private static String speedInKb(long kbs) {


### PR DESCRIPTION
(cherry picked from commit 8b6dd4f32afe78ed4d4f21b3bbdcc6fecbe64d00)