### PR TITLE
GG-48631 Fix flaky IgniteTopologyPrintFormatSelfTest

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/managers/discovery/IgniteTopologyPrintFormatSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/managers/discovery/IgniteTopologyPrintFormatSelfTest.java
@@ -113,7 +113,9 @@ public class IgniteTopologyPrintFormatSelfTest extends GridCommonAbstractTest {
 
         Pattern ptrn = Pattern.compile(String.format(ALIVE_NODES_MSG, 1, 2));
 
-        LogListener aliveNodesLsnr = LogListener.matches(ptrn).times(log.isDebugEnabled() ? 0 : 4).build();
+        LogListener aliveNodesLsnr = log.isDebugEnabled()
+            ? LogListener.matches(ptrn).times(0).build()
+            : LogListener.matches(ptrn).atLeast(3).build();
 
         testLog.registerListener(aliveNodesLsnr);
 
@@ -177,7 +179,9 @@ public class IgniteTopologyPrintFormatSelfTest extends GridCommonAbstractTest {
 
         Pattern ptrn = Pattern.compile(String.format(ALIVE_NODES_MSG, 1, 4));
 
-        LogListener aliveNodesLsnr = LogListener.matches(ptrn).times(log.isDebugEnabled() ? 0 : 16).build();
+        LogListener aliveNodesLsnr = log.isDebugEnabled()
+            ? LogListener.matches(ptrn).times(0).build()
+            : LogListener.matches(ptrn).atLeast(10).build();
 
         testLog.registerListener(aliveNodesLsnr);
 
@@ -243,7 +247,9 @@ public class IgniteTopologyPrintFormatSelfTest extends GridCommonAbstractTest {
 
         Pattern ptrn = Pattern.compile(String.format(ALIVE_NODES_MSG, 1, 4));
 
-        LogListener aliveNodesLsnr = LogListener.matches(ptrn).times(log.isDebugEnabled() ? 0 : 25).build();
+        LogListener aliveNodesLsnr = log.isDebugEnabled()
+            ? LogListener.matches(ptrn).times(0).build()
+            : LogListener.matches(ptrn).atLeast(15).build();
 
         testLog.registerListener(aliveNodesLsnr);
 


### PR DESCRIPTION
No more failures of IgniteTopologyPrintFormatSelfTest:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Basic1?branch=GG-48631&buildTypeTab=overview

The exact times(N) assertion races with stopAllGrids(): the last surviving node's disco-event-worker may be stopped before it can log the final topology snapshot, leaving the count one short. Only the startup-phase counts are deterministic, so switch the aliveNodesLsnr to atLeast(startup-only-N) in all three test variants.