### PR TITLE
GG-45607 C++: Fix warnings on newer compiler versions

### DIFF
--- a/modules/platforms/cpp/common/include/ignite/common/bits.h
+++ b/modules/platforms/cpp/common/include/ignite/common/bits.h
@@ -121,13 +121,13 @@ namespace ignite
             IGNITE_IMPORT_EXPORT int32_t BitLengthU32(uint32_t i);
 
             /**
-             * Calcutale capasity for required size.
+             * Calculate capacity for the required size.
              * Rounds up to the nearest power of two.
              *
-             * @param size Needed capasity.
-             * @return Recomended capasity to allocate.
+             * @param size Needed capacity.
+             * @return Recommended capacity to allocate.
              */
-            IGNITE_IMPORT_EXPORT int32_t GetCapasityForSize(int32_t size);
+            IGNITE_IMPORT_EXPORT int32_t GetCapacityForSize(int32_t size);
 
             /**
              * Get the number of decimal digits of the integer value.

--- a/modules/platforms/cpp/common/include/ignite/common/concurrent.h
+++ b/modules/platforms/cpp/common/include/ignite/common/concurrent.h
@@ -128,8 +128,11 @@ namespace ignite
                 // No-op.
             }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuse-after-free"
+#ifndef _MSC_VER
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wuse-after-free"
+#endif // _MSC_VER
+
             /**
              * Shared pointer.
              */
@@ -344,7 +347,10 @@ namespace ignite
                 /** Implementation. */
                 SharedPointerImpl* impl;
             };
-#pragma GCC diagnostic pop
+
+#ifndef _MSC_VER
+#   pragma GCC diagnostic pop
+#endif // _MSC_VER
 
             /**
              * Enables static-cast semantics for SharedPointer.

--- a/modules/platforms/cpp/common/include/ignite/common/concurrent.h
+++ b/modules/platforms/cpp/common/include/ignite/common/concurrent.h
@@ -258,6 +258,8 @@ namespace ignite
                     return *this;
                 }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuse-after-free"
                 /**
                  * Destructor.
                  */
@@ -278,6 +280,7 @@ namespace ignite
                     ptr = 0;
                     impl = 0;
                 }
+#pragma GCC diagnostic pop
 
                 /**
                  * Get raw pointer.
@@ -396,9 +399,9 @@ namespace ignite
                 }
 
                 /**
-                 * Create shared pointer for this instance.
+                 * Create a shared pointer for this instance.
                  *
-                 * Can only be called on already shared object.
+                 * Can only be called on an already shared object.
                  * @return New shared pointer instance.
                  */
                 SharedPointer<T> SharedFromThis()

--- a/modules/platforms/cpp/common/include/ignite/common/concurrent.h
+++ b/modules/platforms/cpp/common/include/ignite/common/concurrent.h
@@ -128,6 +128,8 @@ namespace ignite
                 // No-op.
             }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wuse-after-free"
             /**
              * Shared pointer.
              */
@@ -258,8 +260,6 @@ namespace ignite
                     return *this;
                 }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wuse-after-free"
                 /**
                  * Destructor.
                  */
@@ -280,7 +280,6 @@ namespace ignite
                     ptr = 0;
                     impl = 0;
                 }
-#pragma GCC diagnostic pop
 
                 /**
                  * Get raw pointer.
@@ -345,6 +344,7 @@ namespace ignite
                 /** Implementation. */
                 SharedPointerImpl* impl;
             };
+#pragma GCC diagnostic pop
 
             /**
              * Enables static-cast semantics for SharedPointer.

--- a/modules/platforms/cpp/common/include/ignite/common/concurrent.h
+++ b/modules/platforms/cpp/common/include/ignite/common/concurrent.h
@@ -273,9 +273,10 @@ namespace ignite
                         deleter(ptr0);
 
                         delete impl;
-
-                        ptr = 0;
                     }
+
+                    ptr = 0;
+                    impl = 0;
                 }
 
                 /**

--- a/modules/platforms/cpp/common/include/ignite/common/dynamic_size_array.h
+++ b/modules/platforms/cpp/common/include/ignite/common/dynamic_size_array.h
@@ -249,7 +249,7 @@ namespace ignite
              *
              * @return Array capacity.
              */
-            SizeType Getcapacity() const
+            SizeType GetCapacity() const
             {
                 return capacity;
             }

--- a/modules/platforms/cpp/common/include/ignite/common/dynamic_size_array.h
+++ b/modules/platforms/cpp/common/include/ignite/common/dynamic_size_array.h
@@ -415,6 +415,7 @@ namespace ignite
 
                 alloc.Deallocate(data, capacity);
                 capacity = 0;
+                data = 0;
             }
 
             /** Allocator */

--- a/modules/platforms/cpp/common/include/ignite/common/dynamic_size_array.h
+++ b/modules/platforms/cpp/common/include/ignite/common/dynamic_size_array.h
@@ -150,6 +150,11 @@ namespace ignite
              */
             void Assign(ConstPointerType src, SizeType len)
             {
+                if (len == 0) {
+                    Clear();
+                    return;
+                }
+
                 assert(src);
 
                 if (data == src) {

--- a/modules/platforms/cpp/common/include/ignite/common/shared_state.h
+++ b/modules/platforms/cpp/common/include/ignite/common/shared_state.h
@@ -377,7 +377,7 @@ namespace ignite
         };
 
         /**
-         * Specialization for shared pointer type.
+         * Specialization for a shared pointer type.
          */
         template<typename T>
         class SharedState< concurrent::SharedPointer<T> >

--- a/modules/platforms/cpp/common/include/ignite/future.h
+++ b/modules/platforms/cpp/common/include/ignite/future.h
@@ -24,7 +24,6 @@
 #define _IGNITE_FUTURE
 
 #include <ignite/common/shared_state.h>
-#include <ignite/ignite_error.h>
 
 namespace ignite
 {
@@ -42,7 +41,7 @@ namespace ignite
      */
 
     /**
-     * Future class template. Used to get result of the asynchroniously
+     * Future class template. Used to get result of the asynchronously
      * started computation.
      *
      * @tparam T Future value type.

--- a/modules/platforms/cpp/common/src/common/bits.cpp
+++ b/modules/platforms/cpp/common/src/common/bits.cpp
@@ -178,7 +178,7 @@ namespace ignite
                 return 32 - NumberOfLeadingZerosU32(i);
             }
 
-            int32_t GetCapasityForSize(int32_t size)
+            int32_t GetCapacityForSize(int32_t size)
             {
                 assert(size > 0);
 

--- a/modules/platforms/cpp/core-test/src/dynamic_size_array_test.cpp
+++ b/modules/platforms/cpp/core-test/src/dynamic_size_array_test.cpp
@@ -201,12 +201,12 @@ BOOST_AUTO_TEST_CASE(ReserveMore)
 
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
-    int32_t capasity = test.GetCapacity();
+    int32_t capacity = test.GetCapacity();
 
-    test.Reserve(capasity + 1);
+    test.Reserve(capacity + 1);
 
-    BOOST_CHECK(test.GetCapacity() > capasity);
-    BOOST_CHECK(test.GetCapacity() >= capasity + 1);
+    BOOST_CHECK(test.GetCapacity() > capacity);
+    BOOST_CHECK(test.GetCapacity() >= capacity + 1);
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
     BOOST_CHECK_EQUAL(test[0].one, 3);
@@ -231,11 +231,11 @@ BOOST_AUTO_TEST_CASE(ReserveLess)
 
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
-    int32_t capasity = test.GetCapacity();
+    int32_t capacity = test.GetCapacity();
 
-    test.Reserve(capasity - 1);
+    test.Reserve(capacity - 1);
 
-    BOOST_CHECK(test.GetCapacity() == capasity);
+    BOOST_CHECK(test.GetCapacity() == capacity);
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
     BOOST_CHECK_EQUAL(test[0].one, 3);

--- a/modules/platforms/cpp/core-test/src/dynamic_size_array_test.cpp
+++ b/modules/platforms/cpp/core-test/src/dynamic_size_array_test.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(BasicConstruction)
     DynamicSizeArray<int> test(16);
 
     BOOST_CHECK_EQUAL(test.GetSize(), 0);
-    BOOST_CHECK(test.GetCapasity() >= 16);
+    BOOST_CHECK(test.GetCapacity() >= 16);
 }
 
 BOOST_AUTO_TEST_CASE(ResizeInt)
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(PushBack)
     test.PushBack(88);
 
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
-    BOOST_CHECK(test.GetCapasity() >= 4);
+    BOOST_CHECK(test.GetCapacity() >= 4);
 
     BOOST_CHECK_EQUAL(test[0], 1);
     BOOST_CHECK_EQUAL(test[1], 2);
@@ -201,12 +201,12 @@ BOOST_AUTO_TEST_CASE(ReserveMore)
 
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
-    int32_t capasity = test.GetCapasity();
+    int32_t capasity = test.GetCapacity();
 
     test.Reserve(capasity + 1);
 
-    BOOST_CHECK(test.GetCapasity() > capasity);
-    BOOST_CHECK(test.GetCapasity() >= capasity + 1);
+    BOOST_CHECK(test.GetCapacity() > capasity);
+    BOOST_CHECK(test.GetCapacity() >= capasity + 1);
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
     BOOST_CHECK_EQUAL(test[0].one, 3);
@@ -231,11 +231,11 @@ BOOST_AUTO_TEST_CASE(ReserveLess)
 
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
-    int32_t capasity = test.GetCapasity();
+    int32_t capasity = test.GetCapacity();
 
     test.Reserve(capasity - 1);
 
-    BOOST_CHECK(test.GetCapasity() == capasity);
+    BOOST_CHECK(test.GetCapacity() == capasity);
     BOOST_CHECK_EQUAL(test.GetSize(), 4);
 
     BOOST_CHECK_EQUAL(test[0].one, 3);

--- a/modules/platforms/cpp/core-test/src/future_test.cpp
+++ b/modules/platforms/cpp/core-test/src/future_test.cpp
@@ -23,7 +23,7 @@ using namespace ignite;
 using namespace ignite::common;
 
 /**
- * Utility to make auto pointer from value.
+ * Utility to make an auto pointer from value.
  *
  * @param val Value.
  * @return Auto pointer.


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-45607

Done:
- Fixed clear deallocation and re-assigning logic in `DynamicSizeArray`;
- Disabled warnings for SharedPointer (false positives);
- Fixed some minor documentation and grammar issues.