### PR TITLE
GG-48666 Fix javadoc typo "isk page compression" -> "disk page compression"

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
+++ b/modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java
@@ -1741,7 +1741,7 @@ public final class IgniteSystemProperties {
         "IGNITE_DISABLE_TRIGGERING_CACHE_INTERCEPTOR_ON_CONFLICT";
 
     /**
-     * Sets default isk page compression.
+     * Sets default disk page compression.
      */
     @SystemProperty(value = "Disk page compression - CacheConfiguration#setDiskPageCompression",
         type = DiskPageCompression.class)


### PR DESCRIPTION
## Summary
- Fix 1-character javadoc typo: `Sets default isk page compression.` → `Sets default disk page compression.` at `modules/core/src/main/java/org/apache/ignite/IgniteSystemProperties.java:1744`.
- `@SystemProperty(value=...)` annotation already correct; only the leading `/** */` block is wrong. No behavioral impact.

## Test plan
- [x] N/A — doc-only change to a single javadoc block.

[GG-48437]: https://ggsystems.atlassian.net/browse/GG-48437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ