### PR TITLE
GG-45652 Fix maxConnectionsPerNode to reject connections before resource allocation

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
@@ -645,6 +645,7 @@ public abstract class GridClientConnectionManagerAdapter implements GridClientCo
         private NioListener(Logger log) {
             this.log = log;
         }
+
         /** {@inheritDoc} */
         @Override public void onConnectedRaw(Socket socket) {
             // No-op.

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
@@ -646,8 +646,8 @@ public abstract class GridClientConnectionManagerAdapter implements GridClientCo
             this.log = log;
         }
 
-        /** {@inheritDoc} */
-        @Override public void onConnectedRaw(Socket socket) {
+        @Override
+        public void onConnectedSocket(Socket socket, int sessionNum) {
             // No-op.
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
@@ -18,6 +18,7 @@ package org.apache.ignite.internal.client.impl.connection;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -643,6 +644,10 @@ public abstract class GridClientConnectionManagerAdapter implements GridClientCo
          */
         private NioListener(Logger log) {
             this.log = log;
+        }
+        /** {@inheritDoc} */
+        @Override public void onConnectedRaw(Socket socket) {
+            // No-op.
         }
 
         /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/impl/connection/GridClientConnectionManagerAdapter.java
@@ -646,8 +646,7 @@ public abstract class GridClientConnectionManagerAdapter implements GridClientCo
             this.log = log;
         }
 
-        @Override
-        public void onConnectedSocket(Socket socket, int sessionNum) {
+        @Override public void onConnectedSocket(Socket socket, int sessionNum) {
             // No-op.
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/router/impl/GridTcpRouterNioListenerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/router/impl/GridTcpRouterNioListenerAdapter.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.internal.client.router.impl;
 
+import java.net.Socket;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -106,6 +107,11 @@ public abstract class GridTcpRouterNioListenerAdapter implements GridNioServerLi
     /**
      */
     protected abstract void init();
+
+    /** {@inheritDoc} */
+    @Override public void onConnectedRaw(Socket socket) {
+        // No-op.
+    }
 
     /** {@inheritDoc} */
     @Override public void onConnected(GridNioSession ses) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/router/impl/GridTcpRouterNioListenerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/router/impl/GridTcpRouterNioListenerAdapter.java
@@ -109,7 +109,7 @@ public abstract class GridTcpRouterNioListenerAdapter implements GridNioServerLi
     protected abstract void init();
 
     /** {@inheritDoc} */
-    @Override public void onConnectedRaw(Socket socket) {
+    @Override public void onConnectedSocket(Socket socket, int sessionNum) {
         // No-op.
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientListener.java
@@ -29,7 +29,7 @@ import org.jetbrains.annotations.Nullable;
  */
 class GridNioClientListener implements GridNioServerListener<ByteBuffer> {
     /** {@inheritDoc} */
-    @Override public void onConnectedRaw(Socket socket) {
+    @Override public void onConnectedSocket(Socket socket, int sessionNum) {
         // No-op.
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/client/thin/io/gridnioserver/GridNioClientListener.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.internal.client.thin.io.gridnioserver;
 
+import java.net.Socket;
 import java.nio.ByteBuffer;
 
 import org.apache.ignite.failure.FailureType;
@@ -27,6 +28,11 @@ import org.jetbrains.annotations.Nullable;
  * Client event listener.
  */
 class GridNioClientListener implements GridNioServerListener<ByteBuffer> {
+    /** {@inheritDoc} */
+    @Override public void onConnectedRaw(Socket socket) {
+        // No-op.
+    }
+
     /** {@inheritDoc} */
     @Override public void onConnected(GridNioSession ses) {
         // No-op.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioListener.java
@@ -159,8 +159,7 @@ public class ClientListenerNioListener extends GridNioServerListenerAdapter<Clie
             String msg = "Connection is rejected due to connection limit is reached [addr=" +
                     socket.getInetAddress() + ", limit=" + maxConn + ']';
 
-            if (log.isDebugEnabled())
-                log.debug(msg);
+            log.warning(msg);
 
             throw new IgniteException(msg);
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerNioListener.java
@@ -156,7 +156,13 @@ public class ClientListenerNioListener extends GridNioServerListenerAdapter<Clie
     @Override public void onConnectedRaw(Socket socket) {
         int maxConn = distrThinCfg.maxConnectionsPerNode();
         if (maxConn > 0 && connectionsCnt.get() >= maxConn) {
-            throw new IgniteException("Connection limit reached: " + maxConn);
+            String msg = "Connection is rejected due to connection limit is reached [addr=" +
+                    socket.getInetAddress() + ", limit=" + maxConn + ']';
+
+            if (log.isDebugEnabled())
+                log.debug(msg);
+
+            throw new IgniteException(msg);
         }
     }
 
@@ -167,13 +173,6 @@ public class ClientListenerNioListener extends GridNioServerListenerAdapter<Clie
         // It means connection was already processed.
         if (connState != null)
             return;
-
-        int maxConn = distrThinCfg.maxConnectionsPerNode();
-        if (maxConn > 0 && connectionsCnt.get() >= maxConn) {
-            ses.close();
-
-            return;
-        }
 
         ses.addMeta(CONN_STATE_META_KEY, CONN_STATE_PHYSICAL_CONNECTED);
         connectionsCnt.incrementAndGet();

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
@@ -2714,7 +2714,7 @@ public class GridNioServer<T> {
                     lsnr.onConnectedRaw(sock);
                 }
                 catch (IgniteException err) {
-                    sock.shutdownInput();
+                    U.close(sock, log);
 
                     fut.onDone(err);
                     return;

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
@@ -2710,6 +2710,16 @@ public class GridNioServer<T> {
             Socket sock = sockCh.socket();
 
             try {
+                try {
+                    lsnr.onConnectedRaw(sock);
+                }
+                catch (IgniteException err) {
+                    sock.close();
+
+                    fut.onDone(err);
+                    return;
+                }
+
                 ByteBuffer writeBuf = null;
                 ByteBuffer readBuf = null;
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
@@ -2711,7 +2711,7 @@ public class GridNioServer<T> {
 
             try {
                 try {
-                    lsnr.onConnectedRaw(sock);
+                    lsnr.onConnectedSocket(sock, sessions.size());
                 }
                 catch (IgniteException err) {
                     U.close(sock, log);

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServer.java
@@ -2714,7 +2714,7 @@ public class GridNioServer<T> {
                     lsnr.onConnectedRaw(sock);
                 }
                 catch (IgniteException err) {
-                    sock.close();
+                    sock.shutdownInput();
 
                     fut.onDone(err);
                     return;

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListener.java
@@ -26,11 +26,12 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface GridNioServerListener<T> extends EventListener {
     /**
-     * This method is called whenever a new client is connected but before a session is created.
+     * This method is called whenever a new connection is accepted but before a session is created.
      *
      * @param socket The socket for remote client.
+     * @param sessionNum The number of the current sessions.
      */
-    public void onConnectedRaw(Socket socket);
+    public void onConnectedSocket(Socket socket, int sessionNum);
 
     /**
      * This method is called whenever a new client is connected and session is created.

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListener.java
@@ -26,7 +26,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public interface GridNioServerListener<T> extends EventListener {
     /**
-     * This method is called whenever a new client is but before a session is created.
+     * This method is called whenever a new client is connected but before a session is created.
      *
      * @param socket The socket for remote client.
      */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListener.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListener.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.internal.util.nio;
 
+import java.net.Socket;
 import java.util.EventListener;
 import org.apache.ignite.failure.FailureType;
 import org.jetbrains.annotations.Nullable;
@@ -24,6 +25,13 @@ import org.jetbrains.annotations.Nullable;
  * Listener passed in to the {@link GridNioServer} that will be notified on client events.
  */
 public interface GridNioServerListener<T> extends EventListener {
+    /**
+     * This method is called whenever a new client is but before a session is created.
+     *
+     * @param socket The socket for remote client.
+     */
+    public void onConnectedRaw(Socket socket);
+
     /**
      * This method is called whenever a new client is connected and session is created.
      *

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListenerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListenerAdapter.java
@@ -25,7 +25,8 @@ import java.net.Socket;
  */
 public abstract class GridNioServerListenerAdapter<T> implements GridNioServerListener<T> {
     /** {@inheritDoc} */
-    @Override public void onConnectedRaw(Socket socket) {
+    @Override public void onConnectedSocket(Socket socket, int sessionNum) {
+        // No-op.
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListenerAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/util/nio/GridNioServerListenerAdapter.java
@@ -18,10 +18,16 @@ package org.apache.ignite.internal.util.nio;
 
 import org.apache.ignite.failure.FailureType;
 
+import java.net.Socket;
+
 /**
  * Server listener adapter providing empty methods implementation for rarely used methods.
  */
 public abstract class GridNioServerListenerAdapter<T> implements GridNioServerListener<T> {
+    /** {@inheritDoc} */
+    @Override public void onConnectedRaw(Socket socket) {
+    }
+
     /** {@inheritDoc} */
     @Override public void onSessionWriteTimeout(GridNioSession ses) {
         // No-op.

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ConnectionLimitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ConnectionLimitTest.java
@@ -58,7 +58,7 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "Connection limit reached: " + MAX_CONNECTIONS);
+                        "connection was closed");
             }
             finally {
                 clients.forEach(IgniteClient::close);
@@ -84,14 +84,14 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "Connection limit reached: " + MAX_CONNECTIONS);
+                        "connection was closed");
 
                 mxBean.setMaxConnectionsPerNode(MAX_CONNECTIONS - 2);
 
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "Connection limit reached: " + (MAX_CONNECTIONS - 2));
+                        "connection was closed");
             }
             finally {
                 clients.forEach(IgniteClient::close);
@@ -117,7 +117,7 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "Connection limit reached: " + MAX_CONNECTIONS);
+                        "connection was closed");
 
                 mxBean.setMaxConnectionsPerNode(MAX_CONNECTIONS + 2);
 
@@ -128,7 +128,7 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "Connection limit reached: " + (MAX_CONNECTIONS + 2));
+                        "connection was closed");
             }
             finally {
                 clients.forEach(IgniteClient::close);
@@ -173,7 +173,11 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
             List<IgniteClient> clients = new ArrayList<>();
             try {
                 for (int i = 0; i < connectionLimit; ++i) {
-                    clients.add(startClient(ignite));
+                    IgniteClient client = startClient(ignite);
+
+                    // Just checking that the client is functioning
+                    client.cluster().forRandom().node();
+                    clients.add(client);
                 }
             }
             finally {

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ConnectionLimitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ConnectionLimitTest.java
@@ -58,7 +58,7 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "connection was closed");
+                        "Channel is closed");
             }
             finally {
                 clients.forEach(IgniteClient::close);
@@ -84,14 +84,14 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "connection was closed");
+                        "Channel is closed");
 
                 mxBean.setMaxConnectionsPerNode(MAX_CONNECTIONS - 2);
 
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "connection was closed");
+                        "Channel is closed");
             }
             finally {
                 clients.forEach(IgniteClient::close);
@@ -117,7 +117,7 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "connection was closed");
+                        "Channel is closed");
 
                 mxBean.setMaxConnectionsPerNode(MAX_CONNECTIONS + 2);
 
@@ -128,7 +128,7 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                 GridTestUtils.assertThrows(log(),
                         () -> startClient(0),
                         ClientConnectionException.class,
-                        "connection was closed");
+                        "Channel is closed");
             }
             finally {
                 clients.forEach(IgniteClient::close);

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ConnectionLimitTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/ConnectionLimitTest.java
@@ -19,11 +19,15 @@ package org.apache.ignite.internal.client.thin;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.client.ClientConnectionException;
 import org.apache.ignite.client.IgniteClient;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.configuration.ClientConnectorConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.processors.odbc.ClientListenerProcessor;
 import org.apache.ignite.mxbean.ClientProcessorMXBean;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.junit.Test;
 
+import java.net.Socket;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -125,6 +129,52 @@ public class ConnectionLimitTest extends AbstractThinClientTest {
                         () -> startClient(0),
                         ClientConnectionException.class,
                         "Connection limit reached: " + (MAX_CONNECTIONS + 2));
+            }
+            finally {
+                clients.forEach(IgniteClient::close);
+            }
+        }
+    }
+
+    /** */
+    @Test
+    public void testIdleConnectionsRejectedOnLimitReached() throws Exception {
+        IgniteConfiguration cfg = getConfiguration();
+        ClientConnectorConfiguration connectorCfg = cfg.getClientConnectorConfiguration();
+        connectorCfg.setIdleTimeout(0);
+        connectorCfg.setHandshakeTimeout(0);
+        connectorCfg.setSocketReceiveBufferSize(4 * 1024 * 1024);
+        connectorCfg.setSocketSendBufferSize(4 * 1024 * 1024);
+        cfg.setClientConnectorConfiguration(new ClientConnectorConfiguration(connectorCfg));
+
+        try (Ignite ignite = startGrid(cfg)) {
+            ClientProcessorMXBean mxBean = getMxBean(ignite.name(), "Clients",
+                    ClientProcessorMXBean.class, ClientListenerProcessor.class);
+
+            int socketNum = 10_000;
+            int connectionLimit = 10;
+
+            mxBean.setMaxConnectionsPerNode(connectionLimit);
+
+            ClusterNode node = ignite.cluster().localNode();
+            List<Socket> conns = new ArrayList<>();
+            try {
+                for (int i = 0; i < socketNum; ++i) {
+                    conns.add(new Socket(clientHost(node), clientPort(node)));
+                }
+            }
+            finally {
+                for (Socket conn : conns) {
+                    conn.close();
+                }
+            }
+
+            // Now check that we still can connect 10 clients
+            List<IgniteClient> clients = new ArrayList<>();
+            try {
+                for (int i = 0; i < connectionLimit; ++i) {
+                    clients.add(startClient(ignite));
+                }
             }
             finally {
                 clients.forEach(IgniteClient::close);

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/events/FakeIgniteServer.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/events/FakeIgniteServer.java
@@ -18,6 +18,7 @@ package org.apache.ignite.internal.client.thin.events;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.EnumSet;
@@ -124,6 +125,11 @@ public class FakeIgniteServer extends JUnitAssertAware implements GridNioServerL
     /** */
     public void stop() {
         srv.stop();
+    }
+
+    /** {@inheritDoc} */
+    @Override public void onConnectedRaw(Socket socket) {
+
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/internal/client/thin/events/FakeIgniteServer.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/client/thin/events/FakeIgniteServer.java
@@ -128,7 +128,7 @@ public class FakeIgniteServer extends JUnitAssertAware implements GridNioServerL
     }
 
     /** {@inheritDoc} */
-    @Override public void onConnectedRaw(Socket socket) {
+    @Override public void onConnectedSocket(Socket socket, int sessionNum) {
 
     }
 


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-45652

- Added a test to show the issue;
- Added a new method to `GridNioServerListener` to be able to reject new connections before buffers are allocated;
- Fixed the rejection logic in `ClientListenerNioListener`.