### PR TITLE
GG-48482 fix resolve log file paths

### DIFF
--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jRollingFileAppender.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jRollingFileAppender.java
@@ -16,6 +16,7 @@
 
 package org.apache.ignite.logger.log4j;
 
+import java.io.File;
 import java.io.IOException;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.lang.IgniteClosure;
@@ -83,7 +84,13 @@ public class Log4jRollingFileAppender extends RollingFileAppender implements Log
     /** {@inheritDoc} */
     @Override public synchronized void setFile(String fileName, boolean fileAppend, boolean bufIO, int bufSize)
         throws IOException {
-        if (baseFileName != null)
+        if (baseFileName != null) {
+            File f = new File(fileName);
+
+            if (f.getParentFile() != null)
+                f.getParentFile().mkdirs();
+
             super.setFile(fileName, fileAppend, bufIO, bufSize);
+        }
     }
 }

--- a/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jRollingFileAppender.java
+++ b/modules/log4j/src/main/java/org/apache/ignite/logger/log4j/Log4jRollingFileAppender.java
@@ -18,6 +18,7 @@ package org.apache.ignite.logger.log4j;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.ignite.internal.util.IgniteUtils;
 import org.apache.ignite.internal.util.typedef.internal.A;
 import org.apache.ignite.lang.IgniteClosure;
 import org.apache.log4j.Layout;
@@ -87,8 +88,21 @@ public class Log4jRollingFileAppender extends RollingFileAppender implements Log
         if (baseFileName != null) {
             File f = new File(fileName);
 
-            if (f.getParentFile() != null)
-                f.getParentFile().mkdirs();
+            // Resolve relative paths against IGNITE_HOME so the log file location matches the
+            // convention used by U.resolveIgnitePath() and does not depend on the JVM's user.dir.
+            if (!f.isAbsolute()) {
+                String home = IgniteUtils.getIgniteHome();
+
+                if (home != null) {
+                    f = new File(home, fileName);
+                    fileName = f.getAbsolutePath();
+                }
+            }
+
+            File parent = f.getParentFile();
+
+            if (parent != null)
+                parent.mkdirs();
 
             super.setFile(fileName, fileAppend, bufIO, bufSize);
         }

--- a/modules/slf4j/src/test/resources/log4j2-test.xml
+++ b/modules/slf4j/src/test/resources/log4j2-test.xml
@@ -18,12 +18,12 @@
 
 <Configuration>
     <Appenders>
-        <File name="FILTERED" fileName="work/log/filtered.log" append="false">
+        <File name="FILTERED" fileName="${env:IGNITE_HOME:-.}/work/log/filtered.log" append="false">
             <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
             <MarkerFilter marker="IGNORE_ME" onMatch="DENY" onMismatch="NEUTRAL"/>
         </File>
 
-        <File name="ALL" fileName="work/log/all.log"  append="false">
+        <File name="ALL" fileName="${env:IGNITE_HOME:-.}/work/log/all.log"  append="false">
             <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
         </File>
     </Appenders>


### PR DESCRIPTION
No more failures of:

* org.apache.ignite.logger.slf4j.Slf4jLoggerSelfTest.testJCLIsRedirectedToSlf4j
* org.apache.ignite.logger.slf4j.Slf4jLoggerSelfTest.testJULIsRedirectedToSlf4j
* org.apache.ignite.logger.log4j.GridLog4jCorrectFileNameTest.testLogFilesTwoNodes

master:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Basic2?branch=%3Cdefault%3E&buildTypeTab=overview

GG-48482:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Basic2?branch=GG-48482&buildTypeTab=overview

Summary:

  Log4jRollingFileAppender.setFile() — now resolves relative paths against IGNITE_HOME (via IgniteUtils.getIgniteHome()) before opening the file. This makes the file land at <IGNITE_HOME>/work/log/... where U.resolveIgnitePath() looks, regardless of where Maven was launched from. Falls back to user.dir-relative if IGNITE_HOME is null.

  modules/slf4j/src/test/resources/log4j2-test.xml — same fix done at config level. Changed fileName="work/log/all.log" to fileName="${env:IGNITE_HOME:-.}/work/log/all.log" (and same for filtered.log). log4j2's ${env:...} reads env vars at config-load time, which is set by TC before the JVM starts. The :-. fallback preserves existing behavior for local dev without IGNITE_HOME set.