### PR TITLE
GG-41944 Add new partition reconciliation algorithms

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/cache/PartitionReconciliation.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/cache/PartitionReconciliation.java
@@ -197,14 +197,12 @@ public class PartitionReconciliation extends AbstractCommand<PartitionReconcilia
 
         // List of server node that do not support partition reconciliation.
         List<GridClientNode> unsupportedSrvNodes = srvNodes.stream()
-            .filter(node -> !node.isClient())
             .filter(node -> !node.supports(IgniteFeatures.PARTITION_RECONCILIATION))
             .collect(Collectors.toList());
 
         List<GridClientNode> unsupportedLatestAlgNodes;
         if (args.repairAlg == LATEST_SKIP_MISSING_PRIMARY || args.repairAlg == LATEST_TRUST_MISSING_PRIMARY) {
             unsupportedLatestAlgNodes = srvNodes.stream()
-                .filter(node -> !node.isClient())
                 .filter(node -> !node.supports(IgniteFeatures.PARTITION_RECONCILIATION_LATEST_ALG_UPDATE))
                 .collect(Collectors.toList());
         }

--- a/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationAbstractTest.java
+++ b/modules/control-utility/src/test/java/org/apache/ignite/util/GridCommandHandlerPartitionReconciliationAbstractTest.java
@@ -220,7 +220,7 @@ public abstract class GridCommandHandlerPartitionReconciliationAbstractTest exte
             invalidDataRowMeta,
             hnd.getLastOperationResult(),
             new PartitionReconciliationRepairMeta(
-                true,
+                false,
                 null,
                 RepairAlgorithm.PRINT_ONLY));
     }
@@ -483,11 +483,11 @@ public abstract class GridCommandHandlerPartitionReconciliationAbstractTest exte
             invalidDataRowMeta,
             hnd.getLastOperationResult(),
             new PartitionReconciliationRepairMeta(
-                true,
+                false,
                 null,
                 RepairAlgorithm.PRINT_ONLY));
 
-        // Enusre that invalid key wasn't fixed.
+        // Ensure that invalid key wasn't fixed.
         assertNull(((IgniteEx)grid(nodes.get(0))).cachex(DEFAULT_CACHE_NAME).localPeek(INVALID_KEY, null));
 
         assertEquals(VALUE_PREFIX + INVALID_KEY,

--- a/modules/core/src/main/java/org/apache/ignite/internal/IgniteFeatures.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/IgniteFeatures.java
@@ -272,7 +272,10 @@ public enum IgniteFeatures {
     POINT_IN_TIME_RECOVERY_EXCHANGELESS_SUPPORT(72),
 
     /** Enables compacted topology history. */
-    TCP_DISCOVERY_COMPACTED_TOPOLOGY_HISTORY(73);
+    TCP_DISCOVERY_COMPACTED_TOPOLOGY_HISTORY(73),
+
+    /** New partition reconciliation algorithms. */
+    PARTITION_RECONCILIATION_LATEST_ALG_UPDATE(74);
 
     /**
      * Unique feature identifier.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairRequestTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairRequestTask.java
@@ -46,7 +46,6 @@ import org.apache.ignite.internal.processors.cache.checker.objects.VersionedKey;
 import org.apache.ignite.internal.processors.cache.checker.objects.VersionedValue;
 import org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm;
 import org.apache.ignite.internal.processors.cache.verify.RepairMeta;
-import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.processors.task.GridInternal;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.resources.IgniteInstanceResource;
@@ -54,8 +53,6 @@ import org.apache.ignite.resources.LoggerResource;
 
 import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.calculateValueToFixWith;
 import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.unmarshalKey;
-import static org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm.LATEST_SKIP_MISSING_PRIMARY;
-import static org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm.PRINT_ONLY;
 
 /**
  * Repairs conflicts based on {@link RepairAlgorithm}.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairRequestTaskV2.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/tasks/RepairRequestTaskV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Copyright 2025 GridGain Systems, Inc. and Contributors.
  *
  * Licensed under the GridGain Community Edition License (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ import org.apache.ignite.internal.processors.cache.checker.objects.VersionedKey;
 import org.apache.ignite.internal.processors.cache.checker.objects.VersionedValue;
 import org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm;
 import org.apache.ignite.internal.processors.cache.verify.RepairMeta;
-import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.processors.task.GridInternal;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.resources.IgniteInstanceResource;
@@ -59,9 +58,11 @@ import static org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm
 
 /**
  * Repairs conflicts based on {@link RepairAlgorithm}.
+ * This task can handle new repair algorithms:
+ * {@link RepairAlgorithm#LATEST_SKIP_MISSING_PRIMARY} and {@link RepairAlgorithm#LATEST_TRUST_MISSING_PRIMARY}.
  */
 @GridInternal
-public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, ExecutionResult<RepairResult>> {
+public class RepairRequestTaskV2 extends ComputeTaskAdapter<RepairRequest, ExecutionResult<RepairResult>> {
     /** */
     private static final long serialVersionUID = 0L;
 
@@ -82,7 +83,9 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
     private RepairRequest repairReq;
 
     /** {@inheritDoc} */
-    @Override public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid, RepairRequest arg) throws IgniteException {
+    @Override public Map<? extends ComputeJob, ClusterNode> map(
+        List<ClusterNode> subgrid, RepairRequest arg
+    ) throws IgniteException {
         repairReq = arg;
 
         IgniteInternalCache<Object, Object> cache = ignite.cachex(repairReq.cacheName());
@@ -172,7 +175,7 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
     }
 
     /** {@inheritDoc} */
-    @Override public ExecutionResult<RepairResult> reduce( List<ComputeJobResult> results) throws IgniteException {
+    @Override public ExecutionResult<RepairResult> reduce(List<ComputeJobResult> results) throws IgniteException {
         RepairResult aggregatedRepairRes = new RepairResult();
 
         for (ComputeJobResult result : results) {
@@ -214,19 +217,19 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
         private final Map<VersionedKey, Map<UUID, VersionedValue>> data;
 
         /** Cache name. */
-        private String cacheName;
+        private final String cacheName;
 
         /** Repair attempt. */
-        private int repairAttempt;
+        private final int repairAttempt;
 
         /** Repair algorithm to use in case of fixing doubtful keys. */
-        private RepairAlgorithm repairAlg;
+        private final RepairAlgorithm repairAlg;
 
         /** Start topology version. */
-        private AffinityTopologyVersion startTopVer;
+        private final AffinityTopologyVersion startTopVer;
 
         /** Partition id. */
-        private int partId;
+        private final int partId;
 
         /**
          * Constructor.
@@ -241,7 +244,7 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
         @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
         public RepairJob(
             Map<VersionedKey, Map<UUID, VersionedValue>> data,
-             String cacheName,
+            String cacheName,
             RepairAlgorithm repairAlg,
             int repairAttempt,
             AffinityTopologyVersion startTopVer,
@@ -267,7 +270,7 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
 
             Map<VersionedKey, RepairMeta> repairedKeys = new HashMap<>();
 
-            GridCacheContext ctx = cache.context();
+            GridCacheContext<Object, Object> ctx = cache.context();
             CacheObjectContext cacheObjCtx = ctx.cacheObjectContext();
 
             final int ownersNodesSize = owners(ctx);
@@ -284,11 +287,16 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
                     CacheObject valToFixWith = null;
 
                     RepairAlgorithm usedRepairAlg = repairAlg;
+                    boolean nextAttemptIsPossible = true;
 
                     // Are there any nodes with missing key?
                     if (dataEntry.getValue().size() != ownersNodesSize && repairAttempt != MAX_REPAIR_ATTEMPTS) {
-                        if (repairAlg == RepairAlgorithm.PRINT_ONLY)
-                            keyWasSuccessfullyFixed = RepairEntryProcessor.RepairStatus.SUCCESS;
+                        if (repairAlg == PRINT_ONLY ||
+                            (repairAlg == LATEST_SKIP_MISSING_PRIMARY && !nodeToVersionedValues.containsKey(primaryUUID))) {
+
+                            keyWasSuccessfullyFixed = RepairEntryProcessor.RepairStatus.FAIL;
+                            nextAttemptIsPossible = false;
+                        }
                         else {
                             valToFixWith = calculateValueToFixWith(
                                 repairAlg,
@@ -359,8 +367,20 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
                         }
                     }
 
-                    if (keyWasSuccessfullyFixed == RepairEntryProcessor.RepairStatus.FAIL)
-                        keysToRepairWithNextAttempt.put(dataEntry.getKey(), dataEntry.getValue());
+                    if (keyWasSuccessfullyFixed == RepairEntryProcessor.RepairStatus.FAIL) {
+                        if (nextAttemptIsPossible)
+                            keysToRepairWithNextAttempt.put(dataEntry.getKey(), dataEntry.getValue());
+                        else {
+                            repairedKeys.put(
+                                dataEntry.getKey(),
+                                new RepairMeta(
+                                    false,
+                                    valToFixWith,
+                                    usedRepairAlg,
+                                    dataEntry.getValue()
+                                ));
+                        }
+                    }
                     else {
                         repairedKeys.put(
                             dataEntry.getKey(),
@@ -382,23 +402,37 @@ public class RepairRequestTask extends ComputeTaskAdapter<RepairRequest, Executi
         }
 
         /**
+         * Returns primary node identifier for the given {@code key}.
          *
+         * @param ctx Cache context.
+         * @param key Key to get primary node identifier.
+         * @return Primary node identifier.
          */
-        protected UUID primaryNodeId(GridCacheContext ctx, Object key) {
+        protected UUID primaryNodeId(GridCacheContext<?, ?> ctx, Object key) {
             return ctx.affinity().nodesByKey(key, startTopVer).get(0).id();
         }
 
         /**
+         * Returns number of owners for the partition.
          *
+         * @param ctx Cache context.
+         * @return Number of owners for the partition.
          */
-        protected int owners(GridCacheContext ctx) {
+        protected int owners(GridCacheContext<?, ?> ctx) {
             return ctx.topology().owners(partId, startTopVer).size();
         }
 
         /**
+         * Returns unmarshalled values of the {@code key}.
          *
+         * @param ctx Cache context.
+         * @param key Key to unmarshal.
+         * @return Unmarshalled value of the key.
          */
-        protected Object keyValue(GridCacheContext ctx, KeyCacheObject key) throws IgniteCheckedException {
+        protected Object keyValue(
+            GridCacheContext<Object, Object> ctx,
+            KeyCacheObject key
+        ) throws IgniteCheckedException {
             KeyCacheObject unmarshalledKey = unmarshalKey(key, ctx);
 
             if (unmarshalledKey instanceof KeyCacheObjectImpl)

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationRepairMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationRepairMeta.java
@@ -105,8 +105,9 @@ public class PartitionReconciliationRepairMeta extends IgniteDataTransferObject 
      * @return string view.
      */
     public String stringView(boolean verbose) {
-        return "fixed=" + fixed + ", new_val=" + (val != null ? val.stringView(verbose) : "null") +
-            ", repairAlg=" + repairAlg;
+        return "fixed=" + fixed
+            + (fixed ? ", new_val=" + (val != null ? val.stringView(verbose) : "null") : "")
+            + ", repairAlg=" + repairAlg;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationValueMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationValueMeta.java
@@ -86,7 +86,7 @@ public class PartitionReconciliationValueMeta extends IgniteDataTransferObject {
             strView + " hex=[" + U.byteArray2HexString(binaryView) + "]" + (ver != null ? " ver=[topVer=" +
                 ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : "") :
             HIDDEN_DATA + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() +
-                ", nodeOrder=" + ver.nodeOrder() : "") + ']';
+                ", nodeOrder=" + ver.nodeOrder() + ']' : "");
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/RepairAlgorithm.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/RepairAlgorithm.java
@@ -36,7 +36,19 @@ public enum RepairAlgorithm {
     REMOVE,
 
     /** Nicht repair, only printing. */
-    PRINT_ONLY;
+    PRINT_ONLY,
+
+    /**
+     * This algorithm behaves in the same way as {@link #LATEST} except the case when a key is missing
+     * on the primary node. In that case, the conflict will not be resolved.
+     */
+    LATEST_SKIP_MISSING_PRIMARY,
+
+    /**
+     * This algorithm behaves in the same way as {@link #LATEST} except the case when a key is missing
+     * on the primary node. In that case, the conflict will be resolved by removing the key from all partitions.
+     */
+    LATEST_TRUST_MISSING_PRIMARY;
 
     /** Enumerated values. */
     private static final RepairAlgorithm[] VALS = values();
@@ -52,10 +64,25 @@ public enum RepairAlgorithm {
     }
 
     /**
+     * Efficiently gets enumerated value from its string representation ignoring case.
+     *
+     * @param str String representation.
+     * @return Enumerated value.
+     * @throws IllegalArgumentException If string representation is not valid.
+     */
+    public static RepairAlgorithm fromString(String str) {
+        for (RepairAlgorithm val : VALS) {
+            if (val.name().equalsIgnoreCase(str))
+                return val;
+        }
+
+        throw new IllegalArgumentException("Invalid repair algorithm [name=" + str + ']');
+    }
+
+    /**
      * @return Default repair algorithm.
      */
     public static RepairAlgorithm defaultValue() {
         return PRINT_ONLY;
     }
-
 }

--- a/modules/core/src/main/resources/META-INF/classnames.properties
+++ b/modules/core/src/main/resources/META-INF/classnames.properties
@@ -755,6 +755,8 @@ org.apache.ignite.internal.processors.cache.checker.tasks.ReconciliationResource
 org.apache.ignite.internal.processors.cache.checker.tasks.RepairEntryProcessor$RepairStatus
 org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTask
 org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTask$RepairJob
+org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTaskV2
+org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTaskV2$RepairJob
 org.apache.ignite.internal.processors.cache.datastructures.CacheDataStructuresManager$BlockSetCallable
 org.apache.ignite.internal.processors.cache.datastructures.CacheDataStructuresManager$QueueHeaderPredicate
 org.apache.ignite.internal.processors.cache.datastructures.CacheDataStructuresManager$RemoveSetDataCallable

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAbstractTest.java
@@ -18,6 +18,7 @@ package org.apache.ignite.internal.processors.cache.checker.processor;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
@@ -122,7 +123,7 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
         return res
             .partitionReconciliationResult()
             .inconsistentKeys()
-            .get(cacheName)
+            .getOrDefault(cacheName, Collections.emptyMap())
             .values()
             .stream()
             .flatMap(Collection::stream)

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAbstractTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAbstractTest.java
@@ -77,9 +77,7 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
         return partitionReconciliation(ig, repair, repairAlgorithm, parallelism, 1000, caches);
     }
 
-    /**
-     *
-     */
+    /** */
     public static ReconciliationResult partitionReconciliation(
         Ignite ig,
         VisorPartitionReconciliationTaskArg.Builder argBuilder
@@ -97,23 +95,12 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
         );
     }
 
-    /**
-     *
-     */
+    /** */
     public static Set<Integer> conflictKeys(ReconciliationResult res, String cacheName) {
-        return res.partitionReconciliationResult().inconsistentKeys().get(cacheName)
-            .values()
-            .stream()
-            .flatMap(Collection::stream)
-            .map(PartitionReconciliationDataRowMeta::keyMeta)
-            .map(k -> (String)U.field(k, "strView"))
-            .map(Integer::valueOf)
-            .collect(Collectors.toSet());
+        return conflictKeys(res, cacheName, Integer::valueOf);
     }
 
-    /**
-     *
-     */
+    /** */
     public static <T> Set<T> conflictKeys(ReconciliationResult res, String cacheName, Function<String, T> map) {
         return res.partitionReconciliationResult().inconsistentKeys().get(cacheName)
             .values()
@@ -125,9 +112,28 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
             .collect(Collectors.toSet());
     }
 
-    /**
-     *
-     */
+    /** */
+    public static Set<Integer> notFixedKeys(ReconciliationResult res, String cacheName) {
+        return notFixedKeys(res, cacheName, Integer::valueOf);
+    }
+
+    /** */
+    public static <T> Set<T> notFixedKeys(ReconciliationResult res, String cacheName, Function<String, T> map) {
+        return res
+            .partitionReconciliationResult()
+            .inconsistentKeys()
+            .get(cacheName)
+            .values()
+            .stream()
+            .flatMap(Collection::stream)
+            .filter(dataRow -> !dataRow.repairMeta().fixed())
+            .map(PartitionReconciliationDataRowMeta::keyMeta)
+            .map(k -> (String)U.field(k, "strView"))
+            .map(map)
+            .collect(Collectors.toSet());
+    }
+
+    /** */
     public static Set<PartitionReconciliationKeyMeta> conflictKeyMetas(ReconciliationResult res, String cacheName) {
         return res.partitionReconciliationResult().inconsistentKeys().get(cacheName)
             .values()
@@ -137,9 +143,7 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
             .collect(Collectors.toSet());
     }
 
-    /**
-     *
-     */
+    /** */
     public static void assertResultContainsConflictKeys(
         ReconciliationResult res,
         String cacheName,
@@ -149,9 +153,7 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
             assertTrue("Key doesn't contain: " + key, conflictKeys(res, cacheName).contains(key));
     }
 
-    /**
-     *
-     */
+    /** */
     public static <T> void assertResultContainsConflictKeys(
         ReconciliationResult res,
         String cacheName,
@@ -162,24 +164,18 @@ public class PartitionReconciliationAbstractTest extends GridCommonAbstractTest 
             assertTrue("Key doesn't contain: " + key, conflictKeys(res, cacheName, map).contains(key));
     }
 
-    /**
-     *
-     */
+    /** */
     public static void simulateOutdatedVersionCorruption(GridCacheContext<?, ?> ctx, Object key) {
         simulateOutdatedVersionCorruption(ctx, key, false);
     }
 
-    /**
-     *
-     */
+    /** */
     public static void simulateOutdatedVersionCorruption(GridCacheContext<?, ?> ctx, Object key, boolean lockEntry) {
         corruptDataEntry(ctx, key, false, true,
             new GridCacheVersion(0, 0, 0L), "_broken", lockEntry);
     }
 
-    /**
-     *
-     */
+    /** */
     public static void simulateMissingEntryCorruption(GridCacheContext<?, ?> ctx, Object key) {
         GridCacheAdapter<Object, Object> cache = (GridCacheAdapter<Object, Object>)ctx.cache();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAtomicLongStressTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationAtomicLongStressTest.java
@@ -58,7 +58,7 @@ public class PartitionReconciliationAtomicLongStressTest extends PartitionReconc
     protected static final String INTERNAL_CACHE_NAME = "ignite-sys-atomic-cache@default-ds-group";
 
     /** Patten to search integer key for data structure key string representation. */
-    protected static final Pattern intKeyPattern = Pattern.compile("name=(\\d+)");
+    protected static final Pattern intKeyPattern = Pattern.compile(".+name=(\\d+).+");
 
     /** Parts. */
     @Parameterized.Parameter(0)
@@ -217,7 +217,7 @@ public class PartitionReconciliationAtomicLongStressTest extends PartitionReconc
     /** */
     protected Integer keyMap(String keyStr) {
         Matcher m = intKeyPattern.matcher(keyStr);
-        if (m.find())
+        if (m.matches())
             return Integer.parseInt(m.group(1));
         return -1;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationFullFixStressTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationFullFixStressTest.java
@@ -28,7 +28,6 @@ import org.apache.ignite.cache.CacheAtomicityMode;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.processors.cache.GridCacheContext;
 import org.apache.ignite.internal.processors.cache.checker.objects.ReconciliationResult;
-import org.apache.ignite.internal.processors.cache.verify.IdleVerifyResultV2;
 import org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.Test;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationStressTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationStressTest.java
@@ -174,13 +174,8 @@ public class PartitionReconciliationStressTest extends PartitionReconciliationAb
         return params;
     }
 
-    /**
-     * Test #37 Stress test for reconciliation under load
-     *
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testReconciliationOfColdKeysUnderLoad() throws Exception {
+    /** */
+    protected ReconciliationUnderLoadResult reconciliationOfColdKeysUnderLoad() throws Exception {
         IgniteCache<Integer, String> clientCache = client.cache(DEFAULT_CACHE_NAME);
 
         Set<Integer> correctKeys = new HashSet<>();
@@ -201,6 +196,7 @@ public class PartitionReconciliationStressTest extends PartitionReconciliationAb
 
         Set<Integer> corruptedColdKeys = new HashSet<>();
         Set<Integer> corruptedHotKeys = new HashSet<>();
+        Set<Integer> missedKeysOnPrimary = new HashSet<>();
 
         for (int i = firstBrokenKey; i < firstBrokenKey + BROKEN_KEYS_CNT; i++) {
             if (isHotKey(i))
@@ -210,10 +206,17 @@ public class PartitionReconciliationStressTest extends PartitionReconciliationAb
 
             correctKeys.remove(i);
 
-            if (i % 3 == 0)
-                simulateMissingEntryCorruption(nodeCacheCtxs[i % NODES_CNT], i);
+            GridCacheContext<Object, Object> ctx = nodeCacheCtxs[i % NODES_CNT];
+
+            if (i % 3 == 0) {
+                simulateMissingEntryCorruption(ctx, i);
+
+                if (ctx.cache().cache().affinity().isPrimary(ctx.kernalContext().discovery().localNode(), i)) {
+                    missedKeysOnPrimary.add(i);
+                }
+            }
             else
-                simulateOutdatedVersionCorruption(nodeCacheCtxs[i % NODES_CNT], i);
+                simulateOutdatedVersionCorruption(ctx, i);
         }
 
         log.info(">>>> Simulating data corruption finished");
@@ -243,6 +246,18 @@ public class PartitionReconciliationStressTest extends PartitionReconciliationAb
 
         for (Integer correctKey : correctKeys)
             assertFalse("Correct key detected as broken: " + correctKey, conflictKeys.contains(correctKey));
+
+        return new ReconciliationUnderLoadResult(res, missedKeysOnPrimary);
+    }
+
+    /**
+     * Test #37 Stress test for reconciliation under load
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testReconciliationOfColdKeysUnderLoad() throws Exception {
+        reconciliationOfColdKeysUnderLoad();
     }
 
     /**
@@ -250,5 +265,15 @@ public class PartitionReconciliationStressTest extends PartitionReconciliationAb
      */
     protected static boolean isHotKey(int key) {
         return key % 13 == 5 || key % 13 == 7 || key % 13 == 11;
+    }
+
+    static class ReconciliationUnderLoadResult {
+        final ReconciliationResult reconciliationResult;
+        final Set<Integer> missedOnPrimaryKeys;
+
+        ReconciliationUnderLoadResult(ReconciliationResult res, Set<Integer> missedOnPrimaryKeys) {
+            this.reconciliationResult = res;
+            this.missedOnPrimaryKeys = missedOnPrimaryKeys;
+        }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationStressTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationStressTest.java
@@ -269,6 +269,7 @@ public class PartitionReconciliationStressTest extends PartitionReconciliationAb
 
     static class ReconciliationUnderLoadResult {
         final ReconciliationResult reconciliationResult;
+
         final Set<Integer> missedOnPrimaryKeys;
 
         ReconciliationUnderLoadResult(ReconciliationResult res, Set<Integer> missedOnPrimaryKeys) {

--- a/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
+++ b/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
@@ -27,7 +27,7 @@ Arguments: --cache help --yes
       --fast-check         - This option allows checking and repairing only partitions that did not pass validation during the last partition map exchange, otherwise, all partitions will be taken into account.
       --parallelism        - Maximum number of threads that can be involved in partition reconciliation activities on one node. Default value equals number of cores.
       --include-sensitive  - Print data to result with sensitive information: keys and values. Default value is false.
-      --repair             - If present, fix all inconsistent data. Specifies which repair algorithm to use for doubtful keys. The following values can be used: [LATEST, PRIMARY, MAJORITY, REMOVE, PRINT_ONLY]. Default value is PRINT_ONLY.
+      --repair             - If present, fix all inconsistent data. Specifies which repair algorithm to use for doubtful keys. The following values can be used: [LATEST, PRIMARY, MAJORITY, REMOVE, PRINT_ONLY, LATEST_SKIP_MISSING_PRIMARY, LATEST_TRUST_MISSING_PRIMARY]. Default value is PRINT_ONLY.
       --batch-size         - Amount of keys to retrieve within one job. Default value is 1000.
       --recheck-attempts   - Amount of potentially inconsistent keys recheck attempts. Value between 1 (inclusive) and 5 (exclusive) should be used. Default value is 2.
 


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-41944

This patch introduces two new algorithms that can be used by the partition reconciliation tool:
- **latest_skip_missing_primary**: This algorithm behaves like LATEST, except that it does not resolve conflicts when the key is missing on the primary node.
- **latest_trust_missing_primary**: This algorithm behaves like LATEST, except that if a key is missing on the primary node, that key will be removed from all backup nodes.

**Implementation details**:
The most significant changes are:
 - [ConsistencyCheckUtils#calculateValueToFixWith](https://github.com/gridgain/gridgain/pull/3399/files#diff-5f89324184c39f9ac894fc143095605497bfbb5e5345a8bc510da0daeae960fdR185) added support of the new algorithms
 - [RepairRequestTaskV2](https://github.com/gridgain/gridgain/pull/3399/files#diff-16a5278dc2523652bc5823be9e6734687928ab90e529f39d5996b5c7a956bebcR65) new task was added due to compatibility reasons. The difference between the previous version of the task and the new one is that support for new algorithms has been added. Also, a bug has been fixed where the `PRINT_ONLY` algorithm erroneously marked a conflict as fixed, even if it was not resolved.