### PR TITLE
GG-41947 Partition reconciliation provides descriptive output when includeSensitive flag is enabled

### DIFF
--- a/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/cache/argument/PartitionReconciliationCommandArg.java
+++ b/modules/control-utility/src/main/java/org/apache/ignite/internal/commandline/cache/argument/PartitionReconciliationCommandArg.java
@@ -23,6 +23,7 @@ import org.apache.ignite.internal.commandline.argument.CommandArg;
 import org.apache.ignite.internal.commandline.cache.CacheSubcommands;
 import org.apache.ignite.internal.processors.cache.verify.PartitionReconciliationRepairMeta;
 import org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm;
+import org.apache.ignite.internal.processors.cache.verify.SensitiveMode;
 
 /**
  * {@link CacheSubcommands#PARTITION_RECONCILIATION} command arguments.
@@ -44,6 +45,9 @@ public enum PartitionReconciliationCommandArg implements CommandArg {
 
     /** If {@code true} - print data to result with sensitive information: keys and values. */
     INCLUDE_SENSITIVE("--include-sensitive", Boolean.FALSE),
+
+    /** Defines a sensitive mode to print keys and values. */
+    SENSITIVE_MODE("--sensitive-mode", SensitiveMode.DEFAULT),
 
     /** Maximum number of threads that can be involved in reconciliation activities. */
     PARALLELISM("--parallelism", 0),

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryEnumObjectImpl.java
@@ -16,6 +16,11 @@
 
 package org.apache.ignite.internal.binary;
 
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.binary.BinaryObject;
@@ -35,12 +40,6 @@ import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.plugin.extensions.communication.MessageReader;
 import org.apache.ignite.plugin.extensions.communication.MessageWriter;
 import org.jetbrains.annotations.Nullable;
-
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
-import java.nio.ByteBuffer;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.ignite.internal.processors.cache.CacheObjectAdapter.objectPutSize;
@@ -272,7 +271,7 @@ public class BinaryEnumObjectImpl implements BinaryObjectEx, Externalizable, Cac
     }
 
     /** {@inheritDoc} */
-    @Override public String getString() {
+    @Override public String deserializedRepresentation() {
         // 1. Try deserializing the object.
         try {
             Object val = deserialize();
@@ -303,10 +302,12 @@ public class BinaryEnumObjectImpl implements BinaryObjectEx, Externalizable, Cac
 
     /** {@inheritDoc} */
     @Override public String toString() {
-        GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging = S.getSensitiveDataLogging();
+        return toString(S.getSensitiveDataLogging());
+    }
 
+    @Override public String toString(GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging) {
         if (sensitiveDataLogging == PLAIN) {
-            return getString();
+            return deserializedRepresentation();
         }
         if (sensitiveDataLogging == HASH)
             return String.valueOf(IgniteUtils.hash(this));

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectEx.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectEx.java
@@ -19,6 +19,7 @@ package org.apache.ignite.internal.binary;
 import org.apache.ignite.binary.BinaryObject;
 import org.apache.ignite.binary.BinaryObjectException;
 import org.apache.ignite.binary.BinaryType;
+import org.apache.ignite.internal.util.tostring.GridToStringBuilder;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -47,7 +48,27 @@ public interface BinaryObjectEx extends BinaryObject {
     public boolean isFlagSet(short flag);
 
     /**
-     * @return String representation of holding object or {@code null} if inapplicable.
+     * Returns a string representation of deserialized underlying object.
+     * This method may return {@code null} if the underlying object cannot be deserialized for some reason.
+     *
+     * @return String representation of the underlying object.
      */
-    @Nullable public String getString();
+    @Nullable String deserializedRepresentation();
+
+    /**
+     * Returns a string representation of this binary object.
+     * This method is equivalent to {@code toString(GridToStringBuilder.getSensitiveDataLogging()}.
+     *
+     * @return String representation of this binary object.
+     */
+    @Override String toString();
+
+    /**
+     * Returns a string representation of this binary object based on the provided sensitive data logging flag.
+     *
+     * @param sensitiveDataLogging Sensitive data logging flag.
+     * @return String representation of this binary object.
+     * @see GridToStringBuilder.SensitiveDataLogging
+     */
+    @Nullable String toString(GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging);
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectExImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectExImpl.java
@@ -193,7 +193,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
     }
 
     /** {@inheritDoc} */
-    @Override public String getString() {
+    @Override public String deserializedRepresentation() {
         try {
             return deserialize().toString();
         } catch (IgniteException ex) {
@@ -203,15 +203,18 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
 
     /** {@inheritDoc} */
     @Override public String toString() {
-        GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging = S.getSensitiveDataLogging();
+        return toString(S.getSensitiveDataLogging());
+    }
 
+    /** {@inheritDoc} */
+    @Override public String toString(GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging) {
         if (sensitiveDataLogging == PLAIN) {
             try {
                 BinaryReaderHandles ctx = new BinaryReaderHandles();
 
                 ctx.put(start(), this);
 
-                return toString(ctx, new IdentityHashMap<BinaryObject, Integer>());
+                return toString(ctx, new IdentityHashMap<BinaryObject, Integer>(), sensitiveDataLogging);
             } catch (BinaryObjectException e) {
                 throw new IgniteException("Failed to create string representation of binary object.", e);
             }
@@ -225,9 +228,14 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
     /**
      * @param ctx Reader context.
      * @param handles Handles for already traversed objects.
+     * @param sensitiveDataLogging Sensitive data logging flag.
      * @return String representation.
      */
-    private String toString(BinaryReaderHandles ctx, IdentityHashMap<BinaryObject, Integer> handles) {
+    private String toString(
+        BinaryReaderHandles ctx,
+        IdentityHashMap<BinaryObject, Integer> handles,
+        GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging
+    ) {
         int idHash = System.identityHashCode(this);
         int hash = hashCode();
 
@@ -245,7 +253,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
             IgniteThread.onForbidBinaryMetadataRequestSectionLeft();
         }
 
-        if (meta == null || !S.includeSensitive())
+        if (meta == null || sensitiveDataLogging != PLAIN)
             return S.toString(S.includeSensitive() ? BinaryObject.class.getSimpleName() : "BinaryObject",
                 "idHash", idHash, false,
                 "hash", hash, false,
@@ -263,7 +271,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
 
                 buf.a(", ").a(name).a('=');
 
-                appendValue(val, buf, ctx, handles);
+                appendValue(val, buf, ctx, handles, sensitiveDataLogging);
             }
 
             buf.a(']');
@@ -294,9 +302,15 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
      * @param buf Buffer to append to.
      * @param ctx Reader context.
      * @param handles Handles for already traversed objects.
+     * @param sensitiveDataLogging Sensitive data logging flag.
      */
-    private void appendValue(Object val, SB buf, BinaryReaderHandles ctx,
-        IdentityHashMap<BinaryObject, Integer> handles) {
+    private void appendValue(
+        Object val,
+        SB buf,
+        BinaryReaderHandles ctx,
+        IdentityHashMap<BinaryObject, Integer> handles,
+        GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging
+    ) {
         if (val instanceof byte[])
             buf.a(Arrays.toString((byte[])val));
         else if (val instanceof short[])
@@ -330,7 +344,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
                 buf.a(meta0.typeName()).a(" [hash=").a(idHash0).a(", ...]");
             }
             else
-                buf.a(po.toString(ctx, handles));
+                buf.a(po.toString(ctx, handles, sensitiveDataLogging));
         }
         else if (val instanceof Object[]) {
             Object[] arr = (Object[])val;
@@ -340,7 +354,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
             for (int i = 0; i < arr.length; i++) {
                 Object o = arr[i];
 
-                appendValue(o, buf, ctx, handles);
+                appendValue(o, buf, ctx, handles, sensitiveDataLogging);
 
                 if (i < arr.length - 1)
                     buf.a(", ");
@@ -356,7 +370,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
             while (it.hasNext()) {
                 Object o = it.next();
 
-                appendValue(o, buf, ctx, handles);
+                appendValue(o, buf, ctx, handles, sensitiveDataLogging);
 
                 if (it.hasNext())
                     buf.a(", ");
@@ -374,11 +388,11 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
             while (it.hasNext()) {
                 Map.Entry<Object, Object> e = it.next();
 
-                appendValue(e.getKey(), buf, ctx, handles);
+                appendValue(e.getKey(), buf, ctx, handles, sensitiveDataLogging);
 
                 buf.a('=');
 
-                appendValue(e.getValue(), buf, ctx, handles);
+                appendValue(e.getValue(), buf, ctx, handles, sensitiveDataLogging);
 
                 if (it.hasNext())
                     buf.a(", ");

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectExImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectExImpl.java
@@ -254,7 +254,7 @@ public abstract class BinaryObjectExImpl implements BinaryObjectEx {
         }
 
         if (meta == null || sensitiveDataLogging != PLAIN)
-            return S.toString(S.includeSensitive() ? BinaryObject.class.getSimpleName() : "BinaryObject",
+            return S.toString(sensitiveDataLogging == PLAIN ? BinaryObject.class.getSimpleName() : "BinaryObject",
                 "idHash", idHash, false,
                 "hash", hash, false,
                 "typeId", typeId(), true);

--- a/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/binary/BinaryObjectImpl.java
@@ -44,7 +44,6 @@ import org.apache.ignite.internal.processors.cache.compress.EntryCompressionStra
 import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.tostring.GridToStringBuilder;
 import org.apache.ignite.internal.util.typedef.F;
-import org.apache.ignite.internal.util.typedef.internal.S;
 import org.apache.ignite.internal.util.typedef.internal.U;
 import org.apache.ignite.plugin.extensions.communication.MessageReader;
 import org.apache.ignite.plugin.extensions.communication.MessageWriter;
@@ -1020,14 +1019,12 @@ public final class BinaryObjectImpl extends BinaryObjectExImpl implements Extern
     }
 
     /** {@inheritDoc} */
-    @Override public String toString() {
-        GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging = S.getSensitiveDataLogging();
-
+    @Override public String toString(GridToStringBuilder.SensitiveDataLogging sensitiveDataLogging) {
         if (sensitiveDataLogging == PLAIN) {
             if (arr == null || ctx == null)
                 return "BinaryObjectImpl [arr=" + (arr != null) + ", ctx=" + (ctx != null) + ", start=" + start + "]";
 
-            return super.toString();
+            return super.toString(sensitiveDataLogging);
         }
         else if (sensitiveDataLogging == HASH)
             return String.valueOf(IgniteUtils.hash(this));

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessor.java
@@ -60,6 +60,7 @@ import org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTa
 import org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTaskV2;
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtLocalPartition;
 import org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm;
+import org.apache.ignite.internal.processors.cache.verify.SensitiveMode;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.processors.diagnostic.ReconciliationExecutionContext.ReconciliationStatisticsUpdateListener;
 import org.apache.ignite.internal.util.typedef.internal.CU;
@@ -172,6 +173,7 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
      * @param recheckDelay Specifies the time interval between two consequent attempts to check keys.
      * @param compact {@code true} if the result should be returned in compact form.
      * @param includeSensitive {@code true} if sensitive information should be included in the result.
+     * @param sensitiveMode Sensitive mode.
      */
     @SuppressWarnings("AssignmentOrReturnOfFieldWithMutableType")
     public PartitionReconciliationProcessor(
@@ -186,7 +188,8 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
         int recheckAttempts,
         int recheckDelay,
         boolean compact,
-        boolean includeSensitive
+        boolean includeSensitive,
+        SensitiveMode sensitiveMode
     ) throws IgniteCheckedException {
         super(sesId, ignite, parallelismLevel);
 
@@ -201,8 +204,8 @@ public class PartitionReconciliationProcessor extends AbstractPipelineProcessor 
         registerListener(workloadTracker.andThen(evtLsnr));
 
         collector = (compact) ?
-            new ReconciliationResultCollector.Compact(ignite, log, sesId, includeSensitive) :
-            new ReconciliationResultCollector.Simple(ignite, log, includeSensitive);
+            new ReconciliationResultCollector.Compact(ignite, log, sesId, includeSensitive, sensitiveMode) :
+            new ReconciliationResultCollector.Simple(ignite, log, includeSensitive, sensitiveMode);
 
         boolean latestAlgSupported = allNodesSupport(
             ctx,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/processor/ReconciliationResultCollector.java
@@ -733,7 +733,6 @@ public interface ReconciliationResultCollector {
             String fileName = tmpFiles.computeIfAbsent(cacheName, d -> {
                 File file = new File(reconciliationDir.getPath() + separatorChar + maskId + '-' + sesId + '-' + cacheName + ".txt");
                 try {
-                    // TODO handle a returned value
                     file.createNewFile();
                 }
                 catch (IOException e) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/util/ConsistencyCheckUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/util/ConsistencyCheckUtils.java
@@ -421,8 +421,8 @@ public class ConsistencyCheckUtils {
             objToString = obj.value(ctx, false);
 
         if (objToString instanceof BinaryObjectEx)
-            return ((BinaryObjectEx)obj).toString(sensitiveDataLogging);
+            return ((BinaryObjectEx)objToString).toString(sensitiveDataLogging);
 
-        return Objects.toString(obj);
+        return Objects.toString(objToString);
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/util/ConsistencyCheckUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/checker/util/ConsistencyCheckUtils.java
@@ -393,13 +393,13 @@ public class ConsistencyCheckUtils {
         File dir = new File(U.defaultWorkDirectory() + separatorChar + RECONCILIATION_DIR);
 
         if (!dir.exists())
-            dir.mkdir(); // TODO
+            dir.mkdir();
 
         File file = new File(dir.getPath() + separatorChar + maskId + "_" + startTime.format(TIME_FORMATTER) +
             ".txt");
 
         if (!file.exists())
-            file.createNewFile(); // TODO
+            file.createNewFile();
 
         return file;
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationValueMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationValueMeta.java
@@ -82,12 +82,11 @@ public class PartitionReconciliationValueMeta extends IgniteDataTransferObject {
      * @return string view.
      */
     public String stringView(boolean verbose) {
-        return "value_meta[verbose=" + verbose + "] " + (verbose ?
-            strView
-//                + " hex=[" + U.byteArray2HexString(binaryView) + "]"
-                + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : "") :
-            HIDDEN_DATA
-                + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : ""));
+        return verbose ?
+            strView + " hex=[" + U.byteArray2HexString(binaryView) + "]" + (ver != null ? " ver=[topVer=" +
+                ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : "") :
+            HIDDEN_DATA + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() +
+                ", nodeOrder=" + ver.nodeOrder() + ']' : "");
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationValueMeta.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/PartitionReconciliationValueMeta.java
@@ -82,11 +82,12 @@ public class PartitionReconciliationValueMeta extends IgniteDataTransferObject {
      * @return string view.
      */
     public String stringView(boolean verbose) {
-        return verbose ?
-            strView + " hex=[" + U.byteArray2HexString(binaryView) + "]" + (ver != null ? " ver=[topVer=" +
-                ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : "") :
-            HIDDEN_DATA + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() +
-                ", nodeOrder=" + ver.nodeOrder() + ']' : "");
+        return "value_meta[verbose=" + verbose + "] " + (verbose ?
+            strView
+//                + " hex=[" + U.byteArray2HexString(binaryView) + "]"
+                + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : "") :
+            HIDDEN_DATA
+                + (ver != null ? " ver=[topVer=" + ver.topologyVersion() + ", order=" + ver.order() + ", nodeOrder=" + ver.nodeOrder() + ']' : ""));
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/SensitiveMode.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/SensitiveMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ * Copyright 2025 GridGain Systems, Inc. and Contributors.
  *
  * Licensed under the GridGain Community Edition License (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/SensitiveMode.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/SensitiveMode.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.verify;
+
+import org.apache.ignite.IgniteSystemProperties;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This enum defines possible modes of printing sensitive information provided by the partition reconciliation tool.
+ */
+public enum SensitiveMode {
+    /**
+     * This mode provides the same level as defined in the cluster.
+     * @see IgniteSystemProperties#IGNITE_SENSITIVE_DATA_LOGGING
+     **/
+    DEFAULT,
+
+    /**
+     * This mode provides a hashed representation of objects.
+     * @see IgniteSystemProperties#IGNITE_SENSITIVE_DATA_LOGGING
+     **/
+    HASH,
+
+    /**
+     * This mode provides a plain representation of objects.
+     * @see IgniteSystemProperties#IGNITE_SENSITIVE_DATA_LOGGING
+     **/
+    PLAIN;
+
+    /** Enumerated values. */
+    private static final SensitiveMode[] VALS = values();
+
+    /**
+     * Efficiently gets enumerated value from its ordinal.
+     *
+     * @param ord Ordinal value.
+     * @return Enumerated value or {@code null} if ordinal out of range.
+     */
+    @Nullable public static SensitiveMode fromOrdinal(int ord) {
+        return ord >= 0 && ord < VALS.length ? VALS[ord] : null;
+    }
+
+    /**
+     * Efficiently gets enumerated value from its string representation ignoring case.
+     *
+     * @param str String representation.
+     * @return Enumerated value.
+     * @throws IllegalArgumentException If string representation is not valid.
+     */
+    public static SensitiveMode fromString(String str) {
+        for (SensitiveMode val : VALS) {
+            if (val.name().equalsIgnoreCase(str))
+                return val;
+        }
+
+        throw new IllegalArgumentException("Invalid sensitive mode [name=" + str + ']');
+    }
+
+    /**
+     * @return Default repair algorithm.
+     */
+    public static SensitiveMode defaultValue() {
+        return DEFAULT;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/checker/tasks/PartitionReconciliationProcessorTask.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/verify/checker/tasks/PartitionReconciliationProcessorTask.java
@@ -258,7 +258,8 @@ public class PartitionReconciliationProcessorTask extends ComputeTaskAdapter<Vis
                     reconciliationTaskArg.recheckAttempts(),
                     reconciliationTaskArg.recheckDelay(),
                     !reconciliationTaskArg.locOutput(),
-                    reconciliationTaskArg.includeSensitive());
+                    reconciliationTaskArg.includeSensitive(),
+                    reconciliationTaskArg.sensitiveMode());
 
                 ExecutionResult<ReconciliationAffectedEntries> reconciliationRes = proc.execute();
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/checker/VisorPartitionReconciliationTaskArg.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/checker/VisorPartitionReconciliationTaskArg.java
@@ -364,7 +364,7 @@ public class VisorPartitionReconciliationTaskArg extends IgniteDataTransferObjec
         }
 
         /**
-         * Build metod.
+         * Build method.
          */
         public VisorPartitionReconciliationTaskArg build() {
             return new VisorPartitionReconciliationTaskArg(this);
@@ -412,7 +412,7 @@ public class VisorPartitionReconciliationTaskArg extends IgniteDataTransferObjec
         }
 
         /**
-         * @param locOutput The result will be primted to output if {@code locOutput} equals to {@code true}.
+         * @param locOutput The result will be printed to output if {@code locOutput} equals to {@code true}.
          * @return Builder for chaining.
          */
         public Builder locOutput(boolean locOutput) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/visor/checker/VisorPartitionReconciliationTaskArg.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/visor/checker/VisorPartitionReconciliationTaskArg.java
@@ -361,6 +361,7 @@ public class VisorPartitionReconciliationTaskArg extends IgniteDataTransferObjec
             repair = false;
             locOutput = true;
             includeSensitive = true;
+            sensitiveMode = SensitiveMode.defaultValue();
             fastCheck = false;
             parallelism = 4;
             batchSize = 100;

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessorTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationProcessorTest.java
@@ -62,6 +62,7 @@ import org.apache.ignite.internal.processors.cache.checker.tasks.RepairRequestTa
 import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionsExchangeFuture;
 import org.apache.ignite.internal.processors.cache.distributed.dht.topology.GridDhtPartitionTopology;
 import org.apache.ignite.internal.processors.cache.verify.RepairAlgorithm;
+import org.apache.ignite.internal.processors.cache.verify.SensitiveMode;
 import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
 import org.apache.ignite.internal.processors.diagnostic.DiagnosticProcessor;
 import org.apache.ignite.internal.processors.diagnostic.ReconciliationExecutionContext;
@@ -438,7 +439,8 @@ public class PartitionReconciliationProcessorTest {
                 recheckAttempts,
                 recheckDelay,
                 false,
-                true);
+                true,
+                SensitiveMode.HASH);
         }
 
         /** {@inheritDoc} */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationSensitiveInformationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationSensitiveInformationTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2025 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.cache.checker.processor;
+
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.CacheWriteSynchronizationMode;
+import org.apache.ignite.cache.PartitionLossPolicy;
+import org.apache.ignite.cache.affinity.rendezvous.RendezvousAffinityFunction;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.processors.cache.checker.objects.ReconciliationResult;
+import org.apache.ignite.internal.processors.cache.verify.PartitionReconciliationDataRowMeta;
+import org.apache.ignite.internal.processors.cache.verify.SensitiveMode;
+import org.apache.ignite.internal.processors.cache.version.GridCacheVersion;
+import org.apache.ignite.internal.util.typedef.internal.U;
+import org.apache.ignite.internal.visor.checker.VisorPartitionReconciliationTaskArg;
+import org.apache.ignite.testframework.junits.WithSystemProperty;
+import org.junit.Test;
+
+import static org.apache.ignite.IgniteSystemProperties.IGNITE_SENSITIVE_DATA_LOGGING;
+import static org.apache.ignite.TestStorageUtils.corruptDataEntry;
+import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
+import static org.apache.ignite.internal.processors.cache.checker.util.ConsistencyCheckUtils.RECONCILIATION_DIR;
+
+/**
+ * Tests sensitive mode reporting.
+ */
+@WithSystemProperty(key = IGNITE_SENSITIVE_DATA_LOGGING, value = "none")
+public class PartitionReconciliationSensitiveInformationTest extends PartitionReconciliationAbstractTest {
+    /** Nodes. */
+    private static final int NODES_CNT = 2;
+
+    /** Keys count. */
+    protected static final int KEYS_CNT = 100;
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        CacheConfiguration<Integer, Integer> ccfg = new CacheConfiguration<>();
+
+        ccfg.setName(DEFAULT_CACHE_NAME);
+        ccfg.setAtomicityMode(ATOMIC);
+        ccfg.setWriteSynchronizationMode(CacheWriteSynchronizationMode.FULL_SYNC);
+        ccfg.setAffinity(new RendezvousAffinityFunction(false, 12));
+        ccfg.setBackups(1);
+        ccfg.setPartitionLossPolicy(PartitionLossPolicy.READ_WRITE_SAFE);
+
+        cfg.setCacheConfiguration(ccfg);
+        cfg.setConsistentId(igniteInstanceName);
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids();
+
+        U.delete(U.resolveWorkDirectory(U.defaultWorkDirectory(), RECONCILIATION_DIR, false));
+    }
+
+    @Test
+    public void testSensitiveModes() throws Exception {
+        startGrids(NODES_CNT);
+
+        IgniteCache<Object, Object> cache = grid(0).cache(DEFAULT_CACHE_NAME);
+
+        for (int i = 0; i < KEYS_CNT; i++)
+            cache.put(new CustomKey(i), new CustomValue("custom value " + i));
+
+        CustomKey key = new CustomKey(12);
+        int partId = grid(0).affinity(DEFAULT_CACHE_NAME).partition(key);
+
+        for (SensitiveMode mode : SensitiveMode.values()) {
+            corruptDataEntry(
+                grid(1).cachex(DEFAULT_CACHE_NAME).context(),
+                key,
+                false,
+                true,
+                new GridCacheVersion(0, 0, 0L),
+                "_broken");
+
+            ReconciliationResult res = partitionReconciliation(
+                grid(0),
+                new VisorPartitionReconciliationTaskArg.Builder()
+                    .fastCheck(false)
+                    .repair(false)
+                    .recheckAttempts(1)
+                    .recheckDelay(0)
+                    .includeSensitive(true)
+                    .sensitiveMode(mode));
+
+            assertEquals(
+                "Number of inconsistent keys should not be empty.",
+                1,
+                res.partitionReconciliationResult().inconsistentKeysCount()
+            );
+
+            PartitionReconciliationDataRowMeta meta = res
+                .partitionReconciliationResult()
+                .inconsistentKeys()
+                .get(DEFAULT_CACHE_NAME)
+                .get(partId)
+                .get(0);
+
+            String keyView = meta.keyMeta().stringView(true);
+            String valView0 = meta.valueMeta().get(grid(0).localNode().id()).stringView(true);
+            String valView1 = meta.valueMeta().get(grid(1).localNode().id()).stringView(true);
+
+            // The broken value is just a string.
+            // It is not 'obfuscated' in any way. See ConsistencyCheckUtils#objectStringView
+            assertTrue(
+                "Val1 view is incorrect [val1=" + valView1 +']',
+                valView1.contains("BinaryObject_broken hex=["));
+
+            switch (mode) {
+                case DEFAULT: {
+                    assertTrue(
+                        "Key view is incorrect [key=" + keyView + ']',
+                        keyView.contains("BinaryObject hex=["));
+
+                    assertTrue(
+                        "Val0 view is incorrect [val0=" + valView0 +']',
+                        valView0.contains("BinaryObject hex=["));
+
+                    break;
+                }
+                case HASH: {
+                    assertTrue(
+                        "Key view is incorrect [key=" + keyView + ']',
+                        checkHashView(keyView.split(" ")[0]));
+
+                    assertTrue(
+                        "Val0 view is incorrect [val0=" + valView0 +']',
+                        checkHashView(valView0.split(" ")[0]));
+
+                    break;
+                }
+                case PLAIN: {
+                    assertTrue(
+                        "Key view is incorrect [key=" + keyView + ']',
+                        keyView.contains("CustomKey"));
+
+                    assertTrue(
+                        "Val0 view is incorrect [val0=" + valView0 +']',
+                        valView0.contains("CustomValue"));
+
+                    break;
+                }
+
+                default:
+                    throw new IllegalArgumentException("Unsupported sensitive mode [mode=" + mode + ']');
+            }
+
+            cache.put(key, new CustomValue("custom value " + 12));
+        }
+    }
+
+    /**
+     * @param val String to check.
+     * @return {@code true} if the provided {@code val} represents an integer value.
+     */
+    private static boolean checkHashView(String val) {
+        try {
+            Integer.parseInt(val);
+            return true;
+        }
+        catch (NumberFormatException e) {
+            return false;
+        }
+    }
+
+    /** User defined key class. */
+    public static class CustomKey {
+        final int key;
+
+        public CustomKey(int key) {
+            this.key = key;
+        }
+    }
+
+    /** User defined value class. */
+    public static class CustomValue {
+        final String customVal;
+
+        public CustomValue(String val) {
+            this.customVal = val;
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationSensitiveInformationTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/checker/processor/PartitionReconciliationSensitiveInformationTest.java
@@ -126,7 +126,7 @@ public class PartitionReconciliationSensitiveInformationTest extends PartitionRe
             // The broken value is just a string.
             // It is not 'obfuscated' in any way. See ConsistencyCheckUtils#objectStringView
             assertTrue(
-                "Val1 view is incorrect [val1=" + valView1 +']',
+                "Val1 view is incorrect [val1=" + valView1 + ']',
                 valView1.contains("BinaryObject_broken hex=["));
 
             switch (mode) {
@@ -136,7 +136,7 @@ public class PartitionReconciliationSensitiveInformationTest extends PartitionRe
                         keyView.contains("BinaryObject hex=["));
 
                     assertTrue(
-                        "Val0 view is incorrect [val0=" + valView0 +']',
+                        "Val0 view is incorrect [val0=" + valView0 + ']',
                         valView0.contains("BinaryObject hex=["));
 
                     break;
@@ -147,7 +147,7 @@ public class PartitionReconciliationSensitiveInformationTest extends PartitionRe
                         checkHashView(keyView.split(" ")[0]));
 
                     assertTrue(
-                        "Val0 view is incorrect [val0=" + valView0 +']',
+                        "Val0 view is incorrect [val0=" + valView0 + ']',
                         checkHashView(valView0.split(" ")[0]));
 
                     break;
@@ -158,7 +158,7 @@ public class PartitionReconciliationSensitiveInformationTest extends PartitionRe
                         keyView.contains("CustomKey"));
 
                     assertTrue(
-                        "Val0 view is incorrect [val0=" + valView0 +']',
+                        "Val0 view is incorrect [val0=" + valView0 + ']',
                         valView0.contains("CustomValue"));
 
                     break;

--- a/modules/core/src/test/java/org/apache/ignite/testsuites/PartitionReconciliationTestSuite.java
+++ b/modules/core/src/test/java/org/apache/ignite/testsuites/PartitionReconciliationTestSuite.java
@@ -34,6 +34,7 @@ import org.apache.ignite.internal.processors.cache.checker.processor.PartitionRe
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationLostPartitionsTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationProcessorTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationRecheckAttemptsTest;
+import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationSensitiveInformationTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationSetDataStructureTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationStressTest;
 import org.apache.ignite.internal.processors.cache.checker.processor.PartitionReconciliationSystemFastCheckTest;
@@ -88,6 +89,7 @@ public class PartitionReconciliationTestSuite {
         GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationSystemFastCheckTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationLostPartitionsTest.class, ignoredTests);
         GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationBatchSizeTest.class, ignoredTests);
+        GridTestUtils.addTestIfNeeded(suite, PartitionReconciliationSensitiveInformationTest.class, ignoredTests);
 
         return suite;
     }

--- a/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
+++ b/modules/core/src/test/resources/org.apache.ignite.util/GridCommandHandlerClusterByClassTest_cache_help.output
@@ -20,7 +20,7 @@ Arguments: --cache help --yes
     Parameters:
       --check-crc  - check the CRC-sum of pages stored on disk before verifying data consistency in partitions between primary and backup nodes.
 
-  --cache partition_reconciliation [--repair] [--fast-check] [--parallelism] [--batch-size] [--recheck-attempts] [--include-sensitive] [cacheName1,...,cacheNameN]
+  --cache partition_reconciliation [--repair] [--fast-check] [--parallelism] [--batch-size] [--recheck-attempts] [--include-sensitive] [--sensitive-mode] [cacheName1,...,cacheNameN]
     Verify whether there are inconsistent entries for the specified caches and print out the differences if any. Fix inconsistency if --repairargument is presented. When no parameters are specified, all user caches are verified. Cache filtering options configure the set of caches that will be processed by partition_reconciliation command. If cache names are specified, in form of regular expressions, only matching caches will be verified.
 
     Parameters:
@@ -29,6 +29,7 @@ Arguments: --cache help --yes
       --include-sensitive  - Print data to result with sensitive information: keys and values. Default value is false.
       --repair             - If present, fix all inconsistent data. Specifies which repair algorithm to use for doubtful keys. The following values can be used: [LATEST, PRIMARY, MAJORITY, REMOVE, PRINT_ONLY, LATEST_SKIP_MISSING_PRIMARY, LATEST_TRUST_MISSING_PRIMARY]. Default value is PRINT_ONLY.
       --batch-size         - Amount of keys to retrieve within one job. Default value is 1000.
+      --sensitive-mode     - This parameter determines the output mode of sensitive information. Default value is default.
       --recheck-attempts   - Amount of potentially inconsistent keys recheck attempts. Value between 1 (inclusive) and 5 (exclusive) should be used. Default value is 2.
 
   --cache partition_reconciliation_cancel

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2ValueCacheObject.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridH2ValueCacheObject.java
@@ -103,7 +103,7 @@ public class GridH2ValueCacheObject extends Value {
     @Override public String getString() {
         Object obj0 = getObject();
         if (obj0 instanceof BinaryObjectEx) {
-            String str = ((BinaryObjectEx) obj0).getString();
+            String str = ((BinaryObjectEx) obj0).deserializedRepresentation();
             return str == null ? obj0.toString() : str;
         }
         return obj0.toString();


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-41947

The following option was introduced: `sensitive-mode`. 
This option defines possible modes of printing sensitive information provided by the partition reconciliation tool.
The possible values are (See  IgniteSystemProperties#IGNITE_SENSITIVE_DATA_LOGGING`):
 - `default`- This mode provides the same level as defined in the cluster. 
 - `hash` - This mode provides a hashed representation of objects.
 - `plain` - This mode provides a plain representation of objects.

The default value is `default`. This option is ignored when the include-sensitive option is false.

Example:
```
control.sh --cache partition_reconciliation cache_name --include-sesitive=true --sensitive-mode=plain
```