### PR TITLE
GG-48372 bump version to 8.10

### DIFF
--- a/examples-ml/pom.xml
+++ b/examples-ml/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/aop/pom.xml
+++ b/modules/aop/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/apache-license-gen/pom.xml
+++ b/modules/apache-license-gen/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>org.gridgain</groupId>
     <artifactId>ignite-apache-license-gen</artifactId>
-    <version>8.9.127-SNAPSHOT</version>
+    <version>8.10.127-SNAPSHOT</version>
     <url>http://ignite.apache.org</url>
 
     <properties>

--- a/modules/aws/pom.xml
+++ b/modules/aws/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/benchmarks/pom.xml
+++ b/modules/benchmarks/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/cassandra/pom.xml
+++ b/modules/cassandra/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/cassandra/serializers/pom.xml
+++ b/modules/cassandra/serializers/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-cassandra</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/cassandra/store/pom.xml
+++ b/modules/cassandra/store/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-cassandra</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/clients/pom.xml
+++ b/modules/clients/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/cloud/pom.xml
+++ b/modules/cloud/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/codegen/pom.xml
+++ b/modules/codegen/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/compatibility/pom.xml
+++ b/modules/compatibility/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/compress/pom.xml
+++ b/modules/compress/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/control-utility/pom.xml
+++ b/modules/control-utility/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/core/src/main/resources/ignite.properties
+++ b/modules/core/src/main/resources/ignite.properties
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-ignite.version=8.9.127-SNAPSHOT
+ignite.version=8.10.127-SNAPSHOT
 ignite.build=0
 ignite.revision=DEV
 ignite.rel.date=01011970

--- a/modules/direct-io/pom.xml
+++ b/modules/direct-io/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/extdata/p2p/pom.xml
+++ b/modules/extdata/p2p/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/extdata/platform/pom.xml
+++ b/modules/extdata/platform/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/extdata/uri/modules/uri-dependency/pom.xml
+++ b/modules/extdata/uri/modules/uri-dependency/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/extdata/uri/pom.xml
+++ b/modules/extdata/uri/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/gce/pom.xml
+++ b/modules/gce/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/geospatial/pom.xml
+++ b/modules/geospatial/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/h2/pom.xml
+++ b/modules/h2/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/hibernate-4.2/pom.xml
+++ b/modules/hibernate-4.2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/hibernate-5.1/pom.xml
+++ b/modules/hibernate-5.1/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/hibernate-5.3/pom.xml
+++ b/modules/hibernate-5.3/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/hibernate-core/pom.xml
+++ b/modules/hibernate-core/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/ignored-tests/pom.xml
+++ b/modules/ignored-tests/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/indexing/pom.xml
+++ b/modules/indexing/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/jcl/pom.xml
+++ b/modules/jcl/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/jta/pom.xml
+++ b/modules/jta/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/kubernetes/pom.xml
+++ b/modules/kubernetes/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/log4j/pom.xml
+++ b/modules/log4j/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/log4j2/pom.xml
+++ b/modules/log4j2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/lucene-8/pom.xml
+++ b/modules/lucene-8/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 
     <artifactId>ignite-lucene-8</artifactId>
-    <version>8.9.127-SNAPSHOT</version>
+    <version>8.10.127-SNAPSHOT</version>
 
     <dependencies>
         <dependency>

--- a/modules/lucene-9/pom.xml
+++ b/modules/lucene-9/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 
     <artifactId>ignite-lucene-9</artifactId>
-    <version>8.9.127-SNAPSHOT</version>
+    <version>8.10.127-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.target>11</maven.compiler.target>

--- a/modules/mesos/pom.xml
+++ b/modules/mesos/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/ml/mleap-model-parser/pom.xml
+++ b/modules/ml/mleap-model-parser/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/ml/pom.xml
+++ b/modules/ml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/ml/spark-model-parser/pom.xml
+++ b/modules/ml/spark-model-parser/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/ml/xgboost-model-parser/pom.xml
+++ b/modules/ml/xgboost-model-parser/pom.xml
@@ -31,7 +31,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/numa-allocator/pom.xml
+++ b/modules/numa-allocator/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/opencensus/pom.xml
+++ b/modules/opencensus/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/opentelemetry/pom.xml
+++ b/modules/opentelemetry/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/platforms/cpp/benchmarks/configure.ac
+++ b/modules/platforms/cpp/benchmarks/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++ Benchmarks], [8.9.127.6496], [dev@ignite.apache.org], [ignite-benchmarks], [ignite.apache.org])
+AC_INIT([Apache Ignite C++ Benchmarks], [8.10.127.6496], [dev@ignite.apache.org], [ignite-benchmarks], [ignite.apache.org])
 
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])

--- a/modules/platforms/cpp/binary/configure.ac
+++ b/modules/platforms/cpp/binary/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite binary protocol library for C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite-binary], [ignite.apache.org])
+AC_INIT([Apache Ignite binary protocol library for C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite-binary], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/common/configure.ac
+++ b/modules/platforms/cpp/common/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite common library for C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite-common], [ignite.apache.org])
+AC_INIT([Apache Ignite common library for C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite-common], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/configure.ac
+++ b/modules/platforms/cpp/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
+AC_INIT([Apache Ignite C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
 
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])

--- a/modules/platforms/cpp/configure.acrel
+++ b/modules/platforms/cpp/configure.acrel
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
+AC_INIT([Apache Ignite C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
 
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])

--- a/modules/platforms/cpp/core-test/configure.ac
+++ b/modules/platforms/cpp/core-test/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++ Test], [8.9.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
+AC_INIT([Apache Ignite C++ Test], [8.10.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/core/configure.ac
+++ b/modules/platforms/cpp/core/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
+AC_INIT([Apache Ignite C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/examples/configure.ac
+++ b/modules/platforms/cpp/examples/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++ Examples], [8.9.127.6496], [dev@ignite.apache.org], [ignite-examples], [ignite.apache.org])
+AC_INIT([Apache Ignite C++ Examples], [8.10.127.6496], [dev@ignite.apache.org], [ignite-examples], [ignite.apache.org])
 
 AC_CANONICAL_HOST
 AC_CONFIG_MACRO_DIR([m4])

--- a/modules/platforms/cpp/ignite/configure.ac
+++ b/modules/platforms/cpp/ignite/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++ Runner], [8.9.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
+AC_INIT([Apache Ignite C++ Runner], [8.10.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/network/configure.ac
+++ b/modules/platforms/cpp/network/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite network library for C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite-network], [ignite.apache.org])
+AC_INIT([Apache Ignite network library for C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite-network], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/odbc/configure.ac
+++ b/modules/platforms/cpp/odbc/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite ODBC driver for C++], [8.9.127.6496], [dev@ignite.apache.org], [ignite-odbc], [ignite.apache.org])
+AC_INIT([Apache Ignite ODBC driver for C++], [8.10.127.6496], [dev@ignite.apache.org], [ignite-odbc], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/cpp/thin-client-test/configure.ac
+++ b/modules/platforms/cpp/thin-client-test/configure.ac
@@ -17,7 +17,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.69])
-AC_INIT([Apache Ignite C++ Thin Client Test], [8.9.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
+AC_INIT([Apache Ignite C++ Thin Client Test], [8.10.127.6496], [dev@ignite.apache.org], [ignite], [ignite.apache.org])
 AC_CONFIG_SRCDIR(src)
 
 AC_CANONICAL_SYSTEM

--- a/modules/platforms/dotnet/SharedAssemblyInfo.cs
+++ b/modules/platforms/dotnet/SharedAssemblyInfo.cs
@@ -23,6 +23,6 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("8.9.127.6496")]
-[assembly: AssemblyFileVersion("8.9.127.6496")]
-[assembly: AssemblyInformationalVersion("8.9.127")]
+[assembly: AssemblyVersion("8.10.127.6496")]
+[assembly: AssemblyFileVersion("8.10.127.6496")]
+[assembly: AssemblyInformationalVersion("8.10.127")]

--- a/modules/rest-http/pom.xml
+++ b/modules/rest-http/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/schedule/pom.xml
+++ b/modules/schedule/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/slf4j/pom.xml
+++ b/modules/slf4j/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/spring-6/pom.xml
+++ b/modules/spring-6/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/spring-data-2.2/pom.xml
+++ b/modules/spring-data-2.2/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/spring-data-commons/pom.xml
+++ b/modules/spring-data-commons/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/spring/pom.xml
+++ b/modules/spring/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/sqlline/pom.xml
+++ b/modules/sqlline/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/ssh/pom.xml
+++ b/modules/ssh/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/tools/pom.xml
+++ b/modules/tools/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent/pom.xml</relativePath>
     </parent>
 

--- a/modules/urideploy/pom.xml
+++ b/modules/urideploy/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/web/ignite-appserver-test/pom.xml
+++ b/modules/web/ignite-appserver-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/web/ignite-websphere-test/pom.xml
+++ b/modules/web/ignite-websphere-test/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/web/pom.xml
+++ b/modules/web/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/yardstick/pom.xml
+++ b/modules/yardstick/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/yarn/pom.xml
+++ b/modules/yarn/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/modules/zookeeper/pom.xml
+++ b/modules/zookeeper/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent-internal</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../../parent-internal/pom.xml</relativePath>
     </parent>
 

--- a/parent-internal/pom.xml
+++ b/parent-internal/pom.xml
@@ -28,12 +28,12 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>ignite-parent-internal</artifactId>
-    <version>8.9.127-SNAPSHOT</version>
+    <version>8.10.127-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,7 +34,7 @@
 
     <groupId>org.gridgain</groupId>
     <artifactId>ignite-parent</artifactId>
-    <version>8.9.127-SNAPSHOT</version>
+    <version>8.10.127-SNAPSHOT</version>
     <packaging>pom</packaging>
     <url>http://www.gridgain.com</url>
 
@@ -278,7 +278,7 @@
                         <dependency>
                             <groupId>org.gridgain</groupId>
                             <artifactId>ignite-tools</artifactId>
-                            <version>8.9.127-SNAPSHOT</version>
+                            <version>8.10.127-SNAPSHOT</version>
                         </dependency>
                     </dependencies>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,12 +25,12 @@
     <parent>
         <groupId>org.gridgain</groupId>
         <artifactId>ignite-parent</artifactId>
-        <version>8.9.127-SNAPSHOT</version>
+        <version>8.10.127-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>apache-ignite</artifactId>
-    <version>8.9.127-SNAPSHOT</version>
+    <version>8.10.127-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <scm>


### PR DESCRIPTION
[GG-48372](https://ggsystems.atlassian.net/browse/GG-48372)

Bumps version to `8.10.127-SNAPSHOT` (post 8.9-master cut, see [GG-48371](https://ggsystems.atlassian.net/browse/GG-48371)).

Mirrors recipe from GG-37281 (2023 8.8→8.9 bump):
- `pom.xml` `<version>` declarations
- `ignite.properties`
- `*AssemblyInfo.cs` (.NET)
- `configure.ac` / `configure.acrel` (C++)

[GG-48372]: https://ggsystems.atlassian.net/browse/GG-48372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GG-48371]: https://ggsystems.atlassian.net/browse/GG-48371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ