### PR TITLE
GG-48630 Fix lock-order assertion in Private/Isolated deployment.

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/internal/managers/deployment/GridDeploymentPerLoaderStore.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/managers/deployment/GridDeploymentPerLoaderStore.java
@@ -248,7 +248,7 @@ public class GridDeploymentPerLoaderStore extends GridDeploymentStoreAdapter {
                         // If we received execution request even after we waited for P2P
                         // timeout period, we simply ignore it.
                         else if (d.sequenceNumber() > meta.sequenceNumber()) {
-                            if (d.deployedClass(meta.className()).get1() != null) {
+                            if (d.existingDeployedClass(meta.className()) != null) {
                                 long time = U.currentTimeMillis() - d.timestamp();
 
                                 if (time < ctx.config().getNetworkTimeout()) {


### PR DESCRIPTION
Use existingDeployedClass for the stale-deployment check in GridDeploymentPerLoaderStore.getDeployment so the call no longer triggers onDeployed under the mux lock, matching the symmetric newer-deployment branch.

No failures of GridDifferentLocalDeploymentSelfTest.testCheckTaskClassloaderCachePrivateMode:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Basic1?branch=GG-48630