### PR TITLE
GG-45712 .NET: fix TestSpringXml, disable TestMemoryInfoReturnsNonNullLimitOnLinux

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
@@ -16,6 +16,7 @@
 
 namespace Apache.Ignite.Core.Tests.Common
 {
+    using System;
     using Apache.Ignite.Core.Impl;
     using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.Impl.Unmanaged;
@@ -36,6 +37,8 @@ namespace Apache.Ignite.Core.Tests.Common
             {
                 return;
             }
+
+            Console.WriteLine("GC info: " + GC.GetGCMemoryInfo().TotalAvailableMemoryBytes);
 
             Assert.IsNotNull(MemoryInfo.TotalPhysicalMemory);
             Assert.Greater(MemoryInfo.TotalPhysicalMemory, 655360);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.Core.Tests.Common
 {
     using System;
+    using System.IO;
     using Apache.Ignite.Core.Impl;
     using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.Impl.Unmanaged;
@@ -39,6 +40,8 @@ namespace Apache.Ignite.Core.Tests.Common
             }
 
             Console.WriteLine("GC info: " + GC.GetGCMemoryInfo().TotalAvailableMemoryBytes);
+            PrintFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
+            PrintFile("/sys/fs/cgroup/memory.max");
 
             Assert.IsNotNull(MemoryInfo.TotalPhysicalMemory);
             Assert.Greater(MemoryInfo.TotalPhysicalMemory, 655360);
@@ -58,6 +61,18 @@ namespace Apache.Ignite.Core.Tests.Common
             {
                 Assert.AreEqual(CGroup.MemoryLimitInBytes, MemoryInfo.MemoryLimit,
                     "When cgroup limit is set, memory limit is equal to cgroup limit.");
+            }
+        }
+
+        private static void PrintFile(string path)
+        {
+            try
+            {
+                Console.WriteLine("Contents of " + path + ":" + File.ReadAllText(path));
+            }
+            catch (IOException)
+            {
+                Console.WriteLine("Failed to read file: " + path);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
@@ -30,6 +30,7 @@ namespace Apache.Ignite.Core.Tests.Common
         /// Tests that cgroup limit can be always determined on Linux.
         /// </summary>
         [Test]
+        [Explicit("Requires cgroup limits.")]
         public void TestMemoryInfoReturnsNonNullLimitOnLinux()
         {
             if (Os.IsWindows)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Common/MemoryInfoTest.cs
@@ -16,8 +16,6 @@
 
 namespace Apache.Ignite.Core.Tests.Common
 {
-    using System;
-    using System.IO;
     using Apache.Ignite.Core.Impl;
     using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.Impl.Unmanaged;
@@ -39,10 +37,6 @@ namespace Apache.Ignite.Core.Tests.Common
                 return;
             }
 
-            Console.WriteLine("GC info: " + GC.GetGCMemoryInfo().TotalAvailableMemoryBytes);
-            PrintFile("/sys/fs/cgroup/memory/memory.limit_in_bytes");
-            PrintFile("/sys/fs/cgroup/memory.max");
-
             Assert.IsNotNull(MemoryInfo.TotalPhysicalMemory);
             Assert.Greater(MemoryInfo.TotalPhysicalMemory, 655360);
 
@@ -61,18 +55,6 @@ namespace Apache.Ignite.Core.Tests.Common
             {
                 Assert.AreEqual(CGroup.MemoryLimitInBytes, MemoryInfo.MemoryLimit,
                     "When cgroup limit is set, memory limit is equal to cgroup limit.");
-            }
-        }
-
-        private static void PrintFile(string path)
-        {
-            try
-            {
-                Console.WriteLine("Contents of " + path + ":" + File.ReadAllText(path));
-            }
-            catch (IOException)
-            {
-                Console.WriteLine("Failed to read file: " + path);
             }
         }
     }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/IgniteConfigurationTest.cs
@@ -655,11 +655,15 @@ namespace Apache.Ignite.Core.Tests
                 var physMem = MemoryInfo.TotalPhysicalMemory;
                 Assert.IsNotNull(physMem);
 
-                var expected = (long) physMem / 5;
+                // If MaxSize from Java is more than physical memory, then Java ignored cgroups and we skip the check.
+                if (cfg.MaxSize < (long)physMem)
+                {
+                    var expected = (long)physMem / 5;
 
-                Assert.AreEqual(expected, cfg.MaxSize,
-                    string.Format("Expected max size with cgroup limit: '{0}', without: '{1}'",
-                        DataRegionConfiguration.DefaultMaxSize, expected));
+                    Assert.AreEqual(expected, cfg.MaxSize,
+                        string.Format("Expected max size with cgroup limit: '{0}', without: '{1}'",
+                            DataRegionConfiguration.DefaultMaxSize, expected));
+                }
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -64,17 +64,23 @@ namespace Apache.Ignite.Core.Impl.Common
                 var memMount = FindHierarchyMount(MemorySubsystem);
                 if (memMount == null)
                 {
+                    Console.WriteLine("GetMemoryLimitInBytes: memMount is null");
                     return null;
                 }
 
                 var cgroupPathRelativeToMount = FindCGroupPath(MemorySubsystem);
                 if (cgroupPathRelativeToMount == null)
                 {
+                    Console.WriteLine("GetMemoryLimitInBytes: cgroupPathRelativeToMount is null");
                     return null;
                 }
 
                 var hierarchyMount = memMount.Value.Key;
                 var hierarchyRoot = memMount.Value.Value;
+
+                Console.WriteLine("GetMemoryLimitInBytes: hierarchyMount=" + hierarchyMount +
+                                  ", hierarchyRoot=" + hierarchyRoot +
+                                  ", cgroupPathRelativeToMount=" + cgroupPathRelativeToMount);
 
                 // Host CGroup: append the relative path
                 // In Docker: root and relative path are the same
@@ -85,7 +91,11 @@ namespace Apache.Ignite.Core.Impl.Common
 
                 var memLimitFilePath = Path.Combine(groupPath, MemoryLimitFileName);
 
+                Console.WriteLine("GetMemoryLimitInBytes: memLimitFilePath=" + memLimitFilePath);
+
                 var memLimitText = File.ReadAllText(memLimitFilePath);
+
+                Console.WriteLine("GetMemoryLimitInBytes: memLimitText=" + memLimitText);
 
                 ulong memLimit;
                 if (ulong.TryParse(memLimitText, out memLimit))
@@ -106,12 +116,17 @@ namespace Apache.Ignite.Core.Impl.Common
         /// </summary>
         private static KeyValuePair<string, string>? FindHierarchyMount(string subsystem)
         {
+            Console.WriteLine("FindHierarchyMount start: " + subsystem);
+
             foreach (var line in File.ReadAllLines(ProcMountInfoFileName))
             {
+                Console.WriteLine("FindHierarchyMount: " + line);
+
                 var mount = GetHierarchyMount(line, subsystem);
 
                 if (mount != null)
                 {
+                    Console.WriteLine("FindHierarchyMount success: " + mount);
                     return mount;
                 }
             }
@@ -159,6 +174,8 @@ namespace Apache.Ignite.Core.Impl.Common
 
             foreach (var line in lines)
             {
+                Console.WriteLine("FindCGroupPath: " + line);
+
                 var parts = line.Split(new[] {':'}, 3);
 
                 if (parts.Length == 3 && parts[1].Split(',').Contains(subsystem, StringComparer.Ordinal))

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -62,7 +62,9 @@ namespace Apache.Ignite.Core.Impl.Common
             var cgroupV2Text = TryReadFile("/sys/fs/cgroup/memory.max");
             if (cgroupV2Text != null)
             {
-                if (string.Equals(cgroupV2Text.Trim(), "max", StringComparison.OrdinalIgnoreCase))
+                cgroupV2Text = cgroupV2Text.Trim();
+
+                if (string.Equals(cgroupV2Text, "max", StringComparison.OrdinalIgnoreCase))
                 {
                     return null;
                 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -59,6 +59,20 @@ namespace Apache.Ignite.Core.Impl.Common
                 return null;
             }
 
+            var cgroupV2Text = TryReadFile("/sys/fs/cgroup/memory.max");
+            if (cgroupV2Text != null)
+            {
+                if (string.Equals(cgroupV2Text.Trim(), "max", StringComparison.OrdinalIgnoreCase))
+                {
+                    return null;
+                }
+
+                if (ulong.TryParse(cgroupV2Text, out var memLimitV2))
+                {
+                    return memLimitV2;
+                }
+            }
+
             try
             {
                 var memMount = FindHierarchyMount(MemorySubsystem);
@@ -185,6 +199,19 @@ namespace Apache.Ignite.Core.Impl.Common
             }
 
             return null;
+        }
+
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Reviewed")]
+        private static string TryReadFile(string file)
+        {
+            try
+            {
+                return File.ReadAllText(file);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Common/Cgroup.cs
@@ -71,6 +71,8 @@ namespace Apache.Ignite.Core.Impl.Common
                 {
                     return memLimitV2;
                 }
+
+                return null;
             }
 
             try
@@ -78,23 +80,17 @@ namespace Apache.Ignite.Core.Impl.Common
                 var memMount = FindHierarchyMount(MemorySubsystem);
                 if (memMount == null)
                 {
-                    Console.WriteLine("GetMemoryLimitInBytes: memMount is null");
                     return null;
                 }
 
                 var cgroupPathRelativeToMount = FindCGroupPath(MemorySubsystem);
                 if (cgroupPathRelativeToMount == null)
                 {
-                    Console.WriteLine("GetMemoryLimitInBytes: cgroupPathRelativeToMount is null");
                     return null;
                 }
 
                 var hierarchyMount = memMount.Value.Key;
                 var hierarchyRoot = memMount.Value.Value;
-
-                Console.WriteLine("GetMemoryLimitInBytes: hierarchyMount=" + hierarchyMount +
-                                  ", hierarchyRoot=" + hierarchyRoot +
-                                  ", cgroupPathRelativeToMount=" + cgroupPathRelativeToMount);
 
                 // Host CGroup: append the relative path
                 // In Docker: root and relative path are the same
@@ -105,11 +101,7 @@ namespace Apache.Ignite.Core.Impl.Common
 
                 var memLimitFilePath = Path.Combine(groupPath, MemoryLimitFileName);
 
-                Console.WriteLine("GetMemoryLimitInBytes: memLimitFilePath=" + memLimitFilePath);
-
                 var memLimitText = File.ReadAllText(memLimitFilePath);
-
-                Console.WriteLine("GetMemoryLimitInBytes: memLimitText=" + memLimitText);
 
                 ulong memLimit;
                 if (ulong.TryParse(memLimitText, out memLimit))
@@ -130,17 +122,12 @@ namespace Apache.Ignite.Core.Impl.Common
         /// </summary>
         private static KeyValuePair<string, string>? FindHierarchyMount(string subsystem)
         {
-            Console.WriteLine("FindHierarchyMount start: " + subsystem);
-
             foreach (var line in File.ReadAllLines(ProcMountInfoFileName))
             {
-                Console.WriteLine("FindHierarchyMount: " + line);
-
                 var mount = GetHierarchyMount(line, subsystem);
 
                 if (mount != null)
                 {
-                    Console.WriteLine("FindHierarchyMount success: " + mount);
                     return mount;
                 }
             }
@@ -188,8 +175,6 @@ namespace Apache.Ignite.Core.Impl.Common
 
             foreach (var line in lines)
             {
-                Console.WriteLine("FindCGroupPath: " + line);
-
                 var parts = line.Split(new[] {':'}, 3);
 
                 if (parts.Length == 3 && parts[1].Split(',').Contains(subsystem, StringComparer.Ordinal))


### PR DESCRIPTION
* Add cgroup v2 support
* `TestSpringXml` - skip checks if Java ignores cgroups (old JDK)
* `TestMemoryInfoReturnsNonNullLimitOnLinux` - disable (make explicit), requires cgroup limits which are not guaranteed to be present