### PR TITLE
GG-48678 Fix flaky testConcurrentUpdatesAndQueryStartTxCacheGroup

### DIFF
--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryConcurrentPartitionUpdateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryConcurrentPartitionUpdateTest.java
@@ -43,7 +43,6 @@ import org.apache.ignite.testframework.GridTestUtils.SF;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.apache.ignite.transactions.Transaction;
 import org.apache.ignite.transactions.TransactionSerializationException;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.apache.ignite.cache.CacheAtomicityMode.ATOMIC;
@@ -96,14 +95,6 @@ public class CacheContinuousQueryConcurrentPartitionUpdateTest extends GridCommo
      * @throws Exception If failed.
      */
     @Test
-    public void testConcurrentUpdatePartitionMvccTx() throws Exception {
-        concurrentUpdatePartition(TRANSACTIONAL_SNAPSHOT, false);
-    }
-
-    /**
-     * @throws Exception If failed.
-     */
-    @Test
     public void testConcurrentUpdatePartitionAtomicCacheGroup() throws Exception {
         concurrentUpdatePartition(ATOMIC, true);
     }
@@ -114,14 +105,6 @@ public class CacheContinuousQueryConcurrentPartitionUpdateTest extends GridCommo
     @Test
     public void testConcurrentUpdatePartitionTxCacheGroup() throws Exception {
         concurrentUpdatePartition(TRANSACTIONAL, true);
-    }
-
-    /**
-     * @throws Exception If failed.
-     */
-    @Test
-    public void testConcurrentUpdatePartitionMvccTxCacheGroup() throws Exception {
-        concurrentUpdatePartition(TRANSACTIONAL_SNAPSHOT, true);
     }
 
     /**
@@ -284,18 +267,8 @@ public class CacheContinuousQueryConcurrentPartitionUpdateTest extends GridCommo
      * @throws Exception If failed.
      */
     @Test
-    @Ignore("https://ggsystems.atlassian.net/browse/GG-22462")
     public void testConcurrentUpdatesAndQueryStartTx() throws Exception {
         concurrentUpdatesAndQueryStart(TRANSACTIONAL, false);
-    }
-
-    /**
-     * @throws Exception If failed.
-     */
-    @Test
-    @Ignore("https://ggsystems.atlassian.net/browse/GG-46116")
-    public void testConcurrentUpdatesAndQueryStartMvccTx() throws Exception {
-        concurrentUpdatesAndQueryStart(TRANSACTIONAL_SNAPSHOT, false);
     }
 
     /**
@@ -312,15 +285,6 @@ public class CacheContinuousQueryConcurrentPartitionUpdateTest extends GridCommo
     @Test
     public void testConcurrentUpdatesAndQueryStartTxCacheGroup() throws Exception {
         concurrentUpdatesAndQueryStart(TRANSACTIONAL, true);
-    }
-
-    /**
-     * @throws Exception If failed.
-     */
-    @Test
-    @Ignore("https://ggsystems.atlassian.net/browse/GG-46116")
-    public void testConcurrentUpdatesAndQueryStartMvccTxCacheGroup() throws Exception {
-        concurrentUpdatesAndQueryStart(TRANSACTIONAL_SNAPSHOT, true);
     }
 
     /**

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryConcurrentPartitionUpdateTest.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/cache/query/continuous/CacheContinuousQueryConcurrentPartitionUpdateTest.java
@@ -444,7 +444,7 @@ public class CacheContinuousQueryConcurrentPartitionUpdateTest extends GridCommo
                 stop.set(true);
             }
 
-            GridTestUtils.runMultiThreadedAsync(new Callable<Void>() {
+            GridTestUtils.runMultiThreaded(new Callable<Void>() {
                 @Override public Void call() throws Exception {
                     ThreadLocalRandom rnd = ThreadLocalRandom.current();
 


### PR DESCRIPTION
No failures in 10 runs:
https://ggtc.gridgain.com/buildConfiguration/GridGain8_Test_CommunityEdition_ContinuousQuery1?branch=gg-48678-fix-flaky-cq-concurrent-partition

original fail rate is 25%

The second batch of writers used runMultiThreadedAsync without awaiting, so the 30s waitForCondition had to cover the writes themselves. Under load (10 PESSIMISTIC/REPEATABLE_READ threads on a single partition with FULL_SYNC across 3 caches) writes can't finish in 30s on slow agents, firing the assert with the listener counter still climbing. Switching to the synchronous runMultiThreaded mirrors concurrentUpdatePartition in the same file and leaves the 30s window purely for event propagation.