### PR TITLE
GG-41844 ODBC: Add timeout logging

### DIFF
--- a/modules/platforms/cpp/network/CMakeLists.txt
+++ b/modules/platforms/cpp/network/CMakeLists.txt
@@ -18,7 +18,7 @@ project(ignite-network)
 
 set(TARGET ${PROJECT_NAME})
 
-find_package(OpenSSL REQUIRED)
+find_package(OpenSSL)
 
 include_directories(include src ${OPENSSL_INCLUDE_DIR})
 

--- a/modules/platforms/cpp/odbc/include/ignite/odbc/type_traits.h
+++ b/modules/platforms/cpp/odbc/include/ignite/odbc/type_traits.h
@@ -27,7 +27,6 @@ namespace ignite
     {
         namespace type_traits
         {
-#ifdef _DEBUG
             /**
              * Convert statement attribute ID to string containing its name.
              * Debug function.
@@ -35,7 +34,6 @@ namespace ignite
              * @return Null-terminated string containing attribute name.
              */
             const char* StatementAttrIdToString(long id);
-#endif //_DEBUG
 
             /** 
              * ODBC type aliases.

--- a/modules/platforms/cpp/odbc/src/connection.cpp
+++ b/modules/platforms/cpp/odbc/src/connection.cpp
@@ -299,6 +299,8 @@ namespace ignite
 
         Connection::OperationResult::T Connection::SendAll(const int8_t* data, size_t len, int32_t timeout)
         {
+            LOG_MSG("Connection level timeout is set to " << timeout << " seconds");
+
             int sent = 0;
 
             while (sent != static_cast<int64_t>(len))
@@ -370,6 +372,8 @@ namespace ignite
         {
             size_t remain = len;
             int8_t* buffer = reinterpret_cast<int8_t*>(dst);
+
+            LOG_MSG("Connection level timeout is set to " << timeout << " seconds");
 
             while (remain)
             {

--- a/modules/platforms/cpp/odbc/src/odbc.cpp
+++ b/modules/platforms/cpp/odbc/src/odbc.cpp
@@ -834,11 +834,9 @@ namespace ignite
 
         LOG_MSG("SQLGetStmtAttr called");
 
-#ifdef _DEBUG
         using odbc::type_traits::StatementAttrIdToString;
 
         LOG_MSG("Attr: " << StatementAttrIdToString(attr) << " (" << attr << ")");
-#endif //_DEBUG
 
         Statement *statement = reinterpret_cast<Statement*>(stmt);
 
@@ -859,11 +857,9 @@ namespace ignite
 
         LOG_MSG("SQLSetStmtAttr called: " << attr);
 
-#ifdef _DEBUG
         using odbc::type_traits::StatementAttrIdToString;
 
         LOG_MSG("Attr: " << StatementAttrIdToString(attr) << " (" << attr << ")");
-#endif //_DEBUG
 
         Statement *statement = reinterpret_cast<Statement*>(stmt);
 

--- a/modules/platforms/cpp/odbc/src/query/batch_query.cpp
+++ b/modules/platforms/cpp/odbc/src/query/batch_query.cpp
@@ -143,6 +143,8 @@ namespace ignite
             {
                 const std::string& schema = connection.GetSchema();
 
+                LOG_MSG("Statement level timeout is set to " << timeout << " seconds");
+
                 QueryExecuteBatchRequest req(schema, sql, params, begin, end, last, timeout, connection.IsAutoCommit());
                 QueryExecuteBatchResponse rsp;
 

--- a/modules/platforms/cpp/odbc/src/query/data_query.cpp
+++ b/modules/platforms/cpp/odbc/src/query/data_query.cpp
@@ -227,6 +227,8 @@ namespace ignite
             {
                 const std::string& schema = connection.GetSchema();
 
+                LOG_MSG("Statement level timeout is set to " << timeout << " seconds");
+
                 QueryExecuteRequest req(schema, sql, params, timeout, connection.IsAutoCommit());
                 QueryExecuteResponse rsp;
 

--- a/modules/platforms/cpp/odbc/src/type_traits.cpp
+++ b/modules/platforms/cpp/odbc/src/type_traits.cpp
@@ -53,8 +53,6 @@ namespace ignite
 
             const std::string SqlTypeName::GUID("GUID");
 
-#ifdef _DEBUG
-
 #define DBG_STR_CASE(x) case x: return #x
 
             const char* StatementAttrIdToString(long id)
@@ -101,7 +99,6 @@ namespace ignite
             }
 
 #undef DBG_STR_CASE
-#endif // _DEBUG
 
             const std::string& BinaryTypeToSqlTypeName(int8_t binaryType)
             {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-41844

- Added logging of timeouts for query execution and any network operation;
- Removed checks for `_DEBUG` for logging, meaning, we now log all the information even in `Release` build;
- Fixed CMake a bit to work with the latest OpenSSL.