### PR TITLE
GG-42091 Add Http REST endpoint for k8s startup probe

### DIFF
--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridProbeCommandTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridProbeCommandTest.java
@@ -16,33 +16,49 @@
 
 package org.apache.ignite.internal.client.rest;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import org.apache.ignite.cluster.ClusterState;
 import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
 import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.processors.rest.GridRestCommand;
 import org.apache.ignite.internal.processors.rest.GridRestResponse;
 import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandler;
 import org.apache.ignite.internal.processors.rest.handlers.probe.GridProbeCommandHandler;
 import org.apache.ignite.internal.processors.rest.request.GridRestCacheRequest;
+import org.apache.ignite.maintenance.MaintenanceTask;
 import org.apache.ignite.plugin.AbstractTestPluginProvider;
 import org.apache.ignite.plugin.PluginProvider;
 import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
 import org.junit.Test;
 
 /**
- * Test whether REST probe command works correctly when kernal has started and vice versa.
+ * Tests the {@code cmd=probe} REST command and its {@code kind} sub-commands.
+ *
+ * <ul>
+ *     <li>Bare {@code cmd=probe} (BC): kernel-started check → "grid has started" / 503
+ *         "grid has not started".</li>
+ *     <li>{@code kind=liveness}: the same kernel-started check as bare (same body).</li>
+ *     <li>{@code kind=readiness}: 503 "kernel not started" while starting; 200 "ready"
+ *         once active and rebalanced; cluster INACTIVE → 200 "ready"; maintenance mode →
+ *         503 "maintenance mode".</li>
+ *     <li>Unknown {@code kind} → application-level {@code STATUS_FAILED}.</li>
+ * </ul>
+ *
+ * Multi-node, rebalance-gated readiness (the inbound-demand 503 → 200 latch) is covered by
+ * {@link GridProbeReadinessRebalanceTest}.
  */
 public class GridProbeCommandTest extends GridCommonAbstractTest {
 
     private static final int JETTY_PORT = 8080;
+
+    /** Enables persistence (so a non-activated node stays INACTIVE / supports maintenance mode). */
+    private boolean persistence;
 
     private CountDownLatch triggerRestCmdLatch = new CountDownLatch(1);
 
@@ -56,8 +72,12 @@ public class GridProbeCommandTest extends GridCommonAbstractTest {
         IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
         cfg.setConnectorConfiguration(new ConnectorConfiguration());
 
-        if (igniteInstanceName.equals("regular")) return cfg;
-        else if (igniteInstanceName.equals("delayedStart")) {
+        if (persistence) {
+            cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+                .setDefaultDataRegionConfiguration(new DataRegionConfiguration().setPersistenceEnabled(true)));
+        }
+
+        if (igniteInstanceName.equals("delayedStart")) {
             PluginProvider delayedStartPluginProvider = new DelayedStartPluginProvider(triggerPluginStartLatch, triggerRestCmdLatch);
 
             cfg.setPluginProviders(new PluginProvider[] {delayedStartPluginProvider});
@@ -69,14 +89,25 @@ public class GridProbeCommandTest extends GridCommonAbstractTest {
     /**
      * {@inheritDoc}
      */
-    @Override protected void afterTest() throws Exception {
-        super.afterTest();
+    @Override protected void beforeTest() throws Exception {
+        super.beforeTest();
 
-        stopAllGrids(false);
+        cleanPersistenceDir();
     }
 
     /**
-     * <p>Test for the REST probe command
+     * {@inheritDoc}
+     */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids(false);
+
+        cleanPersistenceDir();
+
+        super.afterTest();
+    }
+
+    /**
+     * <p>Test for the REST probe command (handler level).
      *
      * @throws Exception If failed.
      */
@@ -108,29 +139,7 @@ public class GridProbeCommandTest extends GridCommonAbstractTest {
      */
     @Test
     public void testRestProbeCommandGridNotStarted() throws Exception {
-
-        new Thread(new Runnable() {
-            @Override public void run() {
-                try {
-                    startGrid("delayedStart");
-                }
-                catch (Exception e) {
-                    log.error("error when starting delatedStart grid", e);
-                }
-            }
-        }).start();
-
-        Map<String, Object> probeRestCommandResponse;
-
-        log.info("awaiting plugin handler latch");
-        triggerPluginStartLatch.await();
-        log.info("starting rest command url call");
-        try {
-            probeRestCommandResponse = executeProbeRestRequest();
-            log.info("finished rest command url call");
-        } finally {
-            triggerRestCmdLatch.countDown(); //make sure the grid shuts down
-        }
+        Map<String, Object> probeRestCommandResponse = executeWhileKernelStarting("cmd=probe");
 
         assertTrue(probeRestCommandResponse.get("error").equals("grid has not started"));
         assertEquals(GridRestResponse.SERVICE_UNAVAILABLE, probeRestCommandResponse.get("successStatus"));
@@ -153,29 +162,165 @@ public class GridProbeCommandTest extends GridCommonAbstractTest {
         assertEquals(0, probeRestCommandResponse.get("successStatus"));
     }
 
-    public static Map<String, Object> executeProbeRestRequest() throws IOException {
+    /**
+     * {@code kind=liveness} is the same kernel-started check as bare {@code cmd=probe}:
+     * a started node → 200 "grid has started".
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testRestProbeCommandLivenessKind() throws Exception {
+        startGrid("regular");
 
-        HttpURLConnection conn = (HttpURLConnection) (new URL("http://localhost:" + JETTY_PORT + "/ignite?cmd=probe").openConnection());
-        conn.connect();
+        Map<String, Object> resp = executeProbeRestRequest("cmd=probe&kind=liveness");
 
-        boolean isHTTP_OK = conn.getResponseCode() == HttpURLConnection.HTTP_OK;
+        assertEquals(0, resp.get("successStatus"));
+        assertEquals("grid has started", resp.get("response"));
+    }
 
-        Map<String, Object> restResponse = null;
+    /**
+     * {@code kind=readiness} on a node whose kernel has not finished starting → 503
+     * "kernel not started".
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testRestProbeCommandReadinessKernelNotStarted() throws Exception {
+        Map<String, Object> resp = executeWhileKernelStarting("cmd=probe&kind=readiness");
 
-        try (InputStreamReader streamReader = new InputStreamReader(isHTTP_OK ? conn.getInputStream() : conn.getErrorStream())) {
+        assertEquals(GridRestResponse.SERVICE_UNAVAILABLE, resp.get("successStatus"));
+        assertEquals("kernel not started", resp.get("error"));
+    }
 
-            ObjectMapper objMapper = new ObjectMapper();
-            restResponse = objMapper.readValue(streamReader,
-                new TypeReference<Map<String, Object>>() {
-                });
+    /**
+     * {@code kind=readiness} on an active node with nothing to rebalance → 200 "ready".
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testRestProbeCommandReadinessAllClear() throws Exception {
+        startGrid("regular").cluster().state(ClusterState.ACTIVE);
 
-            log.info("probe command response is: " + restResponse);
+        awaitPartitionMapExchange();
 
-        } catch (Exception e) {
-            log.error("error executing probe rest command", e);
+        Map<String, Object> resp = executeProbeRestRequest("cmd=probe&kind=readiness");
+
+        assertEquals(0, resp.get("successStatus"));
+        assertEquals("ready", resp.get("response"));
+    }
+
+    /**
+     * {@code kind=readiness} on an INACTIVE cluster → 200 "ready" (so a k8s rolling update
+     * may proceed). Uses a persistent node deliberately left un-activated.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testRestProbeCommandReadinessInactive() throws Exception {
+        persistence = true;
+
+        startGrid("regular");
+
+        assertEquals(ClusterState.INACTIVE, grid("regular").cluster().state());
+
+        Map<String, Object> resp = executeProbeRestRequest("cmd=probe&kind=readiness");
+
+        assertEquals(0, resp.get("successStatus"));
+        assertEquals("ready", resp.get("response"));
+    }
+
+    /**
+     * {@code kind=readiness} on a node restarted into maintenance mode → 503 "maintenance
+     * mode" (liveness, by contrast, stays 200). Maintenance is re-evaluated live and wins
+     * over the INACTIVE short-circuit (a maintenance node is forced INACTIVE).
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testRestProbeCommandReadinessMaintenance() throws Exception {
+        persistence = true;
+
+        IgniteEx g = startGrid("regular");
+
+        g.cluster().state(ClusterState.ACTIVE);
+
+        g.context().maintenanceRegistry()
+            .registerMaintenanceTask(new MaintenanceTask("probe-readiness-test", "probe readiness MM test", null));
+
+        stopGrid("regular");
+
+        g = startGrid("regular");
+
+        assertTrue("node should be in maintenance mode", g.context().maintenanceRegistry().isMaintenanceMode());
+
+        Map<String, Object> resp = executeProbeRestRequest("cmd=probe&kind=readiness");
+
+        assertEquals(GridRestResponse.SERVICE_UNAVAILABLE, resp.get("successStatus"));
+        assertEquals("maintenance mode", resp.get("error"));
+    }
+
+    /**
+     * Unknown {@code kind} → application-level {@code STATUS_FAILED} (HTTP 200).
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testRestProbeCommandUnknownKind() throws Exception {
+        startGrid("regular");
+
+        Map<String, Object> resp = executeProbeRestRequest("cmd=probe&kind=bogus");
+
+        assertEquals(GridRestResponse.STATUS_FAILED, resp.get("successStatus"));
+        assertTrue("error must mention unknown probe kind: " + resp.get("error"),
+            String.valueOf(resp.get("error")).contains("Unknown probe kind"));
+    }
+
+    /**
+     * Starts the "delayedStart" grid on a separate thread (a plugin holds it after the REST
+     * HTTP processor is up but before the kernel has fully started), issues the given probe
+     * query against the not-fully-started kernel, then releases the grid.
+     *
+     * @param query Query string after {@code /ignite?} (e.g. {@code cmd=probe&kind=readiness}).
+     * @return Parsed probe response.
+     * @throws Exception If failed.
+     */
+    private Map<String, Object> executeWhileKernelStarting(String query) throws Exception {
+        new Thread(new Runnable() {
+            @Override public void run() {
+                try {
+                    startGrid("delayedStart");
+                }
+                catch (Exception e) {
+                    log.error("error when starting delayedStart grid", e);
+                }
+            }
+        }).start();
+
+        triggerPluginStartLatch.await();
+
+        try {
+            return executeProbeRestRequest(query);
         }
-        return restResponse;
+        finally {
+            triggerRestCmdLatch.countDown(); // make sure the grid shuts down
+        }
+    }
 
+    /**
+     * @return Parsed response of bare {@code cmd=probe}.
+     * @throws IOException If failed.
+     */
+    public static Map<String, Object> executeProbeRestRequest() throws IOException {
+        return executeProbeRestRequest("cmd=probe");
+    }
+
+    /**
+     * @param query Query string after {@code /ignite?}.
+     * @return Parsed probe response.
+     * @throws IOException If failed.
+     */
+    public static Map<String, Object> executeProbeRestRequest(String query) throws IOException {
+        return GridRestHttpClient.get(JETTY_PORT, "/ignite?" + query).body;
     }
 
     /**

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridProbeReadinessRebalanceTest.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridProbeReadinessRebalanceTest.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import org.apache.ignite.IgniteCache;
+import org.apache.ignite.cache.CacheRebalanceMode;
+import org.apache.ignite.cluster.ClusterState;
+import org.apache.ignite.configuration.CacheConfiguration;
+import org.apache.ignite.configuration.ConnectorConfiguration;
+import org.apache.ignite.configuration.DataRegionConfiguration;
+import org.apache.ignite.configuration.DataStorageConfiguration;
+import org.apache.ignite.configuration.IgniteConfiguration;
+import org.apache.ignite.internal.IgniteEx;
+import org.apache.ignite.internal.TestRecordingCommunicationSpi;
+import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionDemandMessage;
+import org.apache.ignite.internal.util.typedef.internal.CU;
+import org.apache.ignite.testframework.junits.common.GridCommonAbstractTest;
+import org.junit.Test;
+
+/**
+ * Multi-node HTTP-level test for the core behaviour of
+ * {@code cmd=probe&kind=readiness}: a (re)joining node that is still
+ * <em>demanding</em> (inbound-rebalancing) its partitions reports 503, and only
+ * reports 200 once its initial rebalance completes — then stays 200 (latched)
+ * across later topology rebalances.
+ *
+ * <p>This is the regression that the bare {@code cmd=probe} (kernel-started only)
+ * misses: a (re)joining node has its join PME done while it is still pulling its
+ * partitions, so a kernel-only check reports ready — exactly the
+ * bounce-the-next-pod trigger for Lost Partitions.</p>
+ *
+ * <h3>Rebalance-stall recipe (read before editing)</h3>
+ * <ul>
+ *   <li><b>3 servers + 1 joiner</b>, persistence on, {@code backups=1} so the
+ *       joiner has a real demand exchange.</li>
+ *   <li><b>{@link CacheRebalanceMode#ASYNC}</b> (not {@code SYNC}) so the joiner's
+ *       {@code onKernalStart} does not block on rebalance and its REST endpoint
+ *       comes up while it is still demanding.</li>
+ *   <li><b>Baseline auto-adjust</b> so the joiner is added to the baseline (and
+ *       thus assigned partitions to demand) as soon as it joins.</li>
+ *   <li><b>Block the joiner's own {@link GridDhtPartitionDemandMessage}</b> for the
+ *       test cache group via {@link TestRecordingCommunicationSpi} (installed in
+ *       {@link #getConfiguration}). Only the test group is blocked so system
+ *       caches finish and the joiner completes start.</li>
+ *   <li>Each node's Jetty REST binds the first free port from 8080, so by start
+ *       order node {@code i} → port {@code 8080 + i}; the joiner (node 3) → 8083.</li>
+ * </ul>
+ */
+public class GridProbeReadinessRebalanceTest extends GridCommonAbstractTest {
+    /** Cache name / group used for the rebalance-controlled cache group. */
+    private static final String CACHE = "test";
+
+    /** Jetty REST port of the joiner node (node 3, 4th node started → 8083). */
+    private static final int JOINER_PORT = 8083;
+
+    /** {@inheritDoc} */
+    @Override protected IgniteConfiguration getConfiguration(String igniteInstanceName) throws Exception {
+        IgniteConfiguration cfg = super.getConfiguration(igniteInstanceName);
+
+        cfg.setConnectorConfiguration(new ConnectorConfiguration());
+
+        cfg.setDataStorageConfiguration(new DataStorageConfiguration()
+            .setDefaultDataRegionConfiguration(new DataRegionConfiguration().setPersistenceEnabled(true)));
+
+        TestRecordingCommunicationSpi spi = new TestRecordingCommunicationSpi();
+
+        // Joiner nodes (index >= 3): hold their inbound demand for the test group so
+        // they stay mid-rebalance until the test releases them.
+        if (trailingIdx(igniteInstanceName) >= 3) {
+            spi.blockMessages((node, msg) -> msg instanceof GridDhtPartitionDemandMessage
+                && ((GridDhtPartitionDemandMessage)msg).groupId() == CU.cacheId(CACHE));
+        }
+
+        cfg.setCommunicationSpi(spi);
+
+        return cfg;
+    }
+
+    /** {@inheritDoc} */
+    @Override protected void afterTest() throws Exception {
+        stopAllGrids(false);
+
+        cleanPersistenceDir();
+
+        super.afterTest();
+    }
+
+    /**
+     * Demander mid-rebalance → 503; after rebalance → 200; latched stays 200
+     * during a later rebalance.
+     *
+     * @throws Exception If failed.
+     */
+    @Test
+    public void testReadinessGatesInboundRebalanceAndLatches() throws Exception {
+        seedCluster();
+
+        // --- Stage 1: joiner mid inbound-rebalance -> 503 ---------------------------------
+        // ASYNC rebalance: startGrid returns after kernel start; demand is held by the SPI.
+        startGrid(3);
+
+        TestRecordingCommunicationSpi.spi(grid(3)).waitForBlocked();
+
+        GridRestHttpClient.Response demanding = GridRestHttpClient.get(JOINER_PORT, "/ignite?cmd=probe&kind=readiness");
+
+        log.info("joiner readiness while demanding: code=" + demanding.code + " body=" + demanding.body);
+
+        assertEquals(503, demanding.code);
+        assertEquals(503, demanding.body.get("successStatus"));
+        assertEquals("rebalance in progress", demanding.body.get("error"));
+
+        // BC pin: bare cmd=probe stays 200 on the demander (kernel-only check).
+        GridRestHttpClient.Response bare = GridRestHttpClient.get(JOINER_PORT, "/ignite?cmd=probe");
+        assertEquals("bare cmd=probe must remain 200 while demanding (BC): " + bare.body, 200, bare.code);
+        assertEquals("grid has started", bare.body.get("response"));
+
+        // Liveness stays 200 too — a rebalancing node is alive.
+        GridRestHttpClient.Response live = GridRestHttpClient.get(JOINER_PORT, "/ignite?cmd=probe&kind=liveness");
+        assertEquals("liveness must remain 200 while demanding: " + live.body, 200, live.code);
+        assertEquals("grid has started", live.body.get("response"));
+
+        // --- Stage 2: release rebalance -> joiner becomes ready ---------------------------
+        TestRecordingCommunicationSpi.spi(grid(3)).stopBlock();
+
+        awaitPartitionMapExchange();
+
+        GridRestHttpClient.Response ready = GridRestHttpClient.get(JOINER_PORT, "/ignite?cmd=probe&kind=readiness");
+
+        log.info("joiner readiness after rebalance: code=" + ready.code + " body=" + ready.body);
+
+        assertEquals(200, ready.code);
+        assertEquals(0, ready.body.get("successStatus"));
+        assertEquals("ready", ready.body.get("response"));
+
+        // --- Stage 3: a LATER rebalance must NOT flip the joiner back to 503 (latched) ----
+        // Start node 4 with its demand blocked: the cluster is no longer fully rebalanced,
+        // yet node 3 is already latched and must stay 200.
+        startGrid(4);
+
+        TestRecordingCommunicationSpi.spi(grid(4)).waitForBlocked();
+
+        for (int i = 0; i < 3; i++) {
+            GridRestHttpClient.Response latched = GridRestHttpClient.get(JOINER_PORT, "/ignite?cmd=probe&kind=readiness");
+
+            assertEquals("latched readiness must stay 200 during a later rebalance: " + latched.body,
+                200, latched.code);
+            assertEquals("ready", latched.body.get("response"));
+        }
+
+        TestRecordingCommunicationSpi.spi(grid(4)).stopBlock();
+
+        awaitPartitionMapExchange();
+
+        GridRestHttpClient.Response afterAll = GridRestHttpClient.get(JOINER_PORT, "/ignite?cmd=probe&kind=readiness");
+        assertEquals(200, afterAll.code);
+        assertEquals("ready", afterAll.body.get("response"));
+    }
+
+    /**
+     * Bring up nodes 0/1/2, activate, enable baseline auto-adjust, create a
+     * partitioned cache with backups configured for ASYNC rebalance, seed it, and
+     * let the initial rebalance settle.
+     *
+     * @throws Exception If failed.
+     */
+    private void seedCluster() throws Exception {
+        IgniteEx g0 = startGrid(0);
+        startGrid(1);
+        startGrid(2);
+
+        g0.cluster().state(ClusterState.ACTIVE);
+
+        g0.cluster().baselineAutoAdjustEnabled(true);
+        g0.cluster().baselineAutoAdjustTimeout(0);
+
+        IgniteCache<Integer, Integer> cache = g0.getOrCreateCache(
+            new CacheConfiguration<Integer, Integer>(CACHE)
+                .setBackups(1)
+                .setRebalanceMode(CacheRebalanceMode.ASYNC)
+                .setRebalanceBatchSize(256));
+
+        for (int i = 0; i < 5_000; i++)
+            cache.put(i, i);
+
+        awaitPartitionMapExchange();
+    }
+
+    /**
+     * @param name Ignite instance name.
+     * @return Trailing integer index of the instance name, or {@code -1} if none.
+     */
+    private static int trailingIdx(String name) {
+        int i = name.length();
+
+        while (i > 0 && Character.isDigit(name.charAt(i - 1)))
+            i--;
+
+        return i == name.length() ? -1 : Integer.parseInt(name.substring(i));
+    }
+}

--- a/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridRestHttpClient.java
+++ b/modules/clients/src/test/java/org/apache/ignite/internal/client/rest/GridRestHttpClient.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2026 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.client.rest;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+/** Issues a GET against the node's Jetty REST endpoint and parses the JSON body. */
+public final class GridRestHttpClient {
+    /** */
+    private GridRestHttpClient() {
+        // No-op.
+    }
+
+    /**
+     * @param port Jetty REST port.
+     * @param pathQ Path with query string.
+     * @return HTTP status code and parsed body.
+     * @throws IOException If the request failed.
+     */
+    public static Response get(int port, String pathQ) throws IOException {
+        URL url = new URL("http://localhost:" + port + pathQ);
+
+        HttpURLConnection conn = (HttpURLConnection)url.openConnection();
+
+        conn.connect();
+
+        int code = conn.getResponseCode();
+        boolean isHTTP_OK = code == HttpURLConnection.HTTP_OK;
+
+        Map<String, Object> body;
+
+        try (InputStreamReader streamReader = new InputStreamReader(isHTTP_OK ? conn.getInputStream() : conn.getErrorStream())) {
+            body = new ObjectMapper().readValue(streamReader, new TypeReference<Map<String, Object>>() { /* No-op. */ });
+        }
+        catch (IOException e) {
+            throw new IOException("Failed to read REST response [url=" + url + ", code=" + code + "]", e);
+        }
+
+        return new Response(code, body);
+    }
+
+    /** HTTP status code and parsed JSON body. */
+    public static final class Response {
+        /** Status code. */
+        public final int code;
+
+        /** Parsed body. */
+        public final Map<String, Object> body;
+
+        /**
+         * @param code Status code.
+         * @param body Parsed body.
+         */
+        Response(int code, Map<String, Object> body) {
+            this.code = code;
+            this.body = body;
+        }
+    }
+}

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/GridRestCommand.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/GridRestCommand.java
@@ -233,7 +233,12 @@ public enum GridRestCommand {
     /** Set a distributed property by name. */
     PROPERTY_SET("setproperty"),
 
-    /** probe. */
+    /**
+     * Probe — k8s probe dispatch on the {@code kind} query parameter. Bare GET and
+     * {@code kind=liveness} are the backward-compatible kernel-started check;
+     * {@code kind=readiness} is the k8s readiness/startup gate (latched
+     * initial-rebalance complete, cluster active, not in maintenance).
+     */
     PROBE("probe");
 
     /** Enum values. */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/probe/GridProbeCommandHandler.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/handlers/probe/GridProbeCommandHandler.java
@@ -17,23 +17,103 @@
 package org.apache.ignite.internal.processors.rest.handlers.probe;
 
 import java.util.Collection;
+import org.apache.ignite.cluster.ClusterState;
 import org.apache.ignite.internal.GridKernalContext;
 import org.apache.ignite.internal.IgniteInternalFuture;
 import org.apache.ignite.internal.IgnitionEx;
+import org.apache.ignite.internal.processors.affinity.AffinityTopologyVersion;
+import org.apache.ignite.internal.processors.cache.GridCachePartitionExchangeManager;
+import org.apache.ignite.internal.processors.cache.distributed.dht.preloader.GridDhtPartitionsExchangeFuture;
+import org.apache.ignite.internal.processors.cluster.DiscoveryDataClusterState;
 import org.apache.ignite.internal.processors.rest.GridRestCommand;
 import org.apache.ignite.internal.processors.rest.GridRestResponse;
 import org.apache.ignite.internal.processors.rest.handlers.GridRestCommandHandlerAdapter;
+import org.apache.ignite.internal.processors.rest.request.GridRestProbeRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
 import org.apache.ignite.internal.util.future.GridFinishedFuture;
 import org.apache.ignite.internal.util.typedef.internal.U;
+import org.jetbrains.annotations.Nullable;
 
 import static org.apache.ignite.internal.processors.rest.GridRestCommand.NODE_STATE_BEFORE_START;
 import static org.apache.ignite.internal.processors.rest.GridRestCommand.PROBE;
 
 /**
- * Handler for {@link GridRestCommand#PROBE}.
+ * Handler for {@link GridRestCommand#PROBE}, dispatching on the {@code kind} query parameter
+ * for Kubernetes probes:
+ * <ul>
+ *     <li>bare {@code cmd=probe} (no {@code kind}) and {@code kind=liveness} — kernel-started
+ *         check only: 200 {@code "grid has started"} / 503 {@code "grid has not started"}.
+ *         Never blocks on rebalance, PME, cluster state, or maintenance (a rebalancing node is
+ *         alive). Bare is preserved for backward compatibility; {@code kind=liveness} backs the
+ *         {@code livenessProbe}.</li>
+ *     <li>{@code kind=readiness} — the readiness/startup gate; see {@link #readinessLadder()}.
+ *         Backs the {@code readinessProbe} and {@code startupProbe}.</li>
+ * </ul>
+ *
+ * <p>{@code kind=readiness} reports a (re)joining node not-ready until it has finished pulling
+ * its partitions (inbound rebalance), so a rolling restart does not bounce the next pod (a
+ * supplier) mid-rebalance and lose partitions. It gates on the cluster-wide rebalanced flag of
+ * the last finished partition-map exchange, latched once the node's initial rebalance completes
+ * so later topology rebalances don't flap an already-loaded node out of the Service endpoints
+ * (see {@link #isInitialRebalanceComplete()}). An unknown {@code kind} returns
+ * {@link GridRestResponse#STATUS_FAILED}; the {@code NODE_STATE_BEFORE_START} branch is unchanged.</p>
  */
 public class GridProbeCommandHandler extends GridRestCommandHandlerAdapter {
+    /**
+     * Sub-command of {@code cmd=probe} expressed via the {@code kind} query
+     * parameter. {@code null} {@code kind} routes to the bare-GET BC path.
+     */
+    public enum Kind {
+        /** Liveness check — kernel-started gate ONLY. */
+        LIVENESS("liveness"),
+
+        /** Readiness/startup check — latched initial-rebalance gate. */
+        READINESS("readiness");
+
+        /** Wire-level key as it appears in the {@code kind} query parameter. */
+        private final String key;
+
+        /**
+         * @param key Wire-level key.
+         */
+        Kind(String key) {
+            this.key = key;
+        }
+
+        /**
+         * @return Wire-level key.
+         */
+        public String key() {
+            return key;
+        }
+
+        /**
+         * Case-insensitive lookup of a {@link Kind} by its wire-level key.
+         *
+         * @param key Wire-level key from the request (may be {@code null}).
+         * @return Matching kind, or {@code null} if {@code key} is {@code null}
+         *     or doesn't match any defined kind.
+         */
+        @Nullable public static Kind of(@Nullable String key) {
+            if (key == null)
+                return null;
+
+            for (Kind k : values())
+                if (k.key.equalsIgnoreCase(key))
+                    return k;
+
+            return null;
+        }
+    }
+
+    /**
+     * Set-once readiness latch. Once the node observes a completed initial
+     * rebalance while the cluster is active, readiness stays {@code true} for the
+     * lifetime of this JVM regardless of later topology-change rebalances.
+     * {@code volatile} for visibility across REST worker threads.
+     */
+    private volatile boolean rebalanceLatched;
+
     /**
      * @param ctx Context.
      */
@@ -60,6 +140,18 @@ public class GridProbeCommandHandler extends GridRestCommandHandlerAdapter {
                 if (log.isDebugEnabled())
                     log.debug("probe command handler invoked.");
 
+                String rawKind = req instanceof GridRestProbeRequest ? ((GridRestProbeRequest)req).kind() : null;
+                Kind kind = Kind.of(rawKind);
+
+                if (rawKind != null && kind == null) {
+                    return new GridFinishedFuture<>(new GridRestResponse(GridRestResponse.STATUS_FAILED,
+                        "Unknown probe kind: " + rawKind + " (expected one of: liveness, readiness)"));
+                }
+
+                if (kind == Kind.READINESS)
+                    return readinessLadder();
+
+                // Liveness probe is the same as the bare GET which is kept for compatibility.
                 return new GridFinishedFuture<>(IgnitionEx.hasKernalStarted(ctx.igniteInstanceName()) ? new GridRestResponse("grid has started") : new GridRestResponse(GridRestResponse.SERVICE_UNAVAILABLE, "grid has not started"));
             }
 
@@ -72,5 +164,124 @@ public class GridProbeCommandHandler extends GridRestCommandHandlerAdapter {
         }
 
         return new GridFinishedFuture<>();
+    }
+
+    /**
+     * k8s readiness/startup ladder. Evaluated in fixed order; the first matching
+     * condition determines the response.
+     *
+     * @return Future carrying 200 {@code "ready"} or a 503 with the specific
+     *     blocker as reason.
+     */
+    private IgniteInternalFuture<GridRestResponse> readinessLadder() {
+        // 1. JVM kernel started.
+        if (!IgnitionEx.hasKernalStarted(ctx.igniteInstanceName()))
+            return notReady("kernel not started");
+
+        // 2. Maintenance mode — alive but must not receive traffic (liveness stays 200).
+        if (isMaintenanceMode())
+            return notReady("maintenance mode");
+
+        // 3. Inactive cluster — nothing to rebalance; report ready so a k8s rolling
+        //    update can proceed (the rebalanced flag is always false while INACTIVE,
+        //    so this short-circuit MUST precede the rebalance check).
+        if (isClusterInactive())
+            return new GridFinishedFuture<>(new GridRestResponse("ready"));
+
+        // 4 & 5. Initial rebalance complete (latched) -> ready; else still pulling.
+        if (isInitialRebalanceComplete())
+            return new GridFinishedFuture<>(new GridRestResponse("ready"));
+
+        return notReady("rebalance in progress");
+    }
+
+    /**
+     * Latched "this node has completed its initial post-join rebalance" check.
+     * Once {@code true} while the cluster is active, stays {@code true} for the
+     * JVM lifetime (later topology-change rebalances do not flip it back).
+     *
+     * @return {@code true} if readiness should report ready on the rebalance rung.
+     */
+    private boolean isInitialRebalanceComplete() {
+        if (rebalanceLatched)
+            return true;
+
+        if (isNodeRebalanceComplete()) {
+            rebalanceLatched = true;
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param reason 503 reason.
+     * @return Future carrying a SERVICE_UNAVAILABLE response.
+     */
+    private static IgniteInternalFuture<GridRestResponse> notReady(String reason) {
+        return new GridFinishedFuture<>(new GridRestResponse(GridRestResponse.SERVICE_UNAVAILABLE, reason));
+    }
+
+    /**
+     * @return {@code true} if the cluster is INACTIVE. Non-blocking, null-safe.
+     */
+    private boolean isClusterInactive() {
+        DiscoveryDataClusterState st = ctx.state() == null ? null : ctx.state().clusterState();
+
+        return st != null && st.state() == ClusterState.INACTIVE;
+    }
+
+    /**
+     * @return {@code true} if maintenance mode is active. Non-blocking, null-safe.
+     */
+    private boolean isMaintenanceMode() {
+        return ctx.maintenanceRegistry() != null && ctx.maintenanceRegistry().isMaintenanceMode();
+    }
+
+    /**
+     * Instantaneous "this node has completed its (initial) rebalance" predicate —
+     * the value the readiness latch captures. Reads the cluster-wide rebalanced
+     * flag of the last finished partition-map exchange: {@code false} while this
+     * node is still demanding its initial partitions and {@code false} while the cluster
+     * is INACTIVE (callers MUST short-circuit INACTIVE → ready before relying on
+     * this). Non-blocking, null-safe; returns {@code false} while the cache
+     * subsystem is still initializing so readiness stays 503 until the node is
+     * genuinely settled.
+     *
+     * @return {@code true} if the node's initial PME is complete and the cluster
+     *     reports fully rebalanced.
+     */
+    private boolean isNodeRebalanceComplete() {
+        if (ctx.clientNode())
+            return true; // Clients/daemons never own partitions and never rebalance.
+
+        if (!isInitialPmeComplete())
+            return false;
+
+        // isInitialPmeComplete() guarantees the cache subsystem and a finished exchange exist.
+        GridDhtPartitionsExchangeFuture lastFinished = ctx.cache().context().exchange().lastFinishedFuture();
+
+        return lastFinished != null && lastFinished.rebalanced();
+    }
+
+    /**
+     * Initial/local-join PME finished and affinity is ready (server nodes only —
+     * the sole caller short-circuits client/daemon nodes). Non-blocking, null-safe;
+     * returns {@code false} while the cache subsystem is still initializing or no
+     * exchange has finished yet.
+     *
+     * @return {@code true} if at least one exchange has finished and affinity is ready.
+     */
+    private boolean isInitialPmeComplete() {
+        if (ctx.cache() == null || ctx.cache().context() == null || ctx.cache().context().exchange() == null)
+            return false;
+
+        GridCachePartitionExchangeManager<?, ?> exch = ctx.cache().context().exchange();
+
+        GridDhtPartitionsExchangeFuture lastFinished = exch.lastFinishedFuture();
+
+        // readyAffinityVersion() is never null; NONE (0,0) means no exchange has completed yet.
+        return lastFinished != null && exch.readyAffinityVersion().compareTo(AffinityTopologyVersion.NONE) > 0;
     }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/request/GridRestProbeRequest.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/rest/request/GridRestProbeRequest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.ignite.internal.processors.rest.request;
+
+import org.apache.ignite.internal.util.typedef.internal.S;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Request for the {@code PROBE} REST command. Carries the optional
+ * {@code kind} sub-command that selects the probe semantics:
+ * <ul>
+ *     <li>{@code null} — bare-GET form, backward-compatible kernel-started check.</li>
+ *     <li>{@code "liveness"} — Jetty bound + JVM kernel started.</li>
+ *     <li>{@code "readiness"} — k8s readiness/startup gate (initial rebalance complete,
+ *         cluster active, not in maintenance mode).</li>
+ * </ul>
+ * <p>Unknown {@code kind} values are classified at the handler layer as
+ * {@code STATUS_FAILED} with an explicit message; lookup is case-insensitive.</p>
+ */
+public class GridRestProbeRequest extends GridRestRequest {
+    /** Optional kind: {@code "liveness"}, {@code "readiness"}, or {@code null} (bare-GET). */
+    private String kind;
+
+    /**
+     * @return Kind sub-command, or {@code null} for the bare-GET form.
+     */
+    @Nullable public String kind() {
+        return kind;
+    }
+
+    /**
+     * @param kind Kind sub-command.
+     */
+    public void kind(@Nullable String kind) {
+        this.kind = kind;
+    }
+
+    /** {@inheritDoc} */
+    @Override public String toString() {
+        return S.toString(GridRestProbeRequest.class, this, super.toString());
+    }
+}

--- a/modules/rest-http/src/main/java/org/apache/ignite/internal/processors/rest/protocols/http/jetty/GridJettyRestHandler.java
+++ b/modules/rest-http/src/main/java/org/apache/ignite/internal/processors/rest/protocols/http/jetty/GridJettyRestHandler.java
@@ -59,6 +59,7 @@ import org.apache.ignite.internal.processors.rest.request.GridRestClusterNameReq
 import org.apache.ignite.internal.processors.rest.request.GridRestClusterStateRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestLogRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestNodeStateBeforeStartRequest;
+import org.apache.ignite.internal.processors.rest.request.GridRestProbeRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestPropertyRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestRequest;
 import org.apache.ignite.internal.processors.rest.request.GridRestTaskRequest;
@@ -789,9 +790,18 @@ public class GridJettyRestHandler extends AbstractHandler {
             case DATA_REGION_METRICS:
             case DATA_STORAGE_METRICS:
             case NAME:
-            case VERSION:
-            case PROBE: {
+            case VERSION: {
                 restReq = new GridRestRequest();
+
+                break;
+            }
+
+            case PROBE: {
+                GridRestProbeRequest restReq0 = new GridRestProbeRequest();
+
+                restReq0.kind(params.get("kind"));
+
+                restReq = restReq0;
 
                 break;
             }


### PR DESCRIPTION
## Summary

Add Kubernetes liveness/readiness/startup probe support to the `cmd=probe` REST
endpoint, dispatched on a new `kind` query parameter:

- **`kind=readiness`** — returns **503** while a (re)joining node is still pulling
  its partitions (inbound rebalance/demand) and **200** once its initial rebalance
  completes, then stays **200 (latched)** for the JVM lifetime so later
  topology-change rebalances don't flap an already-loaded node out of the Service
  endpoints. An INACTIVE cluster reports ready (nothing to rebalance); maintenance
  mode reports 503. The same endpoint doubles as a k8s `startupProbe`.
- **`kind=liveness`** and bare **`cmd=probe`** (unchanged, backward-compatible) remain
  the kernel-started check: 200 once the grid has started, 503 otherwise. A
  rebalancing node is alive, so these never block on rebalance/PME/state/maintenance.
- An unknown `kind` returns `STATUS_FAILED` with an explicit message.

This lets a rolling restart wait until each pod has finished inbound rebalance before
the next pod (a supplier) is bounced, avoiding the Lost-Partitions window that a
kernel-only probe leaves open.

## Jira

[GG-42091](https://ggsystems.atlassian.net/browse/GG-42091)

## Test plan

- [x] mtcga verification
- [ ] code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[GG-42091]: https://ggsystems.atlassian.net/browse/GG-42091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ