### PR TITLE
GG-41695 .NET: Fix node crash in consoleWrite callback

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConsoleStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConsoleStream.java
@@ -21,6 +21,8 @@ import org.apache.ignite.internal.processors.platform.callback.PlatformCallbackG
 import java.io.IOException;
 import java.io.OutputStream;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * Stream that writes to the .NET console.
  */
@@ -40,7 +42,7 @@ public class PlatformDotNetConsoleStream extends OutputStream {
     /** {@inheritDoc} */
     @Override public void write(byte[] b, int off, int len) throws IOException {
         try {
-            String s = new String(b, off, len);
+            String s = new String(b, off, len, UTF_8);
 
             PlatformCallbackGateway.consoleWrite(s, isErr);
         } catch (Throwable ignored) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConsoleStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConsoleStream.java
@@ -39,6 +39,7 @@ public class PlatformDotNetConsoleStream extends OutputStream {
 
     /** {@inheritDoc} */
     @Override public void write(byte[] b, int off, int len) throws IOException {
+        // TODO: wrong encoding? Debug this. Should we pass bytes to dotnet instead of string?
         String s = new String(b, off, len);
 
         PlatformCallbackGateway.consoleWrite(s, isErr);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConsoleStream.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/platform/dotnet/PlatformDotNetConsoleStream.java
@@ -39,16 +39,23 @@ public class PlatformDotNetConsoleStream extends OutputStream {
 
     /** {@inheritDoc} */
     @Override public void write(byte[] b, int off, int len) throws IOException {
-        // TODO: wrong encoding? Debug this. Should we pass bytes to dotnet instead of string?
-        String s = new String(b, off, len);
+        try {
+            String s = new String(b, off, len);
 
-        PlatformCallbackGateway.consoleWrite(s, isErr);
+            PlatformCallbackGateway.consoleWrite(s, isErr);
+        } catch (Throwable ignored) {
+            // Ignore. Printing to the console should not crash the node.
+        }
     }
 
     /** {@inheritDoc} */
     @Override public void write(int b) throws IOException {
-        String s = String.valueOf((char) b);
+        try {
+            String s = String.valueOf((char) b);
 
-        PlatformCallbackGateway.consoleWrite(s, isErr);
+            PlatformCallbackGateway.consoleWrite(s, isErr);
+        } catch (Throwable ignored) {
+            // Ignore. Printing to the console should not crash the node.
+        }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Apache.Ignite.BenchmarkDotNet.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.BenchmarkDotNet/Apache.Ignite.BenchmarkDotNet.csproj
@@ -17,6 +17,10 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+
+    <!-- Explicit overrides to fix vulnerable transitive deps. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Apache.Ignite.Core.Tests.DotNetCore.csproj
@@ -36,6 +36,10 @@
     <ProjectReference Include="..\Apache.Ignite.Core\Apache.Ignite.Core.csproj" />
     <ProjectReference Include="..\Apache.Ignite.Linq\Apache.Ignite.Linq.csproj" />
     <ProjectReference Include="..\Apache.Ignite\Apache.Ignite.DotNetCore.csproj" />
+
+    <!-- Explicit overrides to fix vulnerable transitive deps. -->
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ConsoleRedirectTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ConsoleRedirectTest.cs
@@ -101,12 +101,14 @@ namespace Apache.Ignite.Core.Tests
         /// Tests the exception in console writer.
         /// </summary>
         [Test]
-        public void TestExceptionInWriterPropagatesToJavaAndBack()
+        public void TestExceptionInWriterIsIgnoredInJava()
         {
             MyStringWriter.Throw = true;
 
-            var ex = Assert.Throws<IgniteException>(() => Ignition.Start(TestUtils.GetTestConfiguration()));
-            Assert.AreEqual("foo", ex.Message);
+            using (var ignite = Ignition.Start(TestUtils.GetTestConfiguration()))
+            {
+                ignite.GetCacheNames();
+            }
         }
 
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Callbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Callbacks.cs
@@ -288,7 +288,6 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             }
             catch (Exception e)
             {
-                // TODO: ignore, don't crash? Or do it on Java side?
                 _jvm.AttachCurrentThread(envPtr).ThrowToJava(e);
             }
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Callbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Callbacks.cs
@@ -274,7 +274,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             {
                 if (message != IntPtr.Zero)
                 {
-                    // Each domain registers its own writer.
+                    // Each domain registers it's own writer.
                     var writer = _consoleWriters.Select(x => x.Value).FirstOrDefault();
 
                     if (writer != null)

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Callbacks.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Unmanaged/Jni/Callbacks.cs
@@ -274,7 +274,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             {
                 if (message != IntPtr.Zero)
                 {
-                    // Each domain registers it's own writer.
+                    // Each domain registers its own writer.
                     var writer = _consoleWriters.Select(x => x.Value).FirstOrDefault();
 
                     if (writer != null)
@@ -288,6 +288,7 @@ namespace Apache.Ignite.Core.Impl.Unmanaged.Jni
             }
             catch (Exception e)
             {
+                // TODO: ignore, don't crash? Or do it on Java side?
                 _jvm.AttachCurrentThread(envPtr).ThrowToJava(e);
             }
         }


### PR DESCRIPTION
* Handle exceptions in `PlatformDotNetConsoleStream`
* Use UTF8 explicitly
* Fix build warnings in tests and benchmarks