### PR TITLE
GG-41778 Register local metadata during startup on a node with enabled persistence

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/GridCacheProcessor.java
@@ -5507,6 +5507,8 @@ public class GridCacheProcessor extends GridProcessorAdapter {
             CacheJoinNodeDiscoveryData data = locCfgMgr.restoreCacheConfigurations();
 
             cachesInfo.onStart(data);
+
+            ctx.query().registerMetadataForRegisteredCaches(false);
         }
 
         /** {@inheritDoc} */

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/CacheRegisterMetadataLocallyTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/CacheRegisterMetadataLocallyTest.java
@@ -49,7 +49,7 @@ import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
 /**
- * Tests, that binary metadata is registered correctly during the start without extra request to grid.
+ * Tests that binary metadata is registered correctly during the start without extra request to grid.
  */
 public class CacheRegisterMetadataLocallyTest extends GridCommonAbstractTest {
     /** */
@@ -69,8 +69,8 @@ public class CacheRegisterMetadataLocallyTest extends GridCommonAbstractTest {
 
     /** {@inheritDoc} */
     @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
-        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
-            cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName)
+            .setDataStorageConfiguration(new DataStorageConfiguration()
                 .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
                     .setPersistenceEnabled(persistenceEnabled())));
 

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/CacheRegisterMetadataLocallyWithPersistenceTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/CacheRegisterMetadataLocallyWithPersistenceTest.java
@@ -17,7 +17,7 @@
 package org.apache.ignite.internal.processors.cache;
 
 /**
- * Tests, that binary metadata is registered correctly during the start without extra request to grid.
+ * Tests that binary metadata is registered correctly during the start without extra request to grid.
  */
 public class CacheRegisterMetadataLocallyWithPersistenceTest extends CacheRegisterMetadataLocallyTest {
     /** {@inheritDoc} */

--- a/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/CacheRegisterMetadataLocallyWithPersistenceTest.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/internal/processors/cache/CacheRegisterMetadataLocallyWithPersistenceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache;
+
+/**
+ * Tests, that binary metadata is registered correctly during the start without extra request to grid.
+ */
+public class CacheRegisterMetadataLocallyWithPersistenceTest extends CacheRegisterMetadataLocallyTest {
+    /** {@inheritDoc} */
+    @Override protected boolean persistenceEnabled() {
+        return true;
+    }
+}

--- a/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
+++ b/modules/indexing/src/test/java/org/apache/ignite/testsuites/IgniteCacheWithIndexingTestSuite.java
@@ -29,6 +29,7 @@ import org.apache.ignite.internal.processors.cache.CacheQueryAfterDynamicCacheSt
 import org.apache.ignite.internal.processors.cache.CacheQueryFilterExpiredTest;
 import org.apache.ignite.internal.processors.cache.CacheRandomOperationsMultithreadedTest;
 import org.apache.ignite.internal.processors.cache.CacheRegisterMetadataLocallyTest;
+import org.apache.ignite.internal.processors.cache.CacheRegisterMetadataLocallyWithPersistenceTest;
 import org.apache.ignite.internal.processors.cache.ClientReconnectAfterClusterRestartTest;
 import org.apache.ignite.internal.processors.cache.ClusterReadOnlyModeDoesNotBreakSqlSelectTest;
 import org.apache.ignite.internal.processors.cache.ClusterReadOnlyModeSqlTest;
@@ -96,6 +97,7 @@ import org.junit.runners.Suite;
     CacheQueryAfterDynamicCacheStartFailureTest.class,
 
     CacheRegisterMetadataLocallyTest.class,
+    CacheRegisterMetadataLocallyWithPersistenceTest.class,
 
     IgniteCacheGroupsSqlTest.class,
 


### PR DESCRIPTION
**Issue**:

During persistence-enabled node startup, we miss the local registration of metadata for the types specified in QueryEntity for statically configured caches. Because at the moment when we try to register metadata, there are no registered caches.

**Fix description**:

For a node with persistence enabled, an additional call to register metadata has been added after registering cache descriptors (GridCacheProcessor -> CacheRecoveryLifecycle -> onReadyForRead)