### PR TITLE
GG-48476 UriDeploymentSpi file scanner thread dies on NoClassDefFoundError

### DIFF
--- a/modules/extdata/uri/pom.xml
+++ b/modules/extdata/uri/pom.xml
@@ -238,7 +238,7 @@
 
                                 <signjar jar="${basedir}/target/file/bad-signed-deployfile.jar" keystore="${basedir}/config/signeddeploy/keystore" storepass="abc123" keypass="abc123" alias="business" />
 
-                                <sleep seconds="2" />
+                                <sleep seconds="5" />
 
                                 <touch file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask11.class" />
 
@@ -398,7 +398,7 @@
 
                                 <signjar jar="${basedir}/target/file/bad-signed-deployfile.gar" keystore="${basedir}/config/signeddeploy/keystore" storepass="abc123" keypass="abc123" alias="business" />
 
-                                <sleep seconds="2" />
+                                <sleep seconds="5" />
 
                                 <touch file="${basedir}/target/classes/org/apache/ignite/spi/deployment/uri/tasks/GridUriDeploymentTestWithNameTask6.class" />
 

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentDiscovery.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentDiscovery.java
@@ -77,7 +77,7 @@ final class GridUriDeploymentDiscovery {
                         rsrcs.add(rsrc);
                 }
             }
-            catch (IOException e) {
+            catch (IOException | NoClassDefFoundError e) {
                 throw new IgniteSpiException("Failed to discover classes in file: " + file.getAbsolutePath(), e);
             }
         }

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentFileResourceLoader.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentFileResourceLoader.java
@@ -70,7 +70,7 @@ class GridUriDeploymentFileResourceLoader {
             try {
                 return (Class<? extends ComputeTask<?, ?>>)clsLdr.loadClass(str);
             }
-            catch (ClassNotFoundException e) {
+            catch (ClassNotFoundException | NoClassDefFoundError e) {
                 if (ignoreUnknownRsrc) {
                     // No-op.
                 }

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentJarVerifier.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentJarVerifier.java
@@ -233,7 +233,10 @@ final class GridUriDeploymentJarVerifier {
 
                 // Verify by reading the file if altered.
                 // Will return quietly if no problem.
-                verifyDigestsImplicitly(jarFile.getInputStream(jarEntry));
+                // Stream must be closed so JarFile triggers SecurityException on digest mismatch.
+                try (InputStream entryIn = jarFile.getInputStream(jarEntry)) {
+                    verifyDigestsImplicitly(entryIn);
+                }
 
                 if (!verifyEntry(jarEntry, manifest, pubKey, allSigned, false))
                     return false;

--- a/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentSpringDocument.java
+++ b/modules/urideploy/src/main/java/org/apache/ignite/spi/deployment/uri/GridUriDeploymentSpringDocument.java
@@ -73,7 +73,7 @@ class GridUriDeploymentSpringDocument {
                             try {
                                 taskCls = clsLdr.loadClass(clsName);
                             }
-                            catch (ClassNotFoundException e) {
+                            catch (ClassNotFoundException | NoClassDefFoundError e) {
                                 throw new IgniteSpiException("Failed to load task class [className=" + clsName + ']', e);
                             }
 


### PR DESCRIPTION
Failure rate at master branch: https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_SPIURIDeploy?branch=%3Cdefault%3E&buildTypeTab=overview (3 out of 10)

Failure rate at this branch: https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_SPIURIDeploy?branch=GG-48476&buildTypeTab=overview (0 out of 10)

This PR fixes two independent bugs that caused GridFileDeploymentSelfTest.testSignedDeployment to fail intermittently on CI.

Bug 1 — Scanner thread killed by NoClassDefFoundError

  NoClassDefFoundError is thrown by the JVM when a .class file's internal class name doesn't match the name it was loaded as (e.g., GridUriDeploymentTestWithNameTask11.class contains GridUriDeploymentTestTask11 bytecode). This is an Error, not an Exception.

  The URI deployment scanner's call stack only caught IgniteSpiException. Uncaught Error propagated up to IgniteSpiThread.run, which logged it and then re-threw it, killing the scanner thread permanently. All subsequent deployments in the same SPI instance silently failed.


  Bug 2 — Bad-signed JAR passes signature verification intermittently

  bad-signed-deployfile.jar is constructed by signing a JAR, then using <touch> + <zip update="yes"> to replace one class entry with real bytecode (invalidating the signature).


