### PR TITLE
GG-48652 Fix flaky testCacheGroupMetrics

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheGroupMetricsTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/CacheGroupMetricsTest.java
@@ -341,16 +341,15 @@ public class CacheGroupMetricsTest extends GridCommonAbstractTest implements Ser
 
         stopGrid(2);
 
-        // Wait until renting moved to evicting.
-        GridTestUtils.waitForCondition(new GridAbsPredicate() {
-            @Override public boolean apply() {
-                return grid(0).context().cache().cacheGroup(CU.cacheId("group1")).
-                    topology().localPartitions().stream().noneMatch(p -> p.state() == RENTING);
-            }
-        }, 5_000);
-
-        // Check moving partitions while rebalancing.
-        assertFalse(arrayToAllocationMap(new int[10][]).equals(movingPartitionsAllocationMap.value()));
+        // Wait for the moving partition assignment to be reflected in the metric. The previous
+        // "noneMatch RENTING" wait is a proxy that can be trivially satisfied before PME has
+        // assigned any partition state, so it doesn't gate the assertion below.
+        assertTrue("Moving partitions did not appear within 10s",
+            GridTestUtils.waitForCondition(new GridAbsPredicate() {
+                @Override public boolean apply() {
+                    return !arrayToAllocationMap(new int[10][]).equals(movingPartitionsAllocationMap.value());
+                }
+            }, 10_000));
 
         assertTrue(mxBean0Grp1.get2().<IntMetric>findMetric("LocalNodeMovingPartitionsCount").value() > 0);
         assertTrue(mxBean0Grp1.get1().getClusterMovingPartitionsCount() > 0);


### PR DESCRIPTION
The fail rate of the test is 14%, current branch: (0 failures out of 14)
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_Cache7?branch=GG-48652

The previous "noneMatch RENTING" waitForCondition is a proxy that can be trivially satisfied before PME has assigned any partition state, so it didn't gate the immediate assertFalse on movingPartitionsAllocationMap. Wait on the metric itself with a 10s timeout and turn it into assertTrue so a real "never moved" outcome fails with a clear message.