### PR TITLE
GG-44928 Improved eviction logs

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridDhtLocalPartition.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/distributed/dht/topology/GridDhtLocalPartition.java
@@ -1045,6 +1045,8 @@ public class GridDhtLocalPartition extends GridCacheConcurrentMapImpl implements
                         null,
                         false);
                 }
+
+                return cleared;
             }
         }
         catch (GridDhtInvalidPartitionException ignored) {


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-44928

The logs were updated as follows:
`Eviction in progress [groups=N, totalPartsToEvict=NN, totalPartsEvictInProgress=YY, totalPartsToEvictInQueue=ZZ]`
where 
 - `groups` - the number of cache groups that currently require eviction
 - `totalPartsToEvict` - the number of partitions to be evicted
 - `totalPartsEvictInProgress` - the number of partitions currently being evicted
 - `totalPartsToEvictInQueue` - the number of partitions waiting for eviction
 
 `Group eviction in progress [grpName=abc, grpId=123, remainingPartsToEvict=NN, partsEvictInProgress=YY, localParts=ZZ]`
 where
  - `grpName` - the unique cache group name
  - `grpId` - the unique chahe group identifier
  - `remainingPartsToEvict` - the number of partitions that are waiting for eviction
  - `partsEvictInProgress` - the number of partitions currently being evicted
  - `localParts` - the total number of partitions that are owned by his node
