### PR TITLE
GG-48516 Fix flaky testStoppedState: use static IP finder 

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/GridStartStopSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridStartStopSelfTest.java
@@ -64,8 +64,6 @@ public class GridStartStopSelfTest extends GridCommonAbstractTest {
 
         cfg.setConnectorConfiguration(null);
 
-        cfg.setDiscoverySpi(new TcpDiscoverySpi().setIpFinder(sharedStaticIpFinder));
-
         info("Grid start-stop test count: " + COUNT);
 
         for (int i = 0; i < COUNT; i++) {

--- a/modules/core/src/test/java/org/apache/ignite/internal/GridStartStopSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/GridStartStopSelfTest.java
@@ -29,6 +29,7 @@ import org.apache.ignite.IgniteException;
 import org.apache.ignite.configuration.CacheConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
 import org.apache.ignite.internal.util.typedef.G;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.testframework.GridTestUtils;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.testframework.junits.common.GridCommonTest;
@@ -62,6 +63,8 @@ public class GridStartStopSelfTest extends GridCommonAbstractTest {
         IgniteConfiguration cfg = new IgniteConfiguration();
 
         cfg.setConnectorConfiguration(null);
+
+        cfg.setDiscoverySpi(new TcpDiscoverySpi().setIpFinder(sharedStaticIpFinder));
 
         info("Grid start-stop test count: " + COUNT);
 
@@ -152,6 +155,8 @@ public class GridStartStopSelfTest extends GridCommonAbstractTest {
         IgniteConfiguration cfg = new IgniteConfiguration();
 
         cfg.setConnectorConfiguration(null);
+
+        cfg.setDiscoverySpi(new TcpDiscoverySpi().setIpFinder(sharedStaticIpFinder));
 
         IgniteEx ignite = startGrid(cfg);
 


### PR DESCRIPTION
No more failures of testStartStop:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Basic1?branch=GG-48516&buildTypeTab=overview

Both testStartStop and testStoppedState created IgniteConfiguration without an explicit TcpDiscoverySpi, causing GridAbstractTest.optimize() to take the else-branch and set localHost to the external IP of the LXC agent. The resulting TcpDiscoveryMulticastIpFinder sent pings on the external interface; socketConnect then hung indefinitely against addresses returned under DROP firewall rules on the build agent.

Adding TcpDiscoverySpi with sharedStaticIpFinder forces optimize() to take the if-branch (localHost=127.0.0.1) and eliminates multicast entirely. With an empty VmIpFinder, resolvedAddresses() returns empty and each node becomes coordinator immediately without any socketConnect calls.