### PR TITLE
GG-48679 Fix flaky testIpFinderCleaning

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -963,7 +963,10 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
 
             long failureDetectTimeout = g1.configuration().getFailureDetectionTimeout();
 
-            long timeout = (long)(discoMap.get(g1.name()).getIpFinderCleanFrequency() * 1.5) + failureDetectTimeout;
+            // Each cleanup cycle sleeps ipFinderCleanFreq, then pings every registered address sequentially.
+            // Pings to the two stale addresses each can take up to failureDetectTimeout, so allow for two
+            // ping timeouts per cycle plus a second cycle as a safety margin.
+            long timeout = discoMap.get(g1.name()).getIpFinderCleanFrequency() * 2 + failureDetectTimeout * 3;
 
             GridTestUtils.waitForCondition(new GridAbsPredicate() {
                 @Override public boolean apply() {

--- a/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/spi/discovery/tcp/TcpDiscoverySelfTest.java
@@ -966,7 +966,7 @@ public class TcpDiscoverySelfTest extends GridCommonAbstractTest {
             // Each cleanup cycle sleeps ipFinderCleanFreq, then pings every registered address sequentially.
             // Pings to the two stale addresses each can take up to failureDetectTimeout, so allow for two
             // ping timeouts per cycle plus a second cycle as a safety margin.
-            long timeout = discoMap.get(g1.name()).getIpFinderCleanFrequency() * 2 + failureDetectTimeout * 3;
+            long timeout = discoMap.get(g1.name()).getIpFinderCleanFrequency() * 2 + failureDetectTimeout * 4;
 
             GridTestUtils.waitForCondition(new GridAbsPredicate() {
                 @Override public boolean apply() {


### PR DESCRIPTION
No failures in 10 runs:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_SPIDiscovery?branch=GG-48679&buildTypeTab=overview

Original fail rate is 28%

The IpFinder cleaner sleeps ipFinderCleanFreq (5s) then pings every registered address sequentially. Each ping to the two stale 1.1.1.x addresses can block up to failureDetectionTimeout (7.5s), so a single cleanup cycle can take ~20s. The previous wait of
ipFinderCleanFreq*1.5 + failureDetectionTimeout = 15s was below that floor and intermittently expired before the cleaner finished, leaving stale addresses (and sometimes the live address) in the assertion.

Widen the wait to cover two cleanup cycles with both ping timeouts.