### PR TITLE
GG-43609 Improve PriorityQueueCollisionSpi Performance Under High Concurrency

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
@@ -102,6 +102,7 @@ import org.apache.ignite.spi.systemview.view.ComputeJobView;
 import org.apache.ignite.spi.systemview.view.ComputeJobView.ComputeJobState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.TestOnly;
 import org.jsr166.ConcurrentLinkedHashMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -918,8 +919,21 @@ public class GridJobProcessor extends GridProcessorAdapter {
         }
     }
 
-    private void handleCollisionsInternal() {
+    @TestOnly
+    /** Synchronised version of {@link #handleCollisions()} for testing purposes. */
+    public void handleCollisionsSync() {
         if (!rwLock.tryReadLock()) {
+            if (log.isDebugEnabled())
+                log.debug("Skipping handling collisions because node is stopping");
+
+            handlingCollisionFut.completeExceptionally(new NodeStoppingException("Node is stopping"));
+
+            return;
+        }
+
+        if (stopping) {
+            rwLock.readUnlock();
+
             if (log.isDebugEnabled())
                 log.debug("Skipping handling collisions because node is stopping");
 
@@ -1107,7 +1121,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
             if (shouldHandleCollision && (handlingCollisionFut == null || handlingCollisionFut.isDone())) {
                 handlingCollisionFut = new CompletableFuture<>();
 
-                ctx.pools().getManagementExecutorService().submit(this::handleCollisionsInternal);
+                ctx.pools().getManagementExecutorService().submit(this::handleCollisionsSync);
 
                 handlingCollisionFut.whenComplete((res, err) -> {
                     if (err != null) {

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
@@ -26,10 +26,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Condition;
@@ -60,6 +64,7 @@ import org.apache.ignite.internal.GridJobSiblingsResponse;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.GridTaskSessionImpl;
 import org.apache.ignite.internal.GridTaskSessionRequest;
+import org.apache.ignite.internal.NodeStoppingException;
 import org.apache.ignite.internal.SkipDaemon;
 import org.apache.ignite.internal.cluster.ClusterTopologyCheckedException;
 import org.apache.ignite.internal.managers.collision.GridCollisionJobContextAdapter;
@@ -103,6 +108,7 @@ import org.jetbrains.annotations.Nullable;
 import org.jsr166.ConcurrentLinkedHashMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_JOBS_HISTORY_SIZE;
@@ -326,6 +332,14 @@ public class GridJobProcessor extends GridProcessorAdapter {
     /** Timeout interrupt {@link GridJobWorker workers} after {@link GridJobWorker#cancel cancel} im mills. */
     private final DistributedLongProperty computeJobWorkerInterruptTimeout =
         detachedLongProperty(COMPUTE_JOB_WORKER_INTERRUPT_TIMEOUT);
+
+    /** Guarded by handleCollisionMutex. */
+    private CompletableFuture<?> handlingCollisionFut;
+
+    /** Guarded by handleCollisionMutex. */
+    private boolean shouldHandleCollision;
+
+    private final Object handleCollisionMutex = new Object();
 
     /**
      * @param ctx Kernal context.
@@ -898,21 +912,38 @@ public class GridJobProcessor extends GridProcessorAdapter {
 
     /**
      * Handles collisions.
-     * <p>
-     * In most cases this method should be called from main read lock
-     * to avoid jobs activation after node stop has started.
      */
     public void handleCollisions() {
         assert !jobAlwaysActivate;
 
-        if (handlingCollision.get()) {
+        Future<?> curHandleCollisionFut;
+
+        synchronized (handleCollisionMutex) {
+            curHandleCollisionFut = handlingCollisionFut;
+
+            shouldHandleCollision = true;
+            scheduleHandleCollisionsIfNeeded();
+        }
+
+        // To make testing easier wait for the first collision handling to complete.
+        if (curHandleCollisionFut == null) {
+            try {
+                handlingCollisionFut.get(100, SECONDS);
+            } catch (InterruptedException | ExecutionException | TimeoutException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private void handleCollisionsInternal() {
+        if (!rwLock.tryReadLock()) {
             if (log.isDebugEnabled())
-                log.debug("Skipping recursive collision handling.");
+                log.debug("Skipping handling collisions because node is stopping");
+
+            handlingCollisionFut.completeExceptionally(new NodeStoppingException("Node is stopping"));
 
             return;
         }
-
-        handlingCollision.set(Boolean.TRUE);
 
         try {
             if (log.isDebugEnabled())
@@ -922,38 +953,52 @@ public class GridJobProcessor extends GridProcessorAdapter {
             ctx.collision().onCollision(
                 // Passive jobs view.
                 new AbstractCollection<org.apache.ignite.spi.collision.CollisionJobContext>() {
-                    /** {@inheritDoc} */
-                    @NotNull @Override public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @NotNull
+                    @Override
+                    public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
                         final Iterator<GridJobWorker> iter = passiveJobs.values().iterator();
 
                         return new Iterator<org.apache.ignite.spi.collision.CollisionJobContext>() {
                             /** {@inheritDoc} */
-                            @Override public boolean hasNext() {
+                            @Override
+                            public boolean hasNext() {
                                 return iter.hasNext();
                             }
 
                             /** {@inheritDoc} */
-                            @Override public org.apache.ignite.spi.collision.CollisionJobContext next() {
+                            @Override
+                            public org.apache.ignite.spi.collision.CollisionJobContext next() {
                                 return new CollisionJobContext(iter.next(), true);
                             }
 
                             /** {@inheritDoc} */
-                            @Override public void remove() {
+                            @Override
+                            public void remove() {
                                 throw new UnsupportedOperationException();
                             }
                         };
                     }
 
-                    /** {@inheritDoc} */
-                    @Override public int size() {
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @Override
+                    public int size() {
                         return passiveJobs.size();
                     }
                 },
 
                 // Active jobs view.
                 new AbstractCollection<org.apache.ignite.spi.collision.CollisionJobContext>() {
-                    /** {@inheritDoc} */
-                    @NotNull @Override public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @NotNull
+                    @Override
+                    public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
                         final Iterator<GridJobWorker> iter = activeJobs.values().iterator();
 
                         return new Iterator<org.apache.ignite.spi.collision.CollisionJobContext>() {
@@ -983,12 +1028,14 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override public boolean hasNext() {
+                            @Override
+                            public boolean hasNext() {
                                 return w != null;
                             }
 
                             /** {@inheritDoc} */
-                            @Override public org.apache.ignite.spi.collision.CollisionJobContext next() {
+                            @Override
+                            public org.apache.ignite.spi.collision.CollisionJobContext next() {
                                 if (w == null)
                                     throw new NoSuchElementException();
 
@@ -1002,14 +1049,18 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override public void remove() {
+                            @Override
+                            public void remove() {
                                 throw new UnsupportedOperationException();
                             }
                         };
                     }
 
-                    /** {@inheritDoc} */
-                    @Override public int size() {
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @Override
+                    public int size() {
                         int ret = activeJobs.size() - heldJobs.size();
 
                         return Math.max(ret, 0);
@@ -1018,8 +1069,12 @@ public class GridJobProcessor extends GridProcessorAdapter {
 
                 // Held jobs view.
                 new AbstractCollection<org.apache.ignite.spi.collision.CollisionJobContext>() {
-                    /** {@inheritDoc} */
-                    @NotNull @Override public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @NotNull
+                    @Override
+                    public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
                         final Iterator<GridJobWorker> iter = activeJobs.values().iterator();
 
                         return new Iterator<org.apache.ignite.spi.collision.CollisionJobContext>() {
@@ -1049,12 +1104,14 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override public boolean hasNext() {
+                            @Override
+                            public boolean hasNext() {
                                 return w != null;
                             }
 
                             /** {@inheritDoc} */
-                            @Override public org.apache.ignite.spi.collision.CollisionJobContext next() {
+                            @Override
+                            public org.apache.ignite.spi.collision.CollisionJobContext next() {
                                 if (w == null)
                                     throw new NoSuchElementException();
 
@@ -1069,22 +1126,43 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override public void remove() {
+                            @Override
+                            public void remove() {
                                 throw new UnsupportedOperationException();
                             }
                         };
                     }
 
-                    /** {@inheritDoc} */
-                    @Override public int size() {
+                    /**
+                     * {@inheritDoc}
+                     */
+                    @Override
+                    public int size() {
                         return heldJobs.size();
                     }
                 });
-
-            updateJobMetrics();
+        } finally {
+            handlingCollisionFut.complete(null);
+            rwLock.readUnlock();
         }
-        finally {
-            handlingCollision.set(Boolean.FALSE);
+
+        updateJobMetrics();
+    }
+
+    private void scheduleHandleCollisionsIfNeeded() {
+        synchronized (handleCollisionMutex) {
+            if (shouldHandleCollision && (handlingCollisionFut == null || handlingCollisionFut.isDone())) {
+                handlingCollisionFut = new CompletableFuture<>();
+
+                ctx.pools().getManagementExecutorService().submit(this::handleCollisionsInternal);
+
+                handlingCollisionFut.whenComplete((res, err) -> {
+                    if (!(err instanceof NodeStoppingException))
+                        scheduleHandleCollisionsIfNeeded();
+                });
+
+                shouldHandleCollision = false;
+            }
         }
     }
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
@@ -920,7 +920,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
     }
 
     @TestOnly
-    /** Synchronised version of {@link #handleCollisions()} for testing purposes. */
+    /** Synchronised version of {@link #handleCollisions()}. Made public for testing purposes. */
     public void handleCollisionsSync() {
         if (!rwLock.tryReadLock()) {
             if (log.isDebugEnabled())

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
@@ -908,9 +908,9 @@ public class GridJobProcessor extends GridProcessorAdapter {
     }
 
     /**
-     * Handles collisions.
+     * Schedules handling of collisions in management executor pool.
      */
-    public void handleCollisions() {
+    public void scheduleHandleCollisions() {
         assert !jobAlwaysActivate;
 
         synchronized (handleCollisionMutex) {
@@ -920,8 +920,8 @@ public class GridJobProcessor extends GridProcessorAdapter {
     }
 
     @TestOnly
-    /** Synchronised version of {@link #handleCollisions()}. Made public for testing purposes. */
-    public void handleCollisionsSync() {
+    /** Handles collisions in current thread. Made public for testing purposes. */
+    public void handleCollisions() {
         if (!rwLock.tryReadLock()) {
             if (log.isDebugEnabled())
                 log.debug("Skipping handling collisions because node is stopping");
@@ -931,18 +931,13 @@ public class GridJobProcessor extends GridProcessorAdapter {
             return;
         }
 
-        if (stopping) {
-            rwLock.readUnlock();
-
-            if (log.isDebugEnabled())
-                log.debug("Skipping handling collisions because node is stopping");
-
-            handlingCollisionFut.completeExceptionally(new NodeStoppingException("Node is stopping"));
-
-            return;
-        }
-
         try {
+            if (stopping) {
+                if (log.isDebugEnabled())
+                    log.debug("Skipping handling collisions because node is stopping");
+
+                throw new NodeStoppingException("Node is stopping");
+            }
             if (log.isDebugEnabled())
                 log.debug("Before handling collisions.");
 
@@ -1108,8 +1103,11 @@ public class GridJobProcessor extends GridProcessorAdapter {
                         return heldJobs.size();
                     }
                 });
-        } finally {
+
             handlingCollisionFut.complete(null);
+        } catch (Exception e) {
+            handlingCollisionFut.completeExceptionally(e);
+        } finally {
             rwLock.readUnlock();
         }
 
@@ -1121,7 +1119,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
             if (shouldHandleCollision && (handlingCollisionFut == null || handlingCollisionFut.isDone())) {
                 handlingCollisionFut = new CompletableFuture<>();
 
-                ctx.pools().getManagementExecutorService().submit(this::handleCollisionsSync);
+                ctx.pools().getManagementExecutorService().submit(this::handleCollisions);
 
                 handlingCollisionFut.whenComplete((res, err) -> {
                     if (err != null) {
@@ -1458,7 +1456,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             if (old == null) {
                                 waitingJobsMetric.increment();
 
-                                handleCollisions();
+                                scheduleHandleCollisions();
                             }
                             else
                                 U.error(log, "Received computation request with duplicate job ID (could be " +
@@ -2045,7 +2043,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
             }
 
             try {
-                handleCollisions();
+                scheduleHandleCollisions();
             }
             finally {
                 rwLock.readUnlock();
@@ -2157,7 +2155,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
                     heldJobs.remove(worker.getJobId());
 
                     try {
-                        handleCollisions();
+                        scheduleHandleCollisions();
                     }
                     finally {
                         rwLock.readUnlock();
@@ -2348,7 +2346,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
 
                 try {
                     if (!jobAlwaysActivate)
-                        handleCollisions();
+                        scheduleHandleCollisions();
                     else if (metricsUpdateFreq > -1L)
                         updateJobMetrics();
                 }
@@ -2444,7 +2442,7 @@ public class GridJobProcessor extends GridProcessorAdapter {
                 handleCollisions = true;
 
             if (handleCollisions)
-                handleCollisions();
+                scheduleHandleCollisions();
         }
         finally {
             rwLock.readUnlock();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/job/GridJobProcessor.java
@@ -29,11 +29,8 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Condition;
@@ -108,7 +105,6 @@ import org.jetbrains.annotations.Nullable;
 import org.jsr166.ConcurrentLinkedHashMap;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_JOBS_HISTORY_SIZE;
@@ -916,22 +912,9 @@ public class GridJobProcessor extends GridProcessorAdapter {
     public void handleCollisions() {
         assert !jobAlwaysActivate;
 
-        Future<?> curHandleCollisionFut;
-
         synchronized (handleCollisionMutex) {
-            curHandleCollisionFut = handlingCollisionFut;
-
             shouldHandleCollision = true;
             scheduleHandleCollisionsIfNeeded();
-        }
-
-        // To make testing easier wait for the first collision handling to complete.
-        if (curHandleCollisionFut == null) {
-            try {
-                handlingCollisionFut.get(100, SECONDS);
-            } catch (InterruptedException | ExecutionException | TimeoutException e) {
-                throw new RuntimeException(e);
-            }
         }
     }
 
@@ -953,52 +936,38 @@ public class GridJobProcessor extends GridProcessorAdapter {
             ctx.collision().onCollision(
                 // Passive jobs view.
                 new AbstractCollection<org.apache.ignite.spi.collision.CollisionJobContext>() {
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @NotNull
-                    @Override
-                    public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
+                    /** {@inheritDoc} */
+                    @NotNull @Override public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
                         final Iterator<GridJobWorker> iter = passiveJobs.values().iterator();
 
                         return new Iterator<org.apache.ignite.spi.collision.CollisionJobContext>() {
                             /** {@inheritDoc} */
-                            @Override
-                            public boolean hasNext() {
+                            @Override public boolean hasNext() {
                                 return iter.hasNext();
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public org.apache.ignite.spi.collision.CollisionJobContext next() {
+                            @Override public org.apache.ignite.spi.collision.CollisionJobContext next() {
                                 return new CollisionJobContext(iter.next(), true);
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public void remove() {
+                            @Override public void remove() {
                                 throw new UnsupportedOperationException();
                             }
                         };
                     }
 
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @Override
-                    public int size() {
+                    /** {@inheritDoc} */
+                    @Override public int size() {
                         return passiveJobs.size();
                     }
                 },
 
                 // Active jobs view.
                 new AbstractCollection<org.apache.ignite.spi.collision.CollisionJobContext>() {
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @NotNull
-                    @Override
-                    public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
+                    /** {@inheritDoc} */
+                    @NotNull @Override public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
                         final Iterator<GridJobWorker> iter = activeJobs.values().iterator();
 
                         return new Iterator<org.apache.ignite.spi.collision.CollisionJobContext>() {
@@ -1028,14 +997,12 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public boolean hasNext() {
+                            @Override public boolean hasNext() {
                                 return w != null;
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public org.apache.ignite.spi.collision.CollisionJobContext next() {
+                            @Override public org.apache.ignite.spi.collision.CollisionJobContext next() {
                                 if (w == null)
                                     throw new NoSuchElementException();
 
@@ -1049,18 +1016,14 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public void remove() {
+                            @Override public void remove() {
                                 throw new UnsupportedOperationException();
                             }
                         };
                     }
 
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @Override
-                    public int size() {
+                    /** {@inheritDoc} */
+                    @Override public int size() {
                         int ret = activeJobs.size() - heldJobs.size();
 
                         return Math.max(ret, 0);
@@ -1069,12 +1032,8 @@ public class GridJobProcessor extends GridProcessorAdapter {
 
                 // Held jobs view.
                 new AbstractCollection<org.apache.ignite.spi.collision.CollisionJobContext>() {
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @NotNull
-                    @Override
-                    public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
+                    /** {@inheritDoc} */
+                    @NotNull @Override public Iterator<org.apache.ignite.spi.collision.CollisionJobContext> iterator() {
                         final Iterator<GridJobWorker> iter = activeJobs.values().iterator();
 
                         return new Iterator<org.apache.ignite.spi.collision.CollisionJobContext>() {
@@ -1104,14 +1063,12 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public boolean hasNext() {
+                            @Override public boolean hasNext() {
                                 return w != null;
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public org.apache.ignite.spi.collision.CollisionJobContext next() {
+                            @Override public org.apache.ignite.spi.collision.CollisionJobContext next() {
                                 if (w == null)
                                     throw new NoSuchElementException();
 
@@ -1126,18 +1083,14 @@ public class GridJobProcessor extends GridProcessorAdapter {
                             }
 
                             /** {@inheritDoc} */
-                            @Override
-                            public void remove() {
+                            @Override public void remove() {
                                 throw new UnsupportedOperationException();
                             }
                         };
                     }
 
-                    /**
-                     * {@inheritDoc}
-                     */
-                    @Override
-                    public int size() {
+                    /** {@inheritDoc} */
+                    @Override public int size() {
                         return heldJobs.size();
                     }
                 });
@@ -1157,8 +1110,15 @@ public class GridJobProcessor extends GridProcessorAdapter {
                 ctx.pools().getManagementExecutorService().submit(this::handleCollisionsInternal);
 
                 handlingCollisionFut.whenComplete((res, err) -> {
-                    if (!(err instanceof NodeStoppingException))
-                        scheduleHandleCollisionsIfNeeded();
+                    if (err != null) {
+                        if (err instanceof NodeStoppingException)
+                            return;
+                        if (log.isDebugEnabled())
+                            log.debug("Collision handling has been completed with error: " + err);
+                    }
+
+                    // To process collision events that happened during handling collisions.
+                    scheduleHandleCollisionsIfNeeded();
                 });
 
                 shouldHandleCollision = false;

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
@@ -502,49 +502,54 @@ public class PriorityQueueCollisionSpi extends IgniteSpiAdapter implements Colli
     }
 
     /** {@inheritDoc} */
-    @Override public synchronized void onCollision(CollisionContext ctx) {
+    @Override public void onCollision(CollisionContext ctx) {
         assert ctx != null;
 
-        Collection<CollisionJobContext> waitJobs = ctx.waitingJobs();
         int activeSize = ctx.activeJobs().size();
+
+        Collection<CollisionJobContext> waitJobs = ctx.waitingJobs();
+
         int waitSize = waitJobs.size();
-        int activateCnt = parallelJobsNum - activeSize;
 
         runningCnt = activeSize;
         waitingCnt = waitSize;
 
-        if (waitSize == 0 || activateCnt <= 0) {
-            return;
-        }
-
         heldCnt = ctx.heldJobs().size();
+
+        int activateCnt = parallelJobsNum - activeSize;
+
+        int waitJobsNum = this.waitJobsNum;
+
+        if (waitSize == 0 && activateCnt <= 0 && waitSize < waitJobsNum)
+            return;
 
         // Temporary snapshot of waitJobs.
         ArrayList<GridCollisionJobContextWrapper> waitSnap = slice(waitJobs, waitSize);
 
         boolean waitSnapSorted = false;
 
-        if (waitSize <= activateCnt) {
-            for (GridCollisionJobContextWrapper cntx: waitSnap) {
-                cntx.getContext().activate();
-                waitSize--;
+        if (activateCnt > 0 && waitSize > 0) {
+            if (waitSize <= activateCnt) {
+                for (GridCollisionJobContextWrapper cntx: waitSnap) {
+                    cntx.getContext().activate();
+                    waitSize--;
+                }
             }
-        } else {
-            waitSnap.sort(priComp);
-            waitSnapSorted = true;
+            else {
+                waitSnap.sort(priComp);
+                waitSnapSorted = true;
 
-            if (preventStarvation)
-                bumpPriority(waitSnap);
+                if (preventStarvation)
+                    bumpPriority(waitSnap);
 
-            // Passive list could have less then waitSize elements.
-            for (int i = 0; i < activateCnt && i < waitSnap.size(); i++) {
-                waitSnap.get(i).getContext().activate();
+                // Passive list could have less then waitSize elements.
+                for (int i = 0; i < activateCnt && i < waitSnap.size(); i++) {
+                    waitSnap.get(i).getContext().activate();
 
-                waitSize--;
+                    waitSize--;
+                }
             }
         }
-
-        int waitJobsNum = this.waitJobsNum;
 
         if (waitSize > waitJobsNum) {
             int skip = waitSnap.size() - waitSize;

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
@@ -520,7 +520,9 @@ public class PriorityQueueCollisionSpi extends IgniteSpiAdapter implements Colli
 
         int waitJobsNum = this.waitJobsNum;
 
-        if (waitSize == 0 && activateCnt <= 0 && waitSize < waitJobsNum)
+        boolean noExcessiveJobs = waitSize < waitJobsNum;
+
+        if (activateCnt <= 0 && noExcessiveJobs)
             return;
 
         // Temporary snapshot of waitJobs.

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
@@ -542,7 +542,7 @@ public class PriorityQueueCollisionSpi extends IgniteSpiAdapter implements Colli
                 if (preventStarvation)
                     bumpPriority(waitSnap);
 
-                // Passive list could have less then waitSize elements.
+                // Passive list could have less than waitSize elements.
                 for (int i = 0; i < activateCnt && i < waitSnap.size(); i++) {
                     waitSnap.get(i).getContext().activate();
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
@@ -502,47 +502,45 @@ public class PriorityQueueCollisionSpi extends IgniteSpiAdapter implements Colli
     }
 
     /** {@inheritDoc} */
-    @Override public void onCollision(CollisionContext ctx) {
+    @Override public synchronized void onCollision(CollisionContext ctx) {
         assert ctx != null;
 
-        int activeSize = ctx.activeJobs().size();
-
         Collection<CollisionJobContext> waitJobs = ctx.waitingJobs();
-
+        int activeSize = ctx.activeJobs().size();
         int waitSize = waitJobs.size();
+        int activateCnt = parallelJobsNum - activeSize;
 
         runningCnt = activeSize;
         waitingCnt = waitSize;
 
-        heldCnt = ctx.heldJobs().size();
+        if (waitSize == 0 || activateCnt <= 0) {
+            return;
+        }
 
-        int activateCnt = parallelJobsNum - activeSize;
+        heldCnt = ctx.heldJobs().size();
 
         // Temporary snapshot of waitJobs.
         ArrayList<GridCollisionJobContextWrapper> waitSnap = slice(waitJobs, waitSize);
 
         boolean waitSnapSorted = false;
 
-        if (activateCnt > 0 && waitSize > 0) {
-            if (waitSize <= activateCnt) {
-                for (GridCollisionJobContextWrapper cntx: waitSnap) {
-                    cntx.getContext().activate();
-                    waitSize--;
-                }
+        if (waitSize <= activateCnt) {
+            for (GridCollisionJobContextWrapper cntx: waitSnap) {
+                cntx.getContext().activate();
+                waitSize--;
             }
-            else {
-                waitSnap.sort(priComp);
-                waitSnapSorted = true;
+        } else {
+            waitSnap.sort(priComp);
+            waitSnapSorted = true;
 
-                if (preventStarvation)
-                    bumpPriority(waitSnap);
+            if (preventStarvation)
+                bumpPriority(waitSnap);
 
-                // Passive list could have less then waitSize elements.
-                for (int i = 0; i < activateCnt && i < waitSnap.size(); i++) {
-                    waitSnap.get(i).getContext().activate();
+            // Passive list could have less then waitSize elements.
+            for (int i = 0; i < activateCnt && i < waitSnap.size(); i++) {
+                waitSnap.get(i).getContext().activate();
 
-                    waitSize--;
-                }
+                waitSize--;
             }
         }
 

--- a/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
+++ b/modules/core/src/main/java/org/apache/ignite/spi/collision/priorityqueue/PriorityQueueCollisionSpi.java
@@ -520,7 +520,7 @@ public class PriorityQueueCollisionSpi extends IgniteSpiAdapter implements Colli
 
         int waitJobsNum = this.waitJobsNum;
 
-        boolean noExcessiveJobs = waitSize < waitJobsNum;
+        boolean noExcessiveJobs = waitSize <= waitJobsNum;
 
         if (activateCnt <= 0 && noExcessiveJobs)
             return;

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridJobCollisionCancelSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridJobCollisionCancelSelfTest.java
@@ -103,9 +103,8 @@ public class GridJobCollisionCancelSelfTest extends GridCommonAbstractTest {
                 // Should be exactly the same as Jobs number.
                 assert cancelCnt <= SPLIT_COUNT : "Invalid cancel count: " + cancelCnt;
 
-                // One per start and one per stop and some that come with metrics update.
-                assert colResolutionCnt > SPLIT_COUNT + 1 :
-                    "Invalid collision resolution count: " + colResolutionCnt;
+                assert colResolutionCnt > 0 :
+                    "No conflict resolutions happened";
             }
         }
         catch (ComputeTaskTimeoutException e) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
@@ -20,7 +20,6 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Stream;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.IgniteException;
@@ -182,7 +181,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         WaitJob.waitFut.onDone();
 
         for (Ignite n : G.allGrids()) {
-            GridFutureAdapter<Void> fut = PriorityQueueCollisionSpiEx.spiEx(n).onChangeTaskAttrsFut;
+            GridFutureAdapter<Void> fut = PriorityQueueCollisionSpiEx.spiEx(n).onHandleCollisionFut;
 
             if (expHandleCollisionOnChangeTaskAttrs)
                 fut.get(getTestTimeout());
@@ -205,7 +204,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         final GridFutureAdapter<CollisionJobContext> waitJobFut = new GridFutureAdapter<>();
 
         /** */
-        final GridFutureAdapter<Void> onChangeTaskAttrsFut = new GridFutureAdapter<>();
+        final GridFutureAdapter<Void> onHandleCollisionFut = new GridFutureAdapter<>();
 
         /** {@inheritDoc} */
         @Override public void onCollision(CollisionContext ctx) {
@@ -217,15 +216,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
             }
 
             if (handleCollision) {
-                if (!onChangeTaskAttrsFut.isDone()) {
-                    Stream.of(new Exception().getStackTrace())
-                        .filter(el ->
-                            ON_CHANGE_TASK_ATTRS_MTD.getDeclaringClass().getName().equals(el.getClassName()) &&
-                                ON_CHANGE_TASK_ATTRS_MTD.getName().equals(el.getMethodName())
-                        )
-                        .findAny()
-                        .ifPresent(el -> onChangeTaskAttrsFut.onDone());
-                }
+                    onHandleCollisionFut.onDone();
 
                 super.onCollision(ctx);
             }
@@ -237,7 +228,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
 
             waitJobFut.reset();
 
-            onChangeTaskAttrsFut.reset();
+            onHandleCollisionFut.reset();
         }
 
         /** */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
@@ -268,8 +268,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         }
     }
 
-    @Override
-    protected long getTestTimeout() {
+    @Override protected long getTestTimeout() {
         return 30_000;
     }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
@@ -260,6 +260,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         }
     }
 
+    // These tests don't need standard 300 seconds timeout.
     @Override protected long getTestTimeout() {
         return 30_000;
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
@@ -91,6 +91,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
     @Override protected void afterTest() throws Exception {
         super.afterTest();
 
+        // Enable collision handling to ensure that any passive WaitJobs will be handled and won't block subsequent tests.
         for (Ignite n : G.allGrids())
             PriorityQueueCollisionSpiEx.spiEx(n).handleCollision = true;
 
@@ -99,7 +100,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
 
         // Force collision handling to activate any passive WaitJobs.
         for (Ignite n : G.allGrids())
-            ((IgniteEx)n).context().job().handleCollisionsSync();
+            ((IgniteEx)n).context().job().handleCollisions();
 
         assertTrue(waitForCondition(() -> CRD.compute().activeTaskFutures().isEmpty(), getTestTimeout()));
     }
@@ -193,9 +194,8 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
                 assertThrows(log, () -> fut.get(100), IgniteFutureTimeoutCheckedException.class, null);
         }
 
-        if (!expHandleCollisionOnChangeTaskAttrs) {
+        if (!expHandleCollisionOnChangeTaskAttrs)
             CRD.compute().execute(new NoopTask(), null);
-        }
 
         taskFut.get(getTestTimeout());
     }
@@ -211,7 +211,7 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
 
         /** {@inheritDoc} */
         @Override public void onCollision(CollisionContext ctx) {
-            GridFutureAdapter<CollisionJobContext> wFut = waitJobFut;
+            GridFutureAdapter<CollisionJobContext> waitFut = waitJobFut;
             GridFutureAdapter<Void> handleCollisionFut = onHandleCollisionFut;
 
             if (handleCollision) {
@@ -220,11 +220,11 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
                 super.onCollision(ctx);
             }
 
-            if (!wFut.isDone()) {
+            if (!waitFut.isDone()) {
                 ctx.waitingJobs().stream()
                     .filter(collisionJobCtx -> collisionJobCtx.getJob() instanceof WaitJob)
                     .findAny()
-                    .ifPresent(wFut::onDone);
+                    .ifPresent(waitFut::onDone);
             }
         }
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
@@ -167,43 +167,37 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
 
         ComputeTaskFuture<Void> taskFut = CRD.compute().executeAsync(new NoopTask(), null);
 
-        try {
-            for (Ignite n : G.allGrids())
-                PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.get(getTestTimeout());
+        for (Ignite n : G.allGrids())
+            PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.get(getTestTimeout());
 
-            for (Ignite n : G.allGrids())
-                PriorityQueueCollisionSpiEx.spiEx(n).handleCollision = true;
+        for (Ignite n : G.allGrids())
+            PriorityQueueCollisionSpiEx.spiEx(n).handleCollision = true;
 
-            taskFut.getTaskSession().setAttribute(key, val);
+        taskFut.getTaskSession().setAttribute(key, val);
 
-            for (Ignite n : G.allGrids()) {
-                assertEquals(
-                    val,
-                    PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.result()
-                        .getTaskSession().waitForAttribute(key, getTestTimeout()));
-            }
-
-            WaitJob.waitFut.onDone();
-
-            for (Ignite n : G.allGrids()) {
-                GridFutureAdapter<Void> fut = PriorityQueueCollisionSpiEx.spiEx(n).onHandleCollisionFut;
-
-                if (expHandleCollisionOnChangeTaskAttrs)
-                    fut.get(getTestTimeout());
-                else
-                    assertThrows(log, () -> fut.get(100), IgniteFutureTimeoutCheckedException.class, null);
-            }
-
-            if (!expHandleCollisionOnChangeTaskAttrs) {
-                CRD.compute().execute(new NoopTask(), null);
-            }
-
-            taskFut.get(getTestTimeout());
-        } finally {
-            // Ensure WaitJobs never block indefinitely if the test fails before reaching
-            // the explicit WaitJob.waitFut.onDone() call above.
-            WaitJob.waitFut.onDone();
+        for (Ignite n : G.allGrids()) {
+            assertEquals(
+                val,
+                PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.result()
+                    .getTaskSession().waitForAttribute(key, getTestTimeout()));
         }
+
+        WaitJob.waitFut.onDone();
+
+        for (Ignite n : G.allGrids()) {
+            GridFutureAdapter<Void> fut = PriorityQueueCollisionSpiEx.spiEx(n).onHandleCollisionFut;
+
+            if (expHandleCollisionOnChangeTaskAttrs)
+                fut.get(getTestTimeout());
+            else
+                assertThrows(log, () -> fut.get(100), IgniteFutureTimeoutCheckedException.class, null);
+        }
+
+        if (!expHandleCollisionOnChangeTaskAttrs) {
+            CRD.compute().execute(new NoopTask(), null);
+        }
+
+        taskFut.get(getTestTimeout());
     }
 
     /** */
@@ -211,19 +205,17 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         /** */
         volatile boolean handleCollision;
 
-        /** Volatile so that a captured reference in onCollision() outlives a reset(). */
         volatile GridFutureAdapter<CollisionJobContext> waitJobFut = new GridFutureAdapter<>();
 
-        /** Volatile so that a captured reference in onCollision() outlives a reset(). */
         volatile GridFutureAdapter<Void> onHandleCollisionFut = new GridFutureAdapter<>();
 
         /** {@inheritDoc} */
         @Override public void onCollision(CollisionContext ctx) {
             GridFutureAdapter<CollisionJobContext> wFut = waitJobFut;
-            GridFutureAdapter<Void> hFut = onHandleCollisionFut;
+            GridFutureAdapter<Void> handleCollisionFut = onHandleCollisionFut;
 
             if (handleCollision) {
-                hFut.onDone();
+                handleCollisionFut.onDone();
 
                 super.onCollision(ctx);
             }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputeJobChangePriorityTest.java
@@ -16,7 +16,6 @@
 
 package org.apache.ignite.internal.processors.compute;
 
-import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,10 +33,8 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.failure.StopNodeFailureHandler;
 import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.IgniteFutureTimeoutCheckedException;
-import org.apache.ignite.internal.processors.job.GridJobProcessor;
 import org.apache.ignite.internal.util.future.GridFutureAdapter;
 import org.apache.ignite.internal.util.typedef.G;
-import org.apache.ignite.lang.IgniteUuid;
 import org.apache.ignite.spi.collision.CollisionContext;
 import org.apache.ignite.spi.collision.CollisionJobContext;
 import org.apache.ignite.spi.collision.priorityqueue.PriorityQueueCollisionSpi;
@@ -49,6 +46,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.apache.ignite.cluster.ClusterState.ACTIVE;
 import static org.apache.ignite.testframework.GridTestUtils.DFLT_TEST_TIMEOUT;
 import static org.apache.ignite.testframework.GridTestUtils.assertThrows;
+import static org.apache.ignite.testframework.GridTestUtils.waitForCondition;
 
 /**
  * Class for testing job priority change.
@@ -56,9 +54,6 @@ import static org.apache.ignite.testframework.GridTestUtils.assertThrows;
 public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
     /** Coordinator. */
     private static IgniteEx CRD;
-
-    /** */
-    private static Method ON_CHANGE_TASK_ATTRS_MTD;
 
     /** {@inheritDoc} */
     @Override protected void beforeTestsStarted() throws Exception {
@@ -73,13 +68,6 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         awaitPartitionMapExchange();
 
         CRD = crd;
-
-        ON_CHANGE_TASK_ATTRS_MTD = GridJobProcessor.class.getDeclaredMethod(
-            "onChangeTaskAttributes",
-            IgniteUuid.class,
-            IgniteUuid.class,
-            Map.class
-        );
     }
 
     /** {@inheritDoc} */
@@ -89,7 +77,6 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         stopAllGrids();
 
         CRD = null;
-        ON_CHANGE_TASK_ATTRS_MTD = null;
     }
 
     /** {@inheritDoc} */
@@ -98,6 +85,23 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
 
         for (Ignite n : G.allGrids())
             PriorityQueueCollisionSpiEx.spiEx(n).reset();
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        for (Ignite n : G.allGrids())
+            PriorityQueueCollisionSpiEx.spiEx(n).handleCollision = true;
+
+        // Release any WaitJobs already executing (blocked on waitFut.get()).
+        WaitJob.waitFut.onDone();
+
+        // Force collision handling to activate any passive WaitJobs.
+        for (Ignite n : G.allGrids())
+            ((IgniteEx)n).context().job().handleCollisionsSync();
+
+        assertTrue(waitForCondition(() -> CRD.compute().activeTaskFutures().isEmpty(), getTestTimeout()));
     }
 
     /** {@inheritDoc} */
@@ -163,36 +167,43 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
 
         ComputeTaskFuture<Void> taskFut = CRD.compute().executeAsync(new NoopTask(), null);
 
-        for (Ignite n : G.allGrids())
-            PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.get(getTestTimeout());
+        try {
+            for (Ignite n : G.allGrids())
+                PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.get(getTestTimeout());
 
-        for (Ignite n : G.allGrids())
-            PriorityQueueCollisionSpiEx.spiEx(n).handleCollision = true;
+            for (Ignite n : G.allGrids())
+                PriorityQueueCollisionSpiEx.spiEx(n).handleCollision = true;
 
-        taskFut.getTaskSession().setAttribute(key, val);
+            taskFut.getTaskSession().setAttribute(key, val);
 
-        for (Ignite n : G.allGrids()) {
-            assertEquals(
-                val,
-                PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.result()
-                    .getTaskSession().waitForAttribute(key, getTestTimeout()));
+            for (Ignite n : G.allGrids()) {
+                assertEquals(
+                    val,
+                    PriorityQueueCollisionSpiEx.spiEx(n).waitJobFut.result()
+                        .getTaskSession().waitForAttribute(key, getTestTimeout()));
+            }
+
+            WaitJob.waitFut.onDone();
+
+            for (Ignite n : G.allGrids()) {
+                GridFutureAdapter<Void> fut = PriorityQueueCollisionSpiEx.spiEx(n).onHandleCollisionFut;
+
+                if (expHandleCollisionOnChangeTaskAttrs)
+                    fut.get(getTestTimeout());
+                else
+                    assertThrows(log, () -> fut.get(100), IgniteFutureTimeoutCheckedException.class, null);
+            }
+
+            if (!expHandleCollisionOnChangeTaskAttrs) {
+                CRD.compute().execute(new NoopTask(), null);
+            }
+
+            taskFut.get(getTestTimeout());
+        } finally {
+            // Ensure WaitJobs never block indefinitely if the test fails before reaching
+            // the explicit WaitJob.waitFut.onDone() call above.
+            WaitJob.waitFut.onDone();
         }
-
-        WaitJob.waitFut.onDone();
-
-        for (Ignite n : G.allGrids()) {
-            GridFutureAdapter<Void> fut = PriorityQueueCollisionSpiEx.spiEx(n).onHandleCollisionFut;
-
-            if (expHandleCollisionOnChangeTaskAttrs)
-                fut.get(getTestTimeout());
-            else
-                assertThrows(log, () -> fut.get(100), IgniteFutureTimeoutCheckedException.class, null);
-        }
-
-        if (!expHandleCollisionOnChangeTaskAttrs)
-            CRD.compute().execute(new NoopTask(), null);
-
-        taskFut.get(getTestTimeout());
     }
 
     /** */
@@ -200,25 +211,28 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         /** */
         volatile boolean handleCollision;
 
-        /** */
-        final GridFutureAdapter<CollisionJobContext> waitJobFut = new GridFutureAdapter<>();
+        /** Volatile so that a captured reference in onCollision() outlives a reset(). */
+        volatile GridFutureAdapter<CollisionJobContext> waitJobFut = new GridFutureAdapter<>();
 
-        /** */
-        final GridFutureAdapter<Void> onHandleCollisionFut = new GridFutureAdapter<>();
+        /** Volatile so that a captured reference in onCollision() outlives a reset(). */
+        volatile GridFutureAdapter<Void> onHandleCollisionFut = new GridFutureAdapter<>();
 
         /** {@inheritDoc} */
         @Override public void onCollision(CollisionContext ctx) {
-            if (!waitJobFut.isDone()) {
+            GridFutureAdapter<CollisionJobContext> wFut = waitJobFut;
+            GridFutureAdapter<Void> hFut = onHandleCollisionFut;
+
+            if (handleCollision) {
+                hFut.onDone();
+
+                super.onCollision(ctx);
+            }
+
+            if (!wFut.isDone()) {
                 ctx.waitingJobs().stream()
                     .filter(collisionJobCtx -> collisionJobCtx.getJob() instanceof WaitJob)
                     .findAny()
-                    .ifPresent(waitJobFut::onDone);
-            }
-
-            if (handleCollision) {
-                    onHandleCollisionFut.onDone();
-
-                super.onCollision(ctx);
+                    .ifPresent(wFut::onDone);
             }
         }
 
@@ -226,9 +240,9 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         void reset() {
             handleCollision = false;
 
-            waitJobFut.reset();
+            waitJobFut = new GridFutureAdapter<>();
 
-            onHandleCollisionFut.reset();
+            onHandleCollisionFut = new GridFutureAdapter<>();
         }
 
         /** */
@@ -252,6 +266,11 @@ public class ComputeJobChangePriorityTest extends GridCommonAbstractTest {
         @Override public Void reduce(List<ComputeJobResult> results) throws IgniteException {
             return null;
         }
+    }
+
+    @Override
+    protected long getTestTimeout() {
+        return 30_000;
     }
 
     /** */

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
@@ -51,8 +51,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected void beforeTestsStarted() throws Exception {
+    @Override protected void beforeTestsStarted() throws Exception {
         startGrids(GRID_CNT);
 
         spi.setParallelJobsNumber(20);
@@ -64,8 +63,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected void afterTestsStopped() throws Exception {
+    @Override protected void afterTestsStopped() throws Exception {
         super.afterTestsStopped();
 
         stopAllGrids();
@@ -74,8 +72,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
         return super.getConfiguration(igniteInstanceName)
             .setFailureHandler(new StopNodeFailureHandler())
             .setCollisionSpi(spi)
@@ -112,8 +109,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
         }
     }
 
-    @Override
-    protected long getTestTimeout() {
+    @Override protected long getTestTimeout() {
         return 30_000L;
     }
 
@@ -122,15 +118,13 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
         @TaskSessionResource
         private ComputeTaskSession taskSes = null;
 
-        @Override
-        protected Collection<ComputeJob> split(int gridSize, Object arg) {
+        @Override protected Collection<ComputeJob> split(int gridSize, Object arg) {
             taskSes.setAttribute("grid.task.priority", new Random().nextInt(10));
 
             List<ComputeJob> jobs = new ArrayList<>(gridSize);
 
             jobs.add(new ComputeJobAdapter() {
-                @Override
-                public Object execute() throws IgniteException {
+                @Override public Object execute() throws IgniteException {
                     try {
                         Thread.sleep(5);
                     } catch (InterruptedException e) {
@@ -144,8 +138,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
             return jobs;
         }
 
-        @Override
-        public Object reduce(List<ComputeJobResult> results) throws IgniteException {
+        @Override public Object reduce(List<ComputeJobResult> results) throws IgniteException {
             return null;
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ * Copyright 2026 GridGain Systems, Inc. and Contributors.
  *
  * Licensed under the GridGain Community Edition License (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,8 @@ package org.apache.ignite.internal.processors.compute;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Random;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteException;
 import org.apache.ignite.compute.ComputeJob;
@@ -32,13 +30,14 @@ import org.apache.ignite.compute.ComputeTaskSession;
 import org.apache.ignite.compute.ComputeTaskSessionFullSupport;
 import org.apache.ignite.compute.ComputeTaskSplitAdapter;
 import org.apache.ignite.configuration.IgniteConfiguration;
-import org.apache.ignite.failure.StopNodeFailureHandler;
 import org.apache.ignite.resources.TaskSessionResource;
+import org.apache.ignite.spi.collision.CollisionContext;
 import org.apache.ignite.spi.collision.priorityqueue.PriorityQueueCollisionSpi;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
-import static java.util.concurrent.CompletableFuture.allOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Tests related to how priority queue collision SPI handles high concurrency cases.
@@ -46,24 +45,32 @@ import static java.util.concurrent.CompletableFuture.allOf;
 public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTest {
     private static final int GRID_CNT = 1;
 
-    private final PriorityQueueCollisionSpi spi = new PriorityQueueCollisionSpi();
+    private static final int PARALLEL_JOBS_COUNT = 100;
+
+    private static final String JOB_PRIORITY_ATTRIBUTE = "grid.job.priority";
+
+    private static final String TASK_PRIORITY_ATTRIBUTE = "grid.task.priority";
+
+    private static final PriorityQueueCollisionSpiEx spi = new PriorityQueueCollisionSpiEx();
 
     /**
      * {@inheritDoc}
      */
-    @Override protected void beforeTestsStarted() throws Exception {
+    @Override
+    protected void beforeTestsStarted() throws Exception {
         startGrids(GRID_CNT);
 
-        spi.setParallelJobsNumber(20);
-        spi.setPriorityAttributeKey("grid.task.priority");
-        spi.setJobPriorityAttributeKey("grid.job.priority");
+        spi.setParallelJobsNumber(PARALLEL_JOBS_COUNT);
+        spi.setPriorityAttributeKey(TASK_PRIORITY_ATTRIBUTE);
+        spi.setJobPriorityAttributeKey(JOB_PRIORITY_ATTRIBUTE);
         spi.setDefaultPriority(0);
     }
 
     /**
      * {@inheritDoc}
      */
-    @Override protected void afterTestsStopped() throws Exception {
+    @Override
+    protected void afterTestsStopped() throws Exception {
         super.afterTestsStopped();
 
         stopAllGrids();
@@ -72,41 +79,23 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+    @Override
+    protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
         return super.getConfiguration(igniteInstanceName)
-            .setFailureHandler(new StopNodeFailureHandler())
-            .setCollisionSpi(spi)
-            .setMetricsUpdateFrequency(Long.MAX_VALUE)
-            .setClientFailureDetectionTimeout(Long.MAX_VALUE);
+            .setCollisionSpi(spi);
     }
 
     @Test
     public void testSubmitManyJobs() {
         Ignite ignite = grid(0);
 
-        // When we submit new task we wait for collision SPI to start it if there are available slots.
-        // Tasks are short-lived, it happens often, so many threads are used to submit enough tasks fast.
-        ExecutorService executor = Executors.newFixedThreadPool(100);
+        int taskCount = 200_000;
 
-        try {
-            int taskCount = 100000;
-
-            CompletableFuture<?>[] futures = new CompletableFuture<?>[taskCount];
-            for (int i = 0; i < taskCount; i++) {
-                CompletableFuture<Object> future = new CompletableFuture<>();
-
-                futures[i] = future;
-
-                executor.submit(() -> {
-                    ignite.compute().executeAsync(new RandomPriorityTask(), "");
-                    future.complete(null);
-                });
-            }
-
-            allOf(futures).join();
-        } finally {
-            executor.shutdown();
+        for (int i = 0; i < taskCount; i++) {
+            ignite.compute().executeAsync(new RandomPriorityTask(), "");
         }
+
+        assertThat(spi.collisionCounter.get(), greaterThan(0L));
     }
 
     @Override protected long getTestTimeout() {
@@ -119,7 +108,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
         private ComputeTaskSession taskSes = null;
 
         @Override protected Collection<ComputeJob> split(int gridSize, Object arg) {
-            taskSes.setAttribute("grid.task.priority", new Random().nextInt(10));
+            taskSes.setAttribute(TASK_PRIORITY_ATTRIBUTE, ThreadLocalRandom.current().nextInt(10));
 
             List<ComputeJob> jobs = new ArrayList<>(gridSize);
 
@@ -140,6 +129,15 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
 
         @Override public Object reduce(List<ComputeJobResult> results) throws IgniteException {
             return null;
+        }
+    }
+
+    private static class PriorityQueueCollisionSpiEx extends PriorityQueueCollisionSpi {
+        private AtomicLong collisionCounter = new AtomicLong();
+
+        @Override
+        public void onCollision(CollisionContext ctx) {
+            collisionCounter.incrementAndGet();
         }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
@@ -57,8 +57,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected void beforeTestsStarted() throws Exception {
+    @Override protected void beforeTestsStarted() throws Exception {
         startGrids(GRID_CNT);
 
         spi.setParallelJobsNumber(PARALLEL_JOBS_COUNT);
@@ -70,8 +69,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected void afterTestsStopped() throws Exception {
+    @Override protected void afterTestsStopped() throws Exception {
         super.afterTestsStopped();
 
         stopAllGrids();
@@ -80,8 +78,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     /**
      * {@inheritDoc}
      */
-    @Override
-    protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
         return super.getConfiguration(igniteInstanceName)
             .setCollisionSpi(spi);
     }
@@ -140,8 +137,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
     private static class PriorityQueueCollisionSpiEx extends PriorityQueueCollisionSpi {
         private AtomicLong collisionCounter = new AtomicLong();
 
-        @Override
-        public void onCollision(CollisionContext ctx) {
+        @Override public void onCollision(CollisionContext ctx) {
             collisionCounter.incrementAndGet();
         }
     }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
@@ -38,6 +38,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
 
 /**
  * Tests related to how priority queue collision SPI handles high concurrency cases.
@@ -91,8 +92,12 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
 
         int taskCount = 200_000;
 
+        long started = System.currentTimeMillis();
+        long timeout = 20_000L;
+
         for (int i = 0; i < taskCount; i++) {
             ignite.compute().executeAsync(new RandomPriorityTask(), "");
+            assertThat(System.currentTimeMillis() - started, lessThan(timeout));
         }
 
         assertThat(spi.collisionCounter.get(), greaterThan(0L));

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.compute;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobAdapter;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeTaskSession;
+import org.apache.ignite.compute.ComputeTaskSessionFullSupport;
+import org.apache.ignite.compute.ComputeTaskSplitAdapter;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.failure.StopNodeFailureHandler;
+import org.apache.ignite.resources.TaskSessionResource;
+import org.apache.ignite.spi.collision.priorityqueue.PriorityQueueCollisionSpi;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+import static java.util.concurrent.CompletableFuture.allOf;
+
+/**
+ * Tests related to how priority queue collision SPI handles high concurrency cases.
+ */
+public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTest {
+    private static final int GRID_CNT = 1;
+
+    private final PriorityQueueCollisionSpi spi = new PriorityQueueCollisionSpi();
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void beforeTestsStarted() throws Exception {
+        startGrids(GRID_CNT);
+
+        spi.setParallelJobsNumber(20);
+        spi.setPriorityAttributeKey("grid.task.priority");
+        spi.setJobPriorityAttributeKey("grid.job.priority");
+        spi.setDefaultPriority(0);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void afterTestsStopped() throws Exception {
+        super.afterTestsStopped();
+
+        stopAllGrids();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        return super.getConfiguration(igniteInstanceName)
+            .setFailureHandler(new StopNodeFailureHandler())
+            .setCollisionSpi(spi)
+            .setMetricsUpdateFrequency(Long.MAX_VALUE)
+            .setClientFailureDetectionTimeout(Long.MAX_VALUE);
+    }
+
+    @Test
+    public void testSubmitManyJobs() {
+        Ignite ignite = grid(0);
+
+        // When we submit new task we wait for collision SPI to start it if there are available slots.
+        // Tasks are short-lived, it happens often, so many threads are used to submit enough tasks fast.
+        ExecutorService executor = Executors.newFixedThreadPool(100);
+
+        try {
+            int taskCount = 100000;
+
+            CompletableFuture<?>[] futures = new CompletableFuture<?>[taskCount];
+            for (int i = 0; i < taskCount; i++) {
+                CompletableFuture<Object> future = new CompletableFuture<>();
+
+                futures[i] = future;
+
+                executor.submit(() -> {
+                    ignite.compute().executeAsync(new RandomPriorityTask(), "");
+                    future.complete(null);
+                });
+            }
+
+            allOf(futures).join();
+        } finally {
+            executor.shutdown();
+        }
+    }
+
+    @Override
+    protected long getTestTimeout() {
+        return 30_000L;
+    }
+
+    @ComputeTaskSessionFullSupport
+    public static class RandomPriorityTask extends ComputeTaskSplitAdapter<Object, Object> {
+        @TaskSessionResource
+        private ComputeTaskSession taskSes = null;
+
+        @Override
+        protected Collection<ComputeJob> split(int gridSize, Object arg) {
+            taskSes.setAttribute("grid.task.priority", new Random().nextInt(10));
+
+            List<ComputeJob> jobs = new ArrayList<>(gridSize);
+
+            jobs.add(new ComputeJobAdapter() {
+                @Override
+                public Object execute() throws IgniteException {
+                    try {
+                        Thread.sleep(5);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    return null;
+                }
+            });
+
+            return jobs;
+        }
+
+        @Override
+        public Object reduce(List<ComputeJobResult> results) throws IgniteException {
+            return null;
+        }
+    }
+}

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/ComputePriorityQueueSpiConcurrencyTest.java
@@ -139,6 +139,7 @@ public class ComputePriorityQueueSpiConcurrencyTest extends GridCommonAbstractTe
 
         @Override public void onCollision(CollisionContext ctx) {
             collisionCounter.incrementAndGet();
+            super.onCollision(ctx);
         }
     }
 }

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
@@ -219,7 +219,7 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
 
         PriorityQueueCollisionSpiEx.collisionSpiEx(node).handleCollision = true;
 
-        node.context().job().handleCollisions();
+        node.context().job().scheduleHandleCollisions();
 
         assertTrue(waitForCondition(jobWorker::isStarted, getTestTimeout(), 10));
 
@@ -229,7 +229,7 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
     }
 
     private static void forceHandleCollisions() {
-        node.context().job().handleCollisionsSync();
+        node.context().job().handleCollisions();
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
@@ -35,6 +35,7 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.failure.FailureHandler;
 import org.apache.ignite.failure.StopNodeFailureHandler;
 import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.processors.job.GridJobProcessor;
 import org.apache.ignite.internal.processors.job.GridJobWorker;
 import org.apache.ignite.internal.processors.job.JobWorkerInterruptionTimeoutObject;
@@ -155,6 +156,8 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
 
+        waitForCollisionHandling();
+
         GridJobWorker jobWorker = jobWorker(node, taskFut.getTaskSession());
 
         cancelWitchChecks(jobWorker);
@@ -177,6 +180,8 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
         computeJobWorkerInterruptTimeout(node).propagate(100L);
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
+
+        waitForCollisionHandling();
 
         GridJobWorker jobWorker = jobWorker(node, taskFut.getTaskSession());
 
@@ -205,6 +210,8 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
 
+        waitForCollisionHandling();
+
         GridJobWorker jobWorker = jobWorker(node, taskFut.getTaskSession());
 
         cancelBeforeStartWitchChecks(jobWorker);
@@ -220,6 +227,10 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
         assertThat(jobWorker.isCancelled(), equalTo(true));
         assertThat(countDownLatchJobInterrupted(jobWorker), equalTo(false));
         assertThat(jobWorkerInterrupters(timeoutObjects(node), jobWorker), hasSize(2));
+    }
+
+    private static void waitForCollisionHandling() throws IgniteInterruptedCheckedException {
+        waitForCondition(() -> !node.compute().activeTaskFutures().isEmpty(), 1000);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
@@ -35,7 +35,6 @@ import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.failure.FailureHandler;
 import org.apache.ignite.failure.StopNodeFailureHandler;
 import org.apache.ignite.internal.IgniteEx;
-import org.apache.ignite.internal.IgniteInterruptedCheckedException;
 import org.apache.ignite.internal.processors.job.GridJobProcessor;
 import org.apache.ignite.internal.processors.job.GridJobWorker;
 import org.apache.ignite.internal.processors.job.JobWorkerInterruptionTimeoutObject;
@@ -156,7 +155,7 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
 
-        waitForCollisionHandling();
+        forceHandleCollisions();
 
         GridJobWorker jobWorker = jobWorker(node, taskFut.getTaskSession());
 
@@ -177,18 +176,18 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
      */
     @Test
     public void testInterrupt() throws Exception {
-        computeJobWorkerInterruptTimeout(node).propagate(100L);
+        computeJobWorkerInterruptTimeout(node).propagate(1_000L);
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
 
-        waitForCollisionHandling();
+        forceHandleCollisions();
 
         GridJobWorker jobWorker = jobWorker(node, taskFut.getTaskSession());
 
         cancelWitchChecks(jobWorker);
 
         // We are waiting for the GridJobWorkerInterrupter to interrupt the worker.
-        taskFut.get(1_000L);
+        taskFut.get(getTestTimeout());
 
         assertThat(jobWorker.isCancelled(), equalTo(true));
         assertThat(countDownLatchJobInterrupted(jobWorker), equalTo(true));
@@ -210,7 +209,7 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
 
-        waitForCollisionHandling();
+        forceHandleCollisions();
 
         GridJobWorker jobWorker = jobWorker(node, taskFut.getTaskSession());
 
@@ -229,8 +228,8 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
         assertThat(jobWorkerInterrupters(timeoutObjects(node), jobWorker), hasSize(2));
     }
 
-    private static void waitForCollisionHandling() throws IgniteInterruptedCheckedException {
-        waitForCondition(() -> !node.compute().activeTaskFutures().isEmpty(), 1000);
+    private static void forceHandleCollisions() {
+        node.context().job().handleCollisionsSync();
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/compute/InterruptComputeJobTest.java
@@ -176,7 +176,7 @@ public class InterruptComputeJobTest extends GridCommonAbstractTest {
      */
     @Test
     public void testInterrupt() throws Exception {
-        computeJobWorkerInterruptTimeout(node).propagate(1_000L);
+        computeJobWorkerInterruptTimeout(node).propagate(100L);
 
         ComputeTaskFuture<Void> taskFut = node.compute().executeAsync(new ComputeTask(CountDownLatchJob.class), null);
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/jobmetrics/GridJobMetricsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/jobmetrics/GridJobMetricsSelfTest.java
@@ -124,7 +124,7 @@ public class GridJobMetricsSelfTest extends GridCommonAbstractTest {
             assertEquals(0, rejected.value());
             assertEquals(0, finished.value());
 
-            waitForCondition(() -> collisionSpi.jobs.size() == 3, 100);
+            g.context().job().handleCollisionsSync();
 
             // Activating 2 of 3 jobs. Rejecting 1 of them.
             Iterator<CollisionJobContext> iter = collisionSpi.jobs.values().iterator();

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/jobmetrics/GridJobMetricsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/jobmetrics/GridJobMetricsSelfTest.java
@@ -69,10 +69,10 @@ public class GridJobMetricsSelfTest extends GridCommonAbstractTest {
     public void testGridJobWaitingRejectedMetrics() throws Exception {
         latch = new CountDownLatch(1);
 
-        GridTestCollision collisioinSpi = new GridTestCollision();
+        GridTestCollision collisionSpi = new GridTestCollision();
 
         IgniteConfiguration cfg = getConfiguration()
-            .setCollisionSpi(collisioinSpi);
+            .setCollisionSpi(collisionSpi);
 
         try (IgniteEx g = startGrid(cfg)) {
             MetricRegistry mreg = g.context().metric().registry(JOBS_METRICS);
@@ -124,8 +124,10 @@ public class GridJobMetricsSelfTest extends GridCommonAbstractTest {
             assertEquals(0, rejected.value());
             assertEquals(0, finished.value());
 
+            waitForCondition(() -> collisionSpi.jobs.size() == 3, 100);
+
             // Activating 2 of 3 jobs. Rejecting 1 of them.
-            Iterator<CollisionJobContext> iter = collisioinSpi.jobs.values().iterator();
+            Iterator<CollisionJobContext> iter = collisionSpi.jobs.values().iterator();
 
             iter.next().cancel();
 

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/jobmetrics/GridJobMetricsSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/jobmetrics/GridJobMetricsSelfTest.java
@@ -124,7 +124,7 @@ public class GridJobMetricsSelfTest extends GridCommonAbstractTest {
             assertEquals(0, rejected.value());
             assertEquals(0, finished.value());
 
-            g.context().job().handleCollisionsSync();
+            g.context().job().handleCollisions();
 
             // Activating 2 of 3 jobs. Rejecting 1 of them.
             Iterator<CollisionJobContext> iter = collisionSpi.jobs.values().iterator();


### PR DESCRIPTION
https://ggsystems.atlassian.net/browse/GG-43609

Problem was that dozens of onCollision methods were run in parallel every time job is submitted / completed. Every time we created slice of all wait jobs, and if there jobs to activate sorted them

compute().executeAsync is sync wrt to onCollision method. I didn't change it as 1. it requires to fix unknown number of tests as they expect sync behavior 2. makes code much messier 3. no benefits outside of synthethic stress test with huge number of short lived tasks 

There was also a problem with changing priorities of jobs that were sorted in other thread, leading to comparator exceptions

I made onCollision method sync to make it run sequentially + added fast exit route

For huge number of short lived tasks it still not great, because we always need to activate new jobs, but this is an extreme case that I don't expect to happen in real life