### PR TITLE
GG-48646 Fix flaky testConfigurationView: use static IP finder

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/metric/SystemViewSelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/metric/SystemViewSelfTest.java
@@ -94,6 +94,7 @@ import org.apache.ignite.lang.IgniteClosure;
 import org.apache.ignite.lang.IgnitePredicate;
 import org.apache.ignite.lang.IgniteRunnable;
 import org.apache.ignite.services.ServiceConfiguration;
+import org.apache.ignite.spi.discovery.tcp.TcpDiscoverySpi;
 import org.apache.ignite.spi.systemview.view.BaselineNodeAttributeView;
 import org.apache.ignite.spi.systemview.view.BinaryMetadataView;
 import org.apache.ignite.spi.systemview.view.CacheGroupView;
@@ -2057,6 +2058,7 @@ public class SystemViewSelfTest extends GridCommonAbstractTest {
         String expDrName = "my-dr";
 
         icfg.setIgniteInstanceName(expName);
+        icfg.setDiscoverySpi(new TcpDiscoverySpi().setIpFinder(sharedStaticIpFinder));
         icfg.setDataStorageConfiguration(new DataStorageConfiguration()
                 .setDefaultDataRegionConfiguration(
                         new DataRegionConfiguration()


### PR DESCRIPTION
No mor failures of testConfigurationView:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Cache13?branch=GG-48646