### PR TITLE
GG-42091 Add HTTP REST endpoints for k8s startup / liveness / readiness / drain

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridAliveCommandTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridAliveCommandTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.processors.rest.GridRestCommand;
+import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.alive.GridAliveCommandHandler;
+import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Handler-level tests for {@link GridAliveCommandHandler}. Per HLD v14 §1,
+ * {@code cmd=alive} returns 200 when the JVM kernel has started, 503
+ * otherwise — and is independent of drain, PME, and supply state.
+ */
+public class GridAliveCommandTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setConnectorConfiguration(new ConnectorConfiguration());
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids(false);
+    }
+
+    /**
+     * Kernel started → HTTP 200 "alive".
+     */
+    @Test
+    public void testAliveOnStartedNode() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        GridAliveCommandHandler hnd = new GridAliveCommandHandler(grid("regular").context());
+
+        GridRestResponse resp = invoke(hnd);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, resp.getSuccessStatus());
+        assertEquals("alive", resp.getResponse());
+    }
+
+    /**
+     * Kernel started but cluster INACTIVE — alive is independent of cluster state.
+     * (cmd=alive answers only "is the node running?").
+     */
+    @Test
+    public void testAliveOnInactiveCluster() throws Exception {
+        startGrid("regular");
+        // Do NOT activate.
+
+        GridAliveCommandHandler hnd = new GridAliveCommandHandler(grid("regular").context());
+
+        GridRestResponse resp = invoke(hnd);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, resp.getSuccessStatus());
+        assertEquals("alive", resp.getResponse());
+    }
+
+    /**
+     * @param hnd Handler.
+     * @return Resolved response.
+     */
+    private static GridRestResponse invoke(GridAliveCommandHandler hnd) throws Exception {
+        GridRestRequest req = new GridRestRequest();
+
+        req.command(GridRestCommand.ALIVE);
+
+        IgniteInternalFuture<GridRestResponse> fut = hnd.handleAsync(req);
+
+        return fut.get();
+    }
+}

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridDrainAndSupplyStatusHttpTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridDrainAndSupplyStatusHttpTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.plugin.AbstractTestPluginProvider;
+import org.apache.ignite.plugin.PluginProvider;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * HTTP-level tests for the v14 probe/lifecycle endpoints: {@code cmd=alive},
+ * {@code cmd=probe}, {@code cmd=drain} (start / status / stop), and
+ * {@code cmd=supply-status}. Exercises the Jetty path end-to-end (request
+ * parsing, handler dispatch, response status, JSON body, and the
+ * {@code X-Active-Thin-Clients} / {@code X-Supplying} response headers
+ * required for shell-parseable preStop hooks).
+ *
+ * <p>Per HLD v14 §2 ({@code 14-probe-rework.md}), {@code cmd=probe} now
+ * returns 503 if any of: kernel not started; drain active; PME in progress;
+ * any non-system cache group has active outbound supply. The
+ * MOVING-partition / supplying transitions during rebalance are exercised
+ * by {@code GridDrainAndSupplyStatusRebalanceTest}.</p>
+ */
+public class GridDrainAndSupplyStatusHttpTest extends GridCommonAbstractTest {
+    /** Default REST port. */
+    private static final int JETTY_PORT = 8080;
+
+    /** Latch released by the delayed-start plugin once the rest http processor is live. */
+    private CountDownLatch triggerPluginStartLatch = new CountDownLatch(1);
+
+    /** Latch awaited by the delayed-start plugin until the test finishes its HTTP probe. */
+    private CountDownLatch triggerRestCmdLatch = new CountDownLatch(1);
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setConnectorConfiguration(new ConnectorConfiguration());
+
+        if ("persistent".equals(igniteInstanceName)) {
+            cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+                .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
+                    .setPersistenceEnabled(true)));
+        }
+        else if ("delayedStart".equals(igniteInstanceName)) {
+            PluginProvider delayedStart = new DelayedStartPluginProvider(triggerPluginStartLatch, triggerRestCmdLatch);
+
+            cfg.setPluginProviders(new PluginProvider[] {delayedStart});
+        }
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids(false);
+
+        cleanPersistenceDir();
+    }
+
+    /**
+     * cmd=probe on a fully ready node returns HTTP 200 "grid has started".
+     */
+    @Test
+    public void testProbeReadyState() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        Resp resp = http("GET", "/ignite?cmd=probe");
+        assertEquals(200, resp.code);
+        assertEquals(0, resp.body.get("successStatus"));
+        assertEquals("grid has started", resp.body.get("response"));
+    }
+
+    /**
+     * cmd=probe returns 503 with error="draining" when the drain flag is set.
+     * action=stop clears the flag and probe returns 200 again.
+     */
+    @Test
+    public void testProbeReturns503WhenDraining() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        // Sanity: probe is 200 before drain is set.
+        Resp pre = http("GET", "/ignite?cmd=probe");
+        assertEquals(200, pre.code);
+
+        // Trip drain.
+        Resp start = http("POST", "/ignite?cmd=drain&action=start");
+        assertEquals(200, start.code);
+        assertEquals("draining", start.body.get("response"));
+
+        // Probe now returns 503 with reason "draining".
+        Resp draining = http("GET", "/ignite?cmd=probe");
+        assertEquals(503, draining.code);
+        assertEquals(503, draining.body.get("successStatus"));
+        assertEquals("draining", draining.body.get("error"));
+
+        // action=stop clears the flag.
+        Resp stop = http("POST", "/ignite?cmd=drain&action=stop");
+        assertEquals(200, stop.code);
+        assertEquals("ready", stop.body.get("response"));
+
+        // Probe is 200 again.
+        Resp ready = http("GET", "/ignite?cmd=probe");
+        assertEquals(200, ready.code);
+        assertEquals("grid has started", ready.body.get("response"));
+    }
+
+    /**
+     * cmd=probe returns 503 "grid has not started" while the kernel is
+     * mid-startup. Mirrors the {@code GridProbeCommandTest#testRestProbeCommandGridNotStarted}
+     * pattern using a plugin that pauses inside {@code onIgniteStart}.
+     */
+    @Test
+    public void testProbeReturns503WhenKernelNotStarted() throws Exception {
+        new Thread(new Runnable() {
+            @Override public void run() {
+                try {
+                    startGrid("delayedStart");
+                }
+                catch (Exception e) {
+                    log.error("error when starting delayedStart grid", e);
+                }
+            }
+        }).start();
+
+        triggerPluginStartLatch.await();
+
+        Resp resp;
+        try {
+            resp = http("GET", "/ignite?cmd=probe");
+        }
+        finally {
+            // Always release the plugin so the grid finishes starting and afterTest can stop it.
+            triggerRestCmdLatch.countDown();
+        }
+
+        assertEquals(503, resp.code);
+        assertEquals(503, resp.body.get("successStatus"));
+        assertEquals("grid has not started", resp.body.get("error"));
+    }
+
+    /**
+     * cmd=probe on an INACTIVE cluster returns HTTP 200. v14 §2 doesn't
+     * special-case cluster state; an INACTIVE cluster with kernel started,
+     * no drain, no PME, and no supply satisfies all 4 conditions.
+     */
+    @Test
+    public void testProbeOnInactiveCluster() throws Exception {
+        // Persistence-enabled config comes up INACTIVE by default — DO NOT activate.
+        startGrid("persistent");
+
+        // Sanity: cluster is INACTIVE.
+        assertFalse(ClusterState.active(grid("persistent").context().state().clusterState().state()));
+
+        Resp resp = http("GET", "/ignite?cmd=probe");
+        assertEquals(200, resp.code);
+        assertEquals(0, resp.body.get("successStatus"));
+        assertEquals("grid has started", resp.body.get("response"));
+    }
+
+    /**
+     * cmd=alive returns HTTP 200 "alive" on a started node, regardless of
+     * cluster state. Liveness is independent of drain / PME / supply.
+     */
+    @Test
+    public void testAliveOnStartedNode() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        Resp resp = http("GET", "/ignite?cmd=alive");
+        assertEquals(200, resp.code);
+        assertEquals(0, resp.body.get("successStatus"));
+        assertEquals("alive", resp.body.get("response"));
+    }
+
+    /**
+     * cmd=alive returns 200 even on an INACTIVE cluster (liveness is "is the
+     * node running?", nothing more).
+     */
+    @Test
+    public void testAliveOnInactiveCluster() throws Exception {
+        startGrid("persistent");
+
+        Resp resp = http("GET", "/ignite?cmd=alive");
+        assertEquals(200, resp.code);
+        assertEquals("alive", resp.body.get("response"));
+    }
+
+    /**
+     * cmd=alive returns 503 "not started" while the kernel is mid-startup.
+     */
+    @Test
+    public void testAliveReturns503WhenKernelNotStarted() throws Exception {
+        new Thread(new Runnable() {
+            @Override public void run() {
+                try {
+                    startGrid("delayedStart");
+                }
+                catch (Exception e) {
+                    log.error("error when starting delayedStart grid", e);
+                }
+            }
+        }).start();
+
+        triggerPluginStartLatch.await();
+
+        Resp resp;
+        try {
+            resp = http("GET", "/ignite?cmd=alive");
+        }
+        finally {
+            triggerRestCmdLatch.countDown();
+        }
+
+        assertEquals(503, resp.code);
+        assertEquals(503, resp.body.get("successStatus"));
+        assertEquals("not started", resp.body.get("error"));
+    }
+
+    /**
+     * action=status emits the {@code X-Active-Thin-Clients} response header
+     * and a structured body containing {@code activeThinClients} and {@code draining}.
+     */
+    @Test
+    public void testDrainStatusEmitsHeader() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        Resp status = http("GET", "/ignite?cmd=drain&action=status");
+        assertEquals(200, status.code);
+        assertEquals(0, status.body.get("successStatus"));
+
+        // Header must be present and match the body field.
+        assertNotNull("X-Active-Thin-Clients header missing", status.headerOf("X-Active-Thin-Clients"));
+
+        // Response payload is a Map (Jackson default for the typed POJO).
+        Object payload = status.body.get("response");
+        assertTrue("response payload not a map: " + payload, payload instanceof Map);
+
+        Map<?, ?> p = (Map<?, ?>)payload;
+        assertEquals(Boolean.FALSE, p.get("draining"));
+        assertEquals(Integer.parseInt(status.headerOf("X-Active-Thin-Clients")), ((Number)p.get("activeThinClients")).intValue());
+    }
+
+    /**
+     * cmd=supply-status returns 200 with {@code X-Supplying: false} on a steady-state
+     * single-node cluster.
+     */
+    @Test
+    public void testSupplyStatusEmitsHeader() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        Resp resp = http("GET", "/ignite?cmd=supply-status");
+        assertEquals(200, resp.code);
+        assertEquals(0, resp.body.get("successStatus"));
+
+        assertEquals("false", resp.headerOf("X-Supplying"));
+
+        Object payload = resp.body.get("response");
+        assertTrue("response payload not a map: " + payload, payload instanceof Map);
+
+        Map<?, ?> p = (Map<?, ?>)payload;
+        assertEquals(Boolean.FALSE, p.get("supplying"));
+    }
+
+    /**
+     * @param method HTTP method.
+     * @param pathQ Path with query string (no host/port).
+     * @return Parsed response.
+     */
+    private static Resp http(String method, String pathQ) throws IOException {
+        URL url = new URL("http://localhost:" + JETTY_PORT + pathQ);
+
+        HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        conn.setRequestMethod(method);
+        conn.connect();
+
+        int code = conn.getResponseCode();
+
+        Map<String, Object> body;
+
+        try (InputStreamReader rdr = new InputStreamReader(
+                code >= 400 ? conn.getErrorStream() : conn.getInputStream())) {
+            body = new ObjectMapper().readValue(rdr, new TypeReference<Map<String, Object>>() { /* No-op. */ });
+        }
+
+        return new Resp(code, body, conn);
+    }
+
+    /** Captures status, body, and response headers. */
+    private static class Resp {
+        /** HTTP status code. */
+        final int code;
+
+        /** Parsed JSON body. */
+        final Map<String, Object> body;
+
+        /** Connection used to read response headers. */
+        private final HttpURLConnection conn;
+
+        /**
+         * @param code Status code.
+         * @param body Parsed body.
+         * @param conn Connection.
+         */
+        Resp(int code, Map<String, Object> body, HttpURLConnection conn) {
+            this.code = code;
+            this.body = body;
+            this.conn = conn;
+        }
+
+        /**
+         * @param name Header name.
+         * @return Header value or {@code null} if absent.
+         */
+        String headerOf(String name) {
+            return conn.getHeaderField(name);
+        }
+    }
+
+    /**
+     * Plugin that pauses inside {@code onIgniteStart} so a test can issue an
+     * HTTP request against a kernal that is mid-startup (REST processor live,
+     * but kernal not yet fully started). Mirror of
+     * {@code GridProbeCommandTest.DelayedStartPluginProvider}.
+     */
+    public static class DelayedStartPluginProvider extends AbstractTestPluginProvider {
+        /** Latch awaited by this plugin until the test finishes its HTTP probe. */
+        private final CountDownLatch triggerRestCmd;
+
+        /** Latch released by this plugin once it has paused (signal to test). */
+        private final CountDownLatch triggerPluginStart;
+
+        /**
+         * @param triggerPluginStartLatch Released when plugin pauses.
+         * @param triggerRestCmdLatch Awaited until test releases.
+         */
+        public DelayedStartPluginProvider(CountDownLatch triggerPluginStartLatch,
+            CountDownLatch triggerRestCmdLatch) {
+            this.triggerPluginStart = triggerPluginStartLatch;
+            this.triggerRestCmd = triggerRestCmdLatch;
+        }
+
+        /** {@inheritDoc} */
+        @Override public String name() {
+            return "DelayedStartPlugin";
+        }
+
+        /** {@inheritDoc} */
+        @Override public void onIgniteStart() {
+            super.onIgniteStart();
+
+            triggerPluginStart.countDown();
+
+            log.info("awaiting rest command latch ...");
+
+            try {
+                triggerRestCmd.await();
+            }
+            catch (InterruptedException e) {
+                log.error("error in custom plugin", e);
+            }
+
+            log.info("finished awaiting rest command latch.");
+        }
+    }
+}

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridDrainAndSupplyStatusRebalanceTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridDrainAndSupplyStatusRebalanceTest.java
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.CacheRebalanceMode;
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.TestRecordingCommunicationSpi;
+import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionSupplyMessage;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Multi-node HTTP-level tests for the rebalance-aware branches of HLD v14
+ * {@code cmd=probe} (which returns 503 while a node has active outbound
+ * supply) and {@code cmd=supply-status} (which reports the same condition
+ * informationally).
+ *
+ * <p>Single-node coverage lives in {@link GridDrainAndSupplyStatusHttpTest};
+ * this class complements it by stalling rebalance with a
+ * {@link TestRecordingCommunicationSpi} so we can observe the HTTP response
+ * while a supplier node is mid-supply.</p>
+ *
+ * <h3>The rebalance-stall recipe (non-obvious — read before editing)</h3>
+ * <ul>
+ *   <li><b>3 existing nodes + 1 joining node</b>, persistence on, {@code backups=1}
+ *       PARTITIONED cache. Backups=1 with 3 servers means partitions actually have
+ *       multiple copies, so the joining node has a real demander/supplier exchange.</li>
+ *   <li><b>{@link CacheRebalanceMode#ASYNC}, NOT {@code SYNC}</b>. {@code SYNC} blocks
+ *       the joining node's {@code onKernalStart} until rebalance completes; the REST
+ *       start-latch never counts down and HTTP requests against the joining node queue
+ *       forever.</li>
+ *   <li><b>{@code setRebalanceBatchSize(256)}</b>. The default 512 KB batch size completes
+ *       in one batch, so {@code isSupply()} flips back to {@code false} instantly even
+ *       with the SPI holding the message. Small batches force multi-batch supply.</li>
+ *   <li><b>Cache-group-scoped block predicate</b>. Blocking ALL
+ *       {@link GridDhtPartitionSupplyMessage}s stalls {@code ignite-sys-cache} too and
+ *       node 3 never finishes start. Block only the test cache group's supply.</li>
+ *   <li><b>Baseline auto-adjust</b>. With persistence, the baseline pins to the original
+ *       3 nodes; node 3 joins topology but isn't in baseline → no partitions assigned →
+ *       no supply demand → {@code waitForBlocked()} hangs. Enable
+ *       {@code baselineAutoAdjustEnabled(true)} + {@code baselineAutoAdjustTimeout(0)}
+ *       so node 3 is added immediately.</li>
+ *   <li>After the block is in place, start node 3, then {@code waitForBlocked()} on the
+ *       suppliers' SPIs. At that moment node 0 has {@code isSupply() == true} for the
+ *       test group.</li>
+ *   <li>After all assertions: {@code stopBlock()} on each existing node's SPI,
+ *       {@code awaitPartitionMapExchange()}, then re-curl to assert the
+ *       {@code false} / 200 transition.</li>
+ * </ul>
+ */
+public class GridDrainAndSupplyStatusRebalanceTest extends GridCommonAbstractTest {
+    /** Cache name used for the rebalance-controlled cache group. */
+    private static final String CACHE = "test";
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setConnectorConfiguration(new ConnectorConfiguration());
+
+        cfg.setCommunicationSpi(new TestRecordingCommunicationSpi());
+
+        cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+            .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
+                .setPersistenceEnabled(true)));
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids(false);
+
+        cleanPersistenceDir();
+    }
+
+    /**
+     * Bring up nodes 0/1/2, activate, create a partitioned-with-backups cache configured
+     * for ASYNC rebalance with small batches, seed it, and let the initial rebalance settle.
+     *
+     * @throws Exception If failed.
+     */
+    private void seedCluster() throws Exception {
+        IgniteEx g0 = startGrid(0);
+        startGrid(1);
+        startGrid(2);
+
+        g0.cluster().state(ClusterState.ACTIVE);
+
+        // Auto-adjust baseline so node 3 will be added to the baseline (and thus assigned
+        // partitions, triggering rebalance) as soon as it joins. Without this, persistence
+        // pins the baseline at the 3-node set and node 3 never demands supply.
+        g0.cluster().baselineAutoAdjustEnabled(true);
+        g0.cluster().baselineAutoAdjustTimeout(0);
+
+        IgniteCache<Integer, Integer> cache = g0.getOrCreateCache(
+            new CacheConfiguration<Integer, Integer>(CACHE)
+                .setBackups(1)
+                .setRebalanceMode(CacheRebalanceMode.ASYNC)
+                .setRebalanceBatchSize(256));
+
+        for (int i = 0; i < 5_000; i++)
+            cache.put(i, i);
+
+        awaitPartitionMapExchange();
+    }
+
+    /**
+     * Install a cache-group-scoped supply-message block on every existing supplier so the
+     * about-to-join node 3 will have MOVING partitions and node 0 will be {@code isSupply()}.
+     */
+    private void blockSupplyForTestGroup() {
+        final int grpId = grid(0).cachex(CACHE).context().groupId();
+
+        for (int i = 0; i < 3; i++) {
+            TestRecordingCommunicationSpi.spi(grid(i)).blockMessages((node, msg) ->
+                msg instanceof GridDhtPartitionSupplyMessage
+                    && ((GridDhtPartitionSupplyMessage)msg).groupId() == grpId);
+        }
+    }
+
+    /** Release the supply block on every existing supplier so rebalance can finish. */
+    private void unblockSupply() {
+        for (int i = 0; i < 3; i++)
+            TestRecordingCommunicationSpi.spi(grid(i)).stopBlock();
+    }
+
+    /**
+     * Per HLD v14 §2, {@code cmd=probe} returns 503 if any non-system cache group has
+     * active outbound supply. While supply is blocked node 0 is mid-supply for the
+     * {@code test} group, so {@code GET /ignite?cmd=probe} on node 0 must respond 503
+     * with {@code error} containing the cache group name. After unblock + PME, node 0
+     * must transition back to 200 "grid has started".
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testProbeReturns503OnSupplier() throws Exception {
+        seedCluster();
+
+        blockSupplyForTestGroup();
+
+        // Start node 3 in a side thread; it'll demand supply from node 0/1/2.
+        Thread joiner = new Thread(() -> {
+            try {
+                startGrid(3);
+            }
+            catch (Exception e) {
+                log.error("error starting node 3", e);
+            }
+        }, "joiner-3");
+
+        joiner.start();
+
+        // Wait for at least one supply message intercepted on node 0 (sufficient evidence
+        // that node 0 has isSupply() == true for the test group right now).
+        TestRecordingCommunicationSpi.spi(grid(0)).waitForBlocked();
+
+        // Node 0 (supplier): cmd=probe must return 503 with reason mentioning the supply.
+        Resp probeOnSupplier = http(8080, "GET", "/ignite?cmd=probe");
+
+        log.info("node0 probe response: code=" + probeOnSupplier.code + " body=" + probeOnSupplier.body);
+
+        assertEquals(503, probeOnSupplier.code);
+        assertEquals(503, probeOnSupplier.body.get("successStatus"));
+        Object err = probeOnSupplier.body.get("error");
+        assertNotNull("error field missing on 503 body: " + probeOnSupplier.body, err);
+        assertTrue("probe error must mention supply: " + err,
+            String.valueOf(err).startsWith("supplying:") || String.valueOf(err).contains(CACHE));
+
+        // Release the block and let rebalance complete.
+        unblockSupply();
+
+        joiner.join(60_000);
+
+        awaitPartitionMapExchange();
+
+        // After rebalance node 0 must transition to 200 "grid has started".
+        Resp probeAfter = http(8080, "GET", "/ignite?cmd=probe");
+
+        log.info("node0 post-rebalance probe: code=" + probeAfter.code + " body=" + probeAfter.body);
+
+        assertEquals(200, probeAfter.code);
+        assertEquals(0, probeAfter.body.get("successStatus"));
+        assertEquals("grid has started", probeAfter.body.get("response"));
+    }
+
+    /**
+     * While supply is blocked, node 0 is mid-supply for the {@code test} group, so
+     * {@code GET /ignite?cmd=supply-status} on node 0 must return 200 with
+     * {@code X-Supplying: true}, body {@code supplying:true}, and {@code supplyingCacheGroups}
+     * containing {@code "test"}. After unblock + PME the same query must report
+     * {@code X-Supplying: false} and an empty {@code supplyingCacheGroups}.
+     *
+     * <p>Also verifies the v14 §2 invariant that {@code cmd=probe} returns 503 on the
+     * supplier during the same window — {@code cmd=supply-status} is informational
+     * (always 200) while {@code cmd=probe} is the gating signal.</p>
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testSupplyStatusReturnsTrueDuringRebalance() throws Exception {
+        seedCluster();
+
+        blockSupplyForTestGroup();
+
+        // Start node 3 — it'll demand supply, the SPI on node 0 holds the message.
+        Thread joiner = new Thread(() -> {
+            try {
+                startGrid(3);
+            }
+            catch (Exception e) {
+                log.error("error starting node 3", e);
+            }
+        }, "joiner-3");
+
+        joiner.start();
+
+        TestRecordingCommunicationSpi.spi(grid(0)).waitForBlocked();
+
+        // Node 0 is now supplying.
+        Resp supplying = http(8080, "GET", "/ignite?cmd=supply-status");
+
+        log.info("node0 supplying response: code=" + supplying.code
+            + " X-Supplying=" + supplying.headerOf("X-Supplying")
+            + " body=" + supplying.body);
+
+        assertEquals(200, supplying.code);
+        assertEquals("true", supplying.headerOf("X-Supplying"));
+
+        Object payload = supplying.body.get("response");
+        assertTrue("response payload not a map: " + payload, payload instanceof Map);
+
+        Map<?, ?> p = (Map<?, ?>)payload;
+        assertEquals(Boolean.TRUE, p.get("supplying"));
+
+        Object groups = p.get("supplyingCacheGroups");
+        assertTrue("supplyingCacheGroups not a list: " + groups, groups instanceof List);
+        assertTrue("expected '" + CACHE + "' in supplyingCacheGroups, got " + groups,
+            ((List<?>)groups).contains(CACHE));
+
+        // v14 invariant: cmd=probe on the same supplier returns 503 in the same window.
+        Resp probe = http(8080, "GET", "/ignite?cmd=probe");
+        assertEquals("cmd=probe must return 503 on a supplier per HLD v14 §2: " + probe.body,
+            503, probe.code);
+
+        // Release the block and let rebalance complete.
+        unblockSupply();
+
+        joiner.join(60_000);
+
+        awaitPartitionMapExchange();
+
+        // After rebalance node 0 must report idle.
+        Resp idle = http(8080, "GET", "/ignite?cmd=supply-status");
+
+        log.info("node0 post-rebalance supply-status: code=" + idle.code
+            + " X-Supplying=" + idle.headerOf("X-Supplying")
+            + " body=" + idle.body);
+
+        assertEquals(200, idle.code);
+        assertEquals("false", idle.headerOf("X-Supplying"));
+
+        Object idlePayload = idle.body.get("response");
+        assertTrue("response payload not a map: " + idlePayload, idlePayload instanceof Map);
+
+        Map<?, ?> ip = (Map<?, ?>)idlePayload;
+        assertEquals(Boolean.FALSE, ip.get("supplying"));
+
+        Object idleGroups = ip.get("supplyingCacheGroups");
+        assertTrue("supplyingCacheGroups not a list: " + idleGroups, idleGroups instanceof List);
+        assertTrue("expected empty supplyingCacheGroups, got " + idleGroups,
+            ((List<?>)idleGroups).isEmpty());
+    }
+
+    /**
+     * @param port Jetty port to hit.
+     * @param method HTTP method.
+     * @param pathQ Path with query string (no host/port).
+     * @return Parsed response.
+     * @throws IOException If the connection failed.
+     */
+    private static Resp http(int port, String method, String pathQ) throws IOException {
+        URL url = new URL("http://localhost:" + port + pathQ);
+
+        HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+        conn.setConnectTimeout(5_000);
+        conn.setReadTimeout(15_000);
+        conn.setRequestMethod(method);
+        conn.connect();
+
+        int code = conn.getResponseCode();
+
+        Map<String, Object> body;
+
+        try (InputStreamReader rdr = new InputStreamReader(
+                code >= 400 ? conn.getErrorStream() : conn.getInputStream())) {
+            body = new ObjectMapper().readValue(rdr, new TypeReference<Map<String, Object>>() { /* No-op. */ });
+        }
+
+        return new Resp(code, body, conn);
+    }
+
+    /** Captures status, body, and response headers. */
+    private static class Resp {
+        /** HTTP status code. */
+        final int code;
+
+        /** Parsed JSON body. */
+        final Map<String, Object> body;
+
+        /** Connection used to read response headers. */
+        private final HttpURLConnection conn;
+
+        /**
+         * @param code Status code.
+         * @param body Parsed body.
+         * @param conn Connection.
+         */
+        Resp(int code, Map<String, Object> body, HttpURLConnection conn) {
+            this.code = code;
+            this.body = body;
+            this.conn = conn;
+        }
+
+        /**
+         * @param name Header name.
+         * @return Header value or {@code null} if absent.
+         */
+        String headerOf(String name) {
+            return conn.getHeaderField(name);
+        }
+    }
+}

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridDrainCommandTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridDrainCommandTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.processors.rest.GridRestCommand;
+import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.drain.DrainStatusResponse;
+import org.apache.ignite.internal.processors.rest.handlers.drain.GridDrainCommandHandler;
+import org.apache.ignite.internal.processors.rest.request.GridRestDrainRequest;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Handler-level tests for {@link GridDrainCommandHandler}. Per HLD v14 §3,
+ * {@code cmd=drain} has three operations: {@code action=start},
+ * {@code action=stop}, and {@code action=status}. The bare-GET readiness
+ * ladder from v13 is gone — readiness moved to {@code cmd=probe}, exercised
+ * by {@code GridProbeCommandTest} and the HTTP-level rebalance tests.
+ */
+public class GridDrainCommandTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setConnectorConfiguration(new ConnectorConfiguration());
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids(false);
+    }
+
+    /**
+     * action=status — returns the {@link DrainStatusResponse} payload with the
+     * current flag and (best-effort) connection count. Connection count is
+     * {@code 0} in this test because no thin client has connected.
+     */
+    @Test
+    public void testActionStatus() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        GridDrainCommandHandler hnd = new GridDrainCommandHandler(grid("regular").context());
+
+        GridRestResponse resp = invoke(hnd, GridDrainCommandHandler.ACTION_STATUS);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, resp.getSuccessStatus());
+        assertTrue(resp.getResponse() instanceof DrainStatusResponse);
+
+        DrainStatusResponse payload = (DrainStatusResponse)resp.getResponse();
+
+        assertFalse(payload.isDraining());
+        assertEquals(0, payload.getActiveThinClients());
+
+        // Trip the flag, then re-read.
+        invoke(hnd, GridDrainCommandHandler.ACTION_START);
+
+        GridRestResponse resp2 = invoke(hnd, GridDrainCommandHandler.ACTION_STATUS);
+
+        DrainStatusResponse payload2 = (DrainStatusResponse)resp2.getResponse();
+
+        assertTrue(payload2.isDraining());
+    }
+
+    /**
+     * action=start sets the drain flag; action=stop clears it (operator
+     * rollback path per HLD v14 §7).
+     */
+    @Test
+    public void testActionStartAndStop() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        GridDrainCommandHandler hnd = new GridDrainCommandHandler(grid("regular").context());
+
+        // Start.
+        GridRestResponse start = invoke(hnd, GridDrainCommandHandler.ACTION_START);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, start.getSuccessStatus());
+        assertEquals("draining", start.getResponse());
+        assertTrue(hnd.drainingFlag());
+
+        // Stop — clears flag, opens cmd=probe back to ready state.
+        GridRestResponse stop = invoke(hnd, GridDrainCommandHandler.ACTION_STOP);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, stop.getSuccessStatus());
+        assertEquals("ready", stop.getResponse());
+        assertFalse(hnd.drainingFlag());
+    }
+
+    /**
+     * Unknown / missing action returns {@code STATUS_FAILED} with a clear
+     * error mentioning the expected actions. Per v14 §3, cmd=drain has no
+     * bare-GET path.
+     */
+    @Test
+    public void testUnknownAction() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        GridDrainCommandHandler hnd = new GridDrainCommandHandler(grid("regular").context());
+
+        GridRestResponse resp = invoke(hnd, null);
+
+        assertEquals(GridRestResponse.STATUS_FAILED, resp.getSuccessStatus());
+        assertNotNull(resp.getError());
+        assertTrue("error must list expected actions: " + resp.getError(),
+            resp.getError().contains("start") && resp.getError().contains("stop") && resp.getError().contains("status"));
+    }
+
+    /**
+     * @param hnd Handler.
+     * @param action Sub-action.
+     * @return Resolved response.
+     */
+    private static GridRestResponse invoke(GridDrainCommandHandler hnd, String action) throws Exception {
+        GridRestDrainRequest req = new GridRestDrainRequest();
+
+        req.command(GridRestCommand.DRAIN);
+        req.action(action);
+
+        IgniteInternalFuture<GridRestResponse> fut = hnd.handleAsync(req);
+
+        return fut.get();
+    }
+}

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridSupplyStatusCommandTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridSupplyStatusCommandTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.processors.rest.GridRestCommand;
+import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.drain.GridSupplyStatusCommandHandler;
+import org.apache.ignite.internal.processors.rest.handlers.drain.SupplyStatusResponse;
+import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Handler-level tests for {@link GridSupplyStatusCommandHandler}. Exercises the
+ * two cases that are testable without forcing a multi-node rebalance — the
+ * supplying-true case is covered by the HTTP-level rebalance tests.
+ */
+public class GridSupplyStatusCommandTest extends GridCommonAbstractTest {
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setConnectorConfiguration(new ConnectorConfiguration());
+
+        if (igniteInstanceName.equals("persistent")) {
+            cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+                .setDefaultDataRegionConfiguration(new DataRegionConfiguration()
+                    .setPersistenceEnabled(true)));
+        }
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        super.afterTest();
+
+        stopAllGrids(false);
+        cleanPersistenceDir();
+    }
+
+    /**
+     * Steady state on a single-node cluster: nothing to supply,
+     * {@code supplying:false}, empty cache-group list.
+     */
+    @Test
+    public void testSteadyStateNotSupplying() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
+
+        GridSupplyStatusCommandHandler hnd = new GridSupplyStatusCommandHandler(grid("regular").context());
+
+        GridRestResponse resp = invoke(hnd);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, resp.getSuccessStatus());
+        assertTrue(resp.getResponse() instanceof SupplyStatusResponse);
+
+        SupplyStatusResponse payload = (SupplyStatusResponse)resp.getResponse();
+
+        assertFalse(payload.isSupplying());
+        assertTrue(payload.getSupplyingCacheGroups().isEmpty());
+    }
+
+    /**
+     * INACTIVE cluster: handler must not throw when iterating cache groups
+     * before activation — returns {@code supplying:false} cleanly.
+     */
+    @Test
+    public void testInactiveClusterNoException() throws Exception {
+        startGrid("persistent");
+
+        // Cluster comes up INACTIVE with persistence; do not activate.
+        assertFalse(ClusterState.active(grid("persistent").context().state().clusterState().state()));
+
+        GridSupplyStatusCommandHandler hnd = new GridSupplyStatusCommandHandler(grid("persistent").context());
+
+        GridRestResponse resp = invoke(hnd);
+
+        assertEquals(GridRestResponse.STATUS_SUCCESS, resp.getSuccessStatus());
+
+        SupplyStatusResponse payload = (SupplyStatusResponse)resp.getResponse();
+
+        assertFalse(payload.isSupplying());
+        assertTrue(payload.getSupplyingCacheGroups().isEmpty());
+    }
+
+    /**
+     * @param hnd Handler.
+     * @return Resolved response.
+     */
+    private static GridRestResponse invoke(GridSupplyStatusCommandHandler hnd) throws Exception {
+        GridRestRequest req = new GridRestRequest();
+
+        req.command(GridRestCommand.SUPPLY_STATUS);
+
+        IgniteInternalFuture<GridRestResponse> fut = hnd.handleAsync(req);
+
+        return fut.get();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/odbc/ClientListenerProcessor.java
@@ -532,6 +532,15 @@ public class ClientListenerProcessor extends GridProcessorAdapter {
     }
 
     /**
+     * @return Number of currently-open client listener sessions (thin clients,
+     * JDBC, ODBC). Returns {@code 0} if the client listener is disabled or has
+     * not started.
+     */
+    public int connectionsCount() {
+        return srv != null ? srv.sessions().size() : 0;
+    }
+
+    /**
      * Prepare connector configuration.
      *
      * @param cfg Ignite configuration.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/GridRestCommand.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/GridRestCommand.java
@@ -224,8 +224,17 @@ public enum GridRestCommand {
     /** Warm-up. */
     WARM_UP("warmup"),
 
-    /** probe. */
-    PROBE("probe");
+    /** probe — readiness gate (kernel started AND no drain AND no PME AND no active supply). */
+    PROBE("probe"),
+
+    /** alive — liveness/startup gate (kernel started). */
+    ALIVE("alive"),
+
+    /** Connection drain control: action=start sets draining flag; action=stop clears it; action=status returns active thin-client count. */
+    DRAIN("drain"),
+
+    /** Outbound partition supply status (informational, never gates traffic). */
+    SUPPLY_STATUS("supply-status");
 
     /** Enum values. */
     private static final GridRestCommand[] VALS = values();

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/GridRestProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/GridRestProcessor.java
@@ -54,7 +54,10 @@ import org.apache.ignite.internal.processors.rest.handlers.cluster.GridBaselineC
 import org.apache.ignite.internal.processors.rest.handlers.cluster.GridChangeClusterStateCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.cluster.GridChangeStateCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.cluster.GridClusterNameCommandHandler;
+import org.apache.ignite.internal.processors.rest.handlers.alive.GridAliveCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.datastructures.DataStructuresCommandHandler;
+import org.apache.ignite.internal.processors.rest.handlers.drain.GridDrainCommandHandler;
+import org.apache.ignite.internal.processors.rest.handlers.drain.GridSupplyStatusCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.log.GridLogCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.memory.MemoryMetricsCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.probe.GridProbeCommandHandler;
@@ -66,6 +69,7 @@ import org.apache.ignite.internal.processors.rest.handlers.version.GridVersionCo
 import org.apache.ignite.internal.processors.rest.handlers.warmup.NodeWarmupCommandHandler;
 import org.apache.ignite.internal.processors.rest.protocols.tcp.GridTcpRestProtocol;
 import org.apache.ignite.internal.processors.rest.request.GridRestCacheRequest;
+import org.apache.ignite.internal.processors.rest.request.GridRestDrainRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestTaskRequest;
 import org.apache.ignite.internal.processors.rest.request.RestQueryRequest;
@@ -96,9 +100,12 @@ import org.apache.ignite.thread.IgniteThread;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_REST_SECURITY_TOKEN_TIMEOUT;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_REST_SESSION_TIMEOUT;
 import static org.apache.ignite.IgniteSystemProperties.IGNITE_REST_START_ON_CLIENT;
+import static org.apache.ignite.internal.processors.rest.GridRestCommand.ALIVE;
 import static org.apache.ignite.internal.processors.rest.GridRestCommand.AUTHENTICATE;
+import static org.apache.ignite.internal.processors.rest.GridRestCommand.DRAIN;
 import static org.apache.ignite.internal.processors.rest.GridRestCommand.NODE_STATE_BEFORE_START;
 import static org.apache.ignite.internal.processors.rest.GridRestCommand.PROBE;
+import static org.apache.ignite.internal.processors.rest.GridRestCommand.SUPPLY_STATUS;
 import static org.apache.ignite.internal.processors.rest.GridRestCommand.VERSION;
 import static org.apache.ignite.internal.processors.rest.GridRestResponse.STATUS_AUTH_FAILED;
 import static org.apache.ignite.internal.processors.rest.GridRestResponse.STATUS_FAILED;
@@ -114,8 +121,12 @@ public class GridRestProcessor extends GridProcessorAdapter {
     private static final String HTTP_PROTO_CLS =
         "org.apache.ignite.internal.processors.rest.protocols.http.jetty.GridJettyRestProtocol";
 
-    /** Commands, that are not required to be authenticated. */
-    private static final Set<GridRestCommand> SKIP_AUTHENTICATION_COMMANDS = EnumSet.of(VERSION, PROBE, NODE_STATE_BEFORE_START);
+    /**
+     * Commands that are unconditionally exempt from authentication. Used by
+     * {@link #isAuthExempt(GridRestRequest)} for the simple case (entire
+     * command, all actions).
+     */
+    private static final Set<GridRestCommand> SKIP_AUTHENTICATION_COMMANDS = EnumSet.of(VERSION, PROBE, ALIVE, NODE_STATE_BEFORE_START, SUPPLY_STATUS);
 
     /** Delay between sessions timeout checks. */
     private static final int SES_TIMEOUT_CHECK_DELAY = 1_000;
@@ -253,7 +264,7 @@ public class GridRestProcessor extends GridProcessorAdapter {
         if (log.isDebugEnabled())
             log.debug("Received request from client: " + req);
 
-        if (SKIP_AUTHENTICATION_COMMANDS.contains(req.command()))
+        if (isAuthExempt(req))
             return handle(req, false);
 
         boolean authenticationEnabled = ctx.authentication().enabled();
@@ -581,6 +592,9 @@ public class GridRestProcessor extends GridProcessorAdapter {
             addHandler(new MemoryMetricsCommandHandler(ctx));
             addHandler(new NodeWarmupCommandHandler(ctx));
             addHandler(new GridProbeCommandHandler(ctx));
+            addHandler(new GridAliveCommandHandler(ctx));
+            addHandler(new GridDrainCommandHandler(ctx));
+            addHandler(new GridSupplyStatusCommandHandler(ctx));
 
             // Start protocols.
             startTcpProtocol();
@@ -979,7 +993,10 @@ public class GridRestProcessor extends GridProcessorAdapter {
             case REMOVE_USER:
             case UPDATE_USER:
             case PROBE:
+            case ALIVE:
             case WARM_UP:
+            case DRAIN:
+            case SUPPLY_STATUS:
                 break;
 
             default:
@@ -995,6 +1012,45 @@ public class GridRestProcessor extends GridProcessorAdapter {
      */
     private boolean isRestEnabled() {
         return !ctx.config().isDaemon() && ctx.config().getConnectorConfiguration() != null;
+    }
+
+    /**
+     * Per-{@code (command, action)} authentication exemption check. Commands
+     * with no mutate path go through the simple
+     * {@link #SKIP_AUTHENTICATION_COMMANDS} set; commands that mix read and
+     * mutate actions on the same key (currently only {@link GridRestCommand#DRAIN})
+     * have a finer-grained check here so that the mutate action requires auth
+     * even though sibling read actions on the same command key do not.
+     *
+     * @param req Request.
+     * @return {@code true} if the request is exempt from authentication.
+     */
+    private static boolean isAuthExempt(GridRestRequest req) {
+        if (SKIP_AUTHENTICATION_COMMANDS.contains(req.command()))
+            return true;
+
+        if (req.command() == DRAIN) {
+            String act = req instanceof GridRestDrainRequest ? ((GridRestDrainRequest)req).action() : null;
+
+            // Per v14: cmd=drain has only start / status / stop (no bare-GET ladder; readiness moved to cmd=probe).
+            // action=status is the sole read path → auth-exempt; action=start and action=stop are mutates → require auth.
+            return GridDrainCommandHandler.ACTION_STATUS.equalsIgnoreCase(act);
+        }
+
+        return false;
+    }
+
+    /**
+     * Lookup the handler registered for a given command. Used by handlers
+     * that need to consult a peer handler's state (e.g.,
+     * {@code GridProbeCommandHandler} reading {@code GridDrainCommandHandler.drainingFlag()}).
+     *
+     * @param cmd Command.
+     * @return Registered handler for {@code cmd}, or {@code null} if no
+     *     handler is registered (REST not started, or unsupported command).
+     */
+    public GridRestCommandHandler getHandler(GridRestCommand cmd) {
+        return handlers.get(cmd);
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/alive/GridAliveCommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/alive/GridAliveCommandHandler.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.handlers.alive;
+
+import java.util.Collection;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.IgnitionEx;
+import org.apache.ignite.internal.processors.rest.GridRestCommand;
+import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandlerAdapter;
+import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
+import org.apache.ignite.internal.util.future.GridFinishedFuture;
+import org.apache.ignite.internal.util.typedef.internal.U;
+
+import static org.apache.ignite.internal.processors.rest.GridRestCommand.ALIVE;
+
+/**
+ * Handler for {@link GridRestCommand#ALIVE}. Liveness/startup gate — returns
+ * {@code 200} when the JVM kernel has started, {@code 503} otherwise. No
+ * partition, supply, or drain logic.
+ *
+ * <p>Used for the Kubernetes {@code livenessProbe} and {@code startupProbe}.
+ * Liveness must NEVER return 503 because the node is rebalancing, supplying,
+ * or being drained — those are all healthy states. Killing the pod in any of
+ * these states triggers a PME, cancels the rebalance, and restarts the cycle.
+ * {@code cmd=alive} answers only "is the node running?"</p>
+ */
+public class GridAliveCommandHandler extends GridRestCommandHandlerAdapter {
+    /** Supported commands. */
+    private static final Collection<GridRestCommand> SUPPORTED_COMMANDS = U.sealList(ALIVE);
+
+    /**
+     * @param ctx Kernal context.
+     */
+    public GridAliveCommandHandler(GridKernalContext ctx) {
+        super(ctx);
+    }
+
+    /** {@inheritDoc} */
+    @Override public Collection<GridRestCommand> supportedCommands() {
+        return SUPPORTED_COMMANDS;
+    }
+
+    /** {@inheritDoc} */
+    @Override public IgniteInternalFuture<GridRestResponse> handleAsync(GridRestRequest req) {
+        assert req != null;
+        assert SUPPORTED_COMMANDS.contains(req.command());
+
+        if (log.isDebugEnabled())
+            log.debug("alive command handler invoked.");
+
+        return new GridFinishedFuture<>(IgnitionEx.hasKernalStarted(ctx.igniteInstanceName())
+            ? new GridRestResponse("alive")
+            : new GridRestResponse(GridRestResponse.SERVICE_UNAVAILABLE, "not started"));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/DrainStatusResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/DrainStatusResponse.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.handlers.drain;
+
+/**
+ * JSON response payload for {@code cmd=drain&action=status}. JavaBean shape so
+ * Jackson serializes the public getters into the {@code response} field of
+ * the surrounding {@code GridRestResponse}. Recognized by
+ * {@code GridJettyRestHandler} to emit the {@code X-Active-Thin-Clients}
+ * response header for shell-parseable preStop hooks.
+ */
+public class DrainStatusResponse {
+    /** Whether the drain flag is currently set on this pod. */
+    private boolean draining;
+
+    /** Active thin-client connection count at the moment this response was built. */
+    private int activeThinClients;
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public DrainStatusResponse() {
+        // No-op.
+    }
+
+    /**
+     * @param draining Drain flag.
+     * @param activeThinClients Active thin-client connection count.
+     */
+    public DrainStatusResponse(boolean draining, int activeThinClients) {
+        this.draining = draining;
+        this.activeThinClients = activeThinClients;
+    }
+
+    /**
+     * @return Drain flag.
+     */
+    public boolean isDraining() {
+        return draining;
+    }
+
+    /**
+     * @param draining Drain flag.
+     */
+    public void setDraining(boolean draining) {
+        this.draining = draining;
+    }
+
+    /**
+     * @return Active thin-client connection count.
+     */
+    public int getActiveThinClients() {
+        return activeThinClients;
+    }
+
+    /**
+     * @param activeThinClients Active thin-client connection count.
+     */
+    public void setActiveThinClients(int activeThinClients) {
+        this.activeThinClients = activeThinClients;
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/GridDrainCommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/GridDrainCommandHandler.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.handlers.drain;
+
+import java.util.Collection;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.processors.rest.GridRestCommand;
+import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandlerAdapter;
+import org.apache.ignite.internal.processors.rest.request.GridRestDrainRequest;
+import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
+import org.apache.ignite.internal.util.future.GridFinishedFuture;
+import org.apache.ignite.internal.util.typedef.internal.U;
+
+import static org.apache.ignite.internal.processors.rest.GridRestCommand.DRAIN;
+
+/**
+ * Handler for {@link GridRestCommand#DRAIN}. Per HLD v14 §3, exposes three
+ * operations:
+ * <ul>
+ *     <li>{@code action=start} — sets a process-scoped {@code drainingFlag}
+ *         (auth required at the processor layer).</li>
+ *     <li>{@code action=stop} — clears the flag (auth required). Operator
+ *         use case: abort a rolling update mid-drain and restore the pod to
+ *         service without restarting it.</li>
+ *     <li>{@code action=status} — returns the current drain flag and the
+ *         active thin-client connection count (auth-exempt).</li>
+ * </ul>
+ *
+ * <p>Readiness is consumed via {@code cmd=probe} (see
+ * {@link org.apache.ignite.internal.processors.rest.handlers.probe.GridProbeCommandHandler}).
+ * {@code cmd=drain} no longer has a bare-GET readiness ladder.</p>
+ *
+ * <p>The drain flag is JVM-scoped — automatically cleared on pod restart by
+ * virtue of being a fresh field on a fresh handler instance. There is no
+ * metastore round-trip or init container.</p>
+ *
+ * <p>This handler MUST NOT touch {@code TcpDiscoverySpi}, MUST NOT trigger
+ * PME, and MUST NOT pause/cancel in-flight supply messages on the drain
+ * path. The drain plane operates in the Kubernetes Service-endpoints plane;
+ * cluster-membership transitions are deferred to SIGTERM and
+ * {@code onKernalStop()}.</p>
+ */
+public class GridDrainCommandHandler extends GridRestCommandHandlerAdapter {
+    /** Supported commands. */
+    private static final Collection<GridRestCommand> SUPPORTED_COMMANDS = U.sealList(DRAIN);
+
+    /** Action constant for the {@code start} sub-command. */
+    public static final String ACTION_START = "start";
+
+    /** Action constant for the {@code stop} sub-command. */
+    public static final String ACTION_STOP = "stop";
+
+    /** Action constant for the {@code status} sub-command. */
+    public static final String ACTION_STATUS = "status";
+
+    /**
+     * Process-scoped drain flag. {@code volatile} for visibility across REST
+     * worker threads and the {@code cmd=probe} handler that reads it. No
+     * metastore round-trip — automatically reset on JVM restart.
+     */
+    private volatile boolean drainingFlag = false;
+
+    /**
+     * @param ctx Kernal context.
+     */
+    public GridDrainCommandHandler(GridKernalContext ctx) {
+        super(ctx);
+    }
+
+    /** {@inheritDoc} */
+    @Override public Collection<GridRestCommand> supportedCommands() {
+        return SUPPORTED_COMMANDS;
+    }
+
+    /**
+     * Public accessor for the drain flag. Read by
+     * {@code GridProbeCommandHandler} via {@code ctx.rest().getHandler(DRAIN)}
+     * and by tests.
+     *
+     * @return Current drain flag value.
+     */
+    public boolean drainingFlag() {
+        return drainingFlag;
+    }
+
+    /** {@inheritDoc} */
+    @Override public IgniteInternalFuture<GridRestResponse> handleAsync(GridRestRequest req) {
+        assert req != null;
+        assert SUPPORTED_COMMANDS.contains(req.command());
+
+        if (log.isDebugEnabled())
+            log.debug("drain command handler invoked: " + req);
+
+        String action = null;
+
+        if (req instanceof GridRestDrainRequest)
+            action = ((GridRestDrainRequest)req).action();
+
+        if (ACTION_START.equalsIgnoreCase(action)) {
+            drainingFlag = true;
+
+            if (log.isInfoEnabled())
+                log.info("Drain flag set; cmd=probe will report 503 (draining) until cmd=drain&action=stop or pod restart.");
+
+            return new GridFinishedFuture<>(new GridRestResponse("draining"));
+        }
+
+        if (ACTION_STOP.equalsIgnoreCase(action)) {
+            drainingFlag = false;
+
+            if (log.isInfoEnabled())
+                log.info("Drain flag cleared; cmd=probe will resume normal readiness behaviour.");
+
+            return new GridFinishedFuture<>(new GridRestResponse("ready"));
+        }
+
+        if (ACTION_STATUS.equalsIgnoreCase(action)) {
+            int connCnt = ctx.sqlListener() != null ? ctx.sqlListener().connectionsCount() : 0;
+
+            return new GridFinishedFuture<>(new GridRestResponse(new DrainStatusResponse(drainingFlag, connCnt)));
+        }
+
+        // Unknown / missing action. Per v14 §3, cmd=drain has no bare-GET path.
+        return new GridFinishedFuture<>(new GridRestResponse(GridRestResponse.STATUS_FAILED,
+            "Unknown drain action: " + action + " (expected one of: start, stop, status)"));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/GridSupplyStatusCommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/GridSupplyStatusCommandHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.handlers.drain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apache.ignite.internal.GridKernalContext;
+import org.apache.ignite.internal.IgniteInternalFuture;
+import org.apache.ignite.internal.processors.cache.CacheGroupContext;
+import org.apache.ignite.internal.processors.cache.GridCachePreloader;
+import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPreloader;
+import org.apache.ignite.internal.processors.rest.GridRestCommand;
+import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandlerAdapter;
+import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
+import org.apache.ignite.internal.util.future.GridFinishedFuture;
+import org.apache.ignite.internal.util.typedef.internal.U;
+
+import static org.apache.ignite.internal.processors.rest.GridRestCommand.SUPPLY_STATUS;
+
+/**
+ * Handler for {@link GridRestCommand#SUPPLY_STATUS}. Reports whether this node
+ * is currently supplying partition data to peers.
+ *
+ * <p>Always returns {@code STATUS_SUCCESS} (HTTP 200). The supply state is
+ * informational only — the design forbids using it as a
+ * readiness gate. The endpoint is consumed by the helm preStop hook (to wait
+ * for outbound supply completion before returning) and by the operator (as an
+ * advisory pre-delete signal).</p>
+ *
+ * <p>This handler MUST NOT influence readiness, MUST NOT trigger PME, and
+ * MUST NOT pause/cancel supply.</p>
+ */
+public class GridSupplyStatusCommandHandler extends GridRestCommandHandlerAdapter {
+    /** Supported commands. */
+    private static final Collection<GridRestCommand> SUPPORTED_COMMANDS = U.sealList(SUPPLY_STATUS);
+
+    /**
+     * @param ctx Kernal context.
+     */
+    public GridSupplyStatusCommandHandler(GridKernalContext ctx) {
+        super(ctx);
+    }
+
+    /** {@inheritDoc} */
+    @Override public Collection<GridRestCommand> supportedCommands() {
+        return SUPPORTED_COMMANDS;
+    }
+
+    /** {@inheritDoc} */
+    @Override public IgniteInternalFuture<GridRestResponse> handleAsync(GridRestRequest req) {
+        assert req != null;
+        assert SUPPORTED_COMMANDS.contains(req.command());
+
+        if (log.isDebugEnabled())
+            log.debug("supply-status command handler invoked.");
+
+        boolean supplying = false;
+        List<String> supplyingGroups = new ArrayList<>();
+
+        // ctx.cache() may be null very early during start; guard.
+        if (ctx.cache() != null) {
+            for (CacheGroupContext grpCtx : ctx.cache().cacheGroups()) {
+                if (grpCtx.isLocal() || grpCtx.systemCache())
+                    continue;
+
+                GridCachePreloader preloader = grpCtx.preloader();
+
+                if (preloader instanceof GridDhtPreloader) {
+                    GridDhtPreloader dht = (GridDhtPreloader)preloader;
+
+                    // Defensive null-check: supplier() may not be set during very early lifecycle.
+                    if (dht.supplier() != null && dht.supplier().isSupply()) {
+                        supplying = true;
+                        supplyingGroups.add(grpCtx.cacheOrGroupName());
+                    }
+                }
+            }
+        }
+
+        return new GridFinishedFuture<>(new GridRestResponse(new SupplyStatusResponse(supplying, supplyingGroups)));
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/SupplyStatusResponse.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/drain/SupplyStatusResponse.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.handlers.drain;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * JSON response payload for {@code cmd=supply-status}. Reports whether this
+ * node is currently supplying partition data to peers and the affected cache
+ * groups. Always paired with {@code STATUS_SUCCESS}; informational only — the
+ * supply state is never used as a readiness gate. Recognized by
+ * {@code GridJettyRestHandler} to emit the {@code X-Supplying} response header
+ * for shell-parseable preStop hooks.
+ */
+public class SupplyStatusResponse {
+    /** Aggregate flag — {@code true} if any non-system, non-local cache group is currently supplying. */
+    private boolean supplying;
+
+    /** Names of the cache groups currently supplying. */
+    private List<String> supplyingCacheGroups = Collections.emptyList();
+
+    /**
+     * Default constructor for Jackson.
+     */
+    public SupplyStatusResponse() {
+        // No-op.
+    }
+
+    /**
+     * @param supplying Aggregate supplying flag.
+     * @param supplyingCacheGroups Names of currently-supplying cache groups.
+     */
+    public SupplyStatusResponse(boolean supplying, List<String> supplyingCacheGroups) {
+        this.supplying = supplying;
+        this.supplyingCacheGroups = supplyingCacheGroups != null ? supplyingCacheGroups : Collections.<String>emptyList();
+    }
+
+    /**
+     * @return Aggregate supplying flag.
+     */
+    public boolean isSupplying() {
+        return supplying;
+    }
+
+    /**
+     * @param supplying Aggregate supplying flag.
+     */
+    public void setSupplying(boolean supplying) {
+        this.supplying = supplying;
+    }
+
+    /**
+     * @return Names of cache groups currently supplying.
+     */
+    public List<String> getSupplyingCacheGroups() {
+        return supplyingCacheGroups;
+    }
+
+    /**
+     * @param supplyingCacheGroups Names of cache groups currently supplying.
+     */
+    public void setSupplyingCacheGroups(List<String> supplyingCacheGroups) {
+        this.supplyingCacheGroups = supplyingCacheGroups != null ? supplyingCacheGroups : Collections.<String>emptyList();
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/probe/GridProbeCommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/probe/GridProbeCommandHandler.java
@@ -20,9 +20,14 @@ import java.util.Collection;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgnitionEx;
+import org.apache.ignite.internal.processors.cache.CacheGroupContext;
+import org.apache.ignite.internal.processors.cache.GridCachePreloader;
+import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPreloader;
 import org.apache.ignite.internal.processors.rest.GridRestCommand;
 import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandlerAdapter;
+import org.apache.ignite.internal.processors.rest.handlers.drain.GridDrainCommandHandler;
 import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
 import org.apache.ignite.internal.util.typedef.internal.U;
@@ -32,6 +37,25 @@ import static org.apache.ignite.internal.processors.rest.GridRestCommand.PROBE;
 
 /**
  * Handler for {@link GridRestCommand#PROBE}.
+ *
+ * <p>Per HLD v14 §2 ({@code 14-probe-rework.md}), {@code cmd=probe} is a
+ * <b>readiness gate</b>. It returns {@code 200} only when ALL of the
+ * following hold:</p>
+ * <ol>
+ *     <li>The kernel has started ({@code IgnitionEx.hasKernalStarted(...)}).</li>
+ *     <li>The drain flag is not set
+ *         ({@link GridDrainCommandHandler#drainingFlag()} {@code == false}).</li>
+ *     <li>No PME is in progress
+ *         ({@code ctx.cache().context().exchange().lastTopologyFuture().isDone()}).</li>
+ *     <li>No non-system cache group has active outbound supply
+ *         ({@code ((GridDhtPreloader) grpCtx.preloader()).supplier().isSupply() == false}).</li>
+ * </ol>
+ *
+ * <p>If any condition fails, returns
+ * {@link GridRestResponse#SERVICE_UNAVAILABLE} (HTTP 503) with the reason in
+ * the {@code error} field.</p>
+ *
+ * <p>The {@code NODE_STATE_BEFORE_START} branch is unchanged.</p>
  */
 public class GridProbeCommandHandler extends GridRestCommandHandlerAdapter {
     /**
@@ -60,7 +84,25 @@ public class GridProbeCommandHandler extends GridRestCommandHandlerAdapter {
                 if (log.isDebugEnabled())
                     log.debug("probe command handler invoked.");
 
-                return new GridFinishedFuture<>(IgnitionEx.hasKernalStarted(ctx.igniteInstanceName()) ? new GridRestResponse("grid has started") : new GridRestResponse(GridRestResponse.SERVICE_UNAVAILABLE, "grid has not started"));
+                // Step 1 — kernel started.
+                if (!IgnitionEx.hasKernalStarted(ctx.igniteInstanceName()))
+                    return notReady("grid has not started");
+
+                // Step 2 — drain flag not set.
+                if (isDraining())
+                    return notReady("draining");
+
+                // Step 3 — no PME in progress.
+                if (!isPmeIdle())
+                    return notReady("PME in progress");
+
+                // Step 4 — no active outbound supply.
+                String supplyingGrp = anySupplyingCacheGroup();
+
+                if (supplyingGrp != null)
+                    return notReady("supplying: " + supplyingGrp);
+
+                return new GridFinishedFuture<>(new GridRestResponse("grid has started"));
             }
 
             case NODE_STATE_BEFORE_START: {
@@ -72,5 +114,70 @@ public class GridProbeCommandHandler extends GridRestCommandHandlerAdapter {
         }
 
         return new GridFinishedFuture<>();
+    }
+
+    /**
+     * @param reason 503 reason.
+     * @return Future carrying a SERVICE_UNAVAILABLE response.
+     */
+    private static IgniteInternalFuture<GridRestResponse> notReady(String reason) {
+        return new GridFinishedFuture<>(new GridRestResponse(GridRestResponse.SERVICE_UNAVAILABLE, reason));
+    }
+
+    /**
+     * Read the drain flag from the registered drain handler instance. If REST
+     * is not started yet (handlers map empty) or the drain handler is not
+     * registered, treat as not draining.
+     *
+     * @return {@code true} if drain is active.
+     */
+    private boolean isDraining() {
+        if (ctx.rest() == null)
+            return false;
+
+        GridRestCommandHandler hnd = ctx.rest().getHandler(GridRestCommand.DRAIN);
+
+        return hnd instanceof GridDrainCommandHandler && ((GridDrainCommandHandler)hnd).drainingFlag();
+    }
+
+    /**
+     * @return {@code true} if the last topology future is done (no PME in
+     *     progress). Returns {@code true} defensively if the cache subsystem
+     *     is not available yet.
+     */
+    private boolean isPmeIdle() {
+        if (ctx.cache() == null || ctx.cache().context() == null || ctx.cache().context().exchange() == null)
+            return true;
+
+        return ctx.cache().context().exchange().lastTopologyFuture() == null
+            || ctx.cache().context().exchange().lastTopologyFuture().isDone();
+    }
+
+    /**
+     * Iterate non-system, non-local cache groups and return the name of the
+     * first group whose DHT preloader's supplier reports {@code isSupply() ==
+     * true}. Returns {@code null} if no group is supplying.
+     *
+     * @return Name of a supplying cache group, or {@code null}.
+     */
+    private String anySupplyingCacheGroup() {
+        if (ctx.cache() == null)
+            return null;
+
+        for (CacheGroupContext grpCtx : ctx.cache().cacheGroups()) {
+            if (grpCtx.isLocal() || grpCtx.systemCache())
+                continue;
+
+            GridCachePreloader preloader = grpCtx.preloader();
+
+            if (preloader instanceof GridDhtPreloader) {
+                GridDhtPreloader dht = (GridDhtPreloader)preloader;
+
+                if (dht.supplier() != null && dht.supplier().isSupply())
+                    return grpCtx.cacheOrGroupName();
+            }
+        }
+
+        return null;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/request/GridRestDrainRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/request/GridRestDrainRequest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.request;
+
+import org.apache.ignite.internal.util.typedef.internal.S;
+
+/**
+ * Request for the {@code DRAIN} REST command. Carries the {@code action}
+ * sub-command per HLD v14 §3: {@code "start"}, {@code "stop"}, or
+ * {@code "status"}.
+ */
+public class GridRestDrainRequest extends GridRestRequest {
+    /** Sub-action: {@code "start"}, {@code "stop"}, or {@code "status"}. */
+    private String action;
+
+    /**
+     * @return Sub-action.
+     */
+    public String action() {
+        return action;
+    }
+
+    /**
+     * @param action Sub-action.
+     */
+    public void action(String action) {
+        this.action = action;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(GridRestDrainRequest.class, this, super.toString());
+    }
+}

--- a/modules/rest-http/src/main/java/org/apache/ignite/internal/processors/rest/protocols/http/jetty/GridJettyRestHandler.java
+++ b/modules/rest-http/src/main/java/org/apache/ignite/internal/processors/rest/protocols/http/jetty/GridJettyRestHandler.java
@@ -51,12 +51,15 @@ import org.apache.ignite.internal.processors.cache.CacheConfigurationOverride;
 import org.apache.ignite.internal.processors.rest.GridRestCommand;
 import org.apache.ignite.internal.processors.rest.GridRestProtocolHandler;
 import org.apache.ignite.internal.processors.rest.GridRestResponse;
+import org.apache.ignite.internal.processors.rest.handlers.drain.DrainStatusResponse;
+import org.apache.ignite.internal.processors.rest.handlers.drain.SupplyStatusResponse;
 import org.apache.ignite.internal.processors.rest.request.DataStructuresRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestBaselineRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestCacheRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestChangeStateRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestClusterNameRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestClusterStateRequest;
+import org.apache.ignite.internal.processors.rest.request.GridRestDrainRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestLogRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestNodeStateBeforeStartRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
@@ -212,6 +215,31 @@ public class GridJettyRestHandler extends AbstractHandler {
         catch (NumberFormatException ignore) {
             throw new IgniteCheckedException(format(FAILED_TO_PARSE_FORMAT, "Long", key, val));
         }
+    }
+
+    /**
+     * Emit response headers that mirror well-known typed payloads carried in
+     * {@link GridRestResponse#getResponse()}. Used by the helm preStop hook,
+     * which parses these headers in pure shell ({@code grep}/{@code awk}) so
+     * the chart works without python or jq in the container image.
+     *
+     * <p>Header contract is frozen by the
+     * {@code GG-47498} ticket:</p>
+     * <ul>
+     *     <li>{@code DrainStatusResponse} → {@code X-Active-Thin-Clients}: integer.</li>
+     *     <li>{@code SupplyStatusResponse} → {@code X-Supplying}: lowercase {@code true}/{@code false}.</li>
+     * </ul>
+     *
+     * @param res HTTP response to mutate.
+     * @param cmdRes REST response carrying the typed payload.
+     */
+    private static void emitTypedResponseHeaders(HttpServletResponse res, GridRestResponse cmdRes) {
+        Object payload = cmdRes.getResponse();
+
+        if (payload instanceof DrainStatusResponse)
+            res.setHeader("X-Active-Thin-Clients", Integer.toString(((DrainStatusResponse)payload).getActiveThinClients()));
+        else if (payload instanceof SupplyStatusResponse)
+            res.setHeader("X-Supplying", ((SupplyStatusResponse)payload).isSupplying() ? "true" : "false");
     }
 
     /**
@@ -460,6 +488,11 @@ public class GridJettyRestHandler extends AbstractHandler {
                 cmdRes.setSessionToken(U.byteArray2HexString(sesTok));
 
             res.setStatus(cmdRes.getSuccessStatus() == GridRestResponse.SERVICE_UNAVAILABLE ? HttpServletResponse.SC_SERVICE_UNAVAILABLE : HttpServletResponse.SC_OK);
+
+            // Emit response headers for shell-parseable preStop hooks. The headers
+            // mirror well-known typed payloads on GridRestResponse.getResponse().
+            // Pure-shell preStop scripts parse these without python/jq.
+            emitTypedResponseHeaders(res, cmdRes);
         }
         catch (Throwable e) {
             res.setStatus(HttpServletResponse.SC_OK);
@@ -789,8 +822,20 @@ public class GridJettyRestHandler extends AbstractHandler {
             case DATA_STORAGE_METRICS:
             case NAME:
             case VERSION:
-            case PROBE: {
+            case PROBE:
+            case ALIVE:
+            case SUPPLY_STATUS: {
                 restReq = new GridRestRequest();
+
+                break;
+            }
+
+            case DRAIN: {
+                GridRestDrainRequest restReq0 = new GridRestDrainRequest();
+
+                restReq0.action(params.get("action"));
+
+                restReq = restReq0;
 
                 break;
             }


### PR DESCRIPTION
## Summary

Implements the GG8 server-side surface for the probe/lifecycle rework HLD (`14-probe-rework.md`).

- New `cmd=alive` REST endpoint — kernel-started check; for livenessProbe and startupProbe.
- `cmd=probe` reworked into the readiness gate — 503 when kernel not started, drain active, PME in progress, or any non-system cache group has active outbound supply.
- New `cmd=drain` REST endpoint with three actions (`start`/`stop`/`status`) — operator-driven drain control with X-Active-Thin-Clients response header.
- New `cmd=supply-status` REST endpoint — informational, always 200, with X-Supplying response header for shell-parseable preStop hooks.
- Auth split per-`(command, action)` — DRAIN `action=status` and the read endpoints are exempt; DRAIN `action=start`/`stop` require auth.

## Jira

[GG-47498](https://ggsystems.atlassian.net/browse/GG-47498)

[GG-47498]: https://ggsystems.atlassian.net/browse/GG-47498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ