### PR TITLE
GG-48648 Fix flaky testTombstonesClearedAfterRestart

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheRemoveWithTombstonesFailoverTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/distributed/CacheRemoveWithTombstonesFailoverTest.java
@@ -178,10 +178,12 @@ public class CacheRemoveWithTombstonesFailoverTest extends GridCommonAbstractTes
 
         awaitPartitionMapExchange();
 
-        // Ensure the evict queue is filled.
+        // Ensure the evict queue is filled. FillEvictQueueTask reschedules itself up to
+        // processEmptyEvictQueueFreq * 10 ms (5s by default) when there's nothing to do,
+        // which is the case while the cluster is inactive between the two restarts above.
         IgniteEx finalDemander = demander;
         assertTrue(GridTestUtils.waitForCondition(() ->
-            !finalDemander.context().cache().context().evict().evictQueue(true).isEmptyx(), 1_000));
+            !finalDemander.context().cache().context().evict().evictQueue(true).isEmptyx(), 10_000));
 
         final LongMetric tombstoneMetric1 = demander.context().metric().registry(
             MetricUtils.cacheGroupMetricsRegistryName(DEFAULT_CACHE_NAME)).findMetric(TS_METRIC_NAME);


### PR DESCRIPTION
extend evict queue wait to 10s

FillEvictQueueTask reschedules up to 5s out when idle (the case while the cluster is inactive between the two restarts), so a 1s wait after activation can time out under CI load.


No more failures of testTombstonesClearedAfterRestart:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Cache13?branch=GG-48648