### PR TITLE
GG-48482 Resolve logger file-name test log paths against IGNITE_HOME

### DIFF
--- a/modules/log4j/src/test/java/org/apache/ignite/logger/log4j/GridLog4jCorrectFileNameTest.java
+++ b/modules/log4j/src/test/java/org/apache/ignite/logger/log4j/GridLog4jCorrectFileNameTest.java
@@ -129,7 +129,7 @@ public class GridLog4jCorrectFileNameTest extends GridCommonAbstractTest {
         Log4jRollingFileAppender appender = new Log4jRollingFileAppender();
 
         appender.setLayout(new PatternLayout("[%d{ISO8601}][%-5p][%t][%c{1}] %m%n"));
-        appender.setFile("work/log/ignite.log");
+        appender.setFile(U.getIgniteHome() + "/work/log/ignite.log");
         appender.setName(Log4jRollingFileAppender.class.getSimpleName());
 
         LevelRangeFilter lvlFilter = new LevelRangeFilter();

--- a/modules/slf4j/src/test/resources/log4j2-test.xml
+++ b/modules/slf4j/src/test/resources/log4j2-test.xml
@@ -18,12 +18,12 @@
 
 <Configuration>
     <Appenders>
-        <File name="FILTERED" fileName="work/log/filtered.log" append="false">
+        <File name="FILTERED" fileName="${sys:IGNITE_HOME:-./ignite}/work/log/filtered.log" append="false">
             <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
             <MarkerFilter marker="IGNORE_ME" onMatch="DENY" onMismatch="NEUTRAL"/>
         </File>
 
-        <File name="ALL" fileName="work/log/all.log"  append="false">
+        <File name="ALL" fileName="${sys:IGNITE_HOME:-./ignite}/work/log/all.log"  append="false">
             <PatternLayout pattern="[%d{ISO8601}][%-5p][%t][%c{1}]%notEmpty{[%markerSimpleName]} %m%n"/>
         </File>
     </Appenders>


### PR DESCRIPTION
## Summary
- Anchor the logger file-name tests' log file to an absolute path under `IGNITE_HOME`, so the location no longer depends on the JVM working directory.

These tests write their log to a path relative to the working directory and then assert it exists via `U.resolveIgnitePath(...)`. Under surefire `forkCount=0` (in-process) the `user.dir` property and the native OS working directory can differ, so on JDK 8 the parent directory is created in one place while the file is opened in another — the log file is never written and the assertion fails. Anchoring the path to `IGNITE_HOME` (the convention `resolveIgnitePath` uses, matching the Log4j2 module's own test configs) fixes:
- `GridLog4jCorrectFileNameTest.testLogFilesTwoNodes`
- `Slf4jLoggerSelfTest.testJULIsRedirectedToSlf4j`
- `Slf4jLoggerSelfTest.testJCLIsRedirectedToSlf4j`

## Jira
[GG-48482](https://ggsystems.atlassian.net/browse/GG-48482)

## Test plan
- [x] mtcga verification
- [ ] code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[GG-48482]: https://ggsystems.atlassian.net/browse/GG-48482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ