### PR TITLE
GG-41098 C++ Remove unnecessary allocation

### DIFF
--- a/modules/platforms/cpp/binary/include/ignite/impl/binary/binary_reader_impl.h
+++ b/modules/platforms/cpp/binary/include/ignite/impl/binary/binary_reader_impl.h
@@ -853,8 +853,8 @@ namespace ignite
                         elemRead = 0;
                     }
 
-                    key = ReadTopObject<K>();
-                    val = ReadTopObject<V>();
+                    ReadTopObject<K>(key);
+                    ReadTopObject<V>(val);
                 }
 
                 /**


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-41098

Removed unnecessary allocations in `BinaryMapReader::GetNext`