### PR TITLE
GG-48491 .NET: Ensure async API parity in thin client

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ApiParity/ClientAsyncApiParityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ApiParity/ClientAsyncApiParityTest.cs
@@ -60,8 +60,8 @@ namespace Apache.Ignite.Core.Tests.ApiParity
         /// Members that are intentionally sync-only because they perform no server IO
         /// (they create local wrappers, return local state, or build projections).
         /// </summary>
-        private static readonly HashSet<string> SyncOnlyMembers = new HashSet<string>
-        {
+        private static readonly HashSet<string> SyncOnlyMembers =
+        [
             // IIgniteClient: local facades and state.
             "GetCache",
             "GetCluster",
@@ -86,7 +86,7 @@ namespace Apache.Ignite.Core.Tests.ApiParity
             // IServicesClient: local proxy and wrappers.
             "GetServiceProxy",
             "WithServerKeepBinary"
-        };
+        ];
 
         /// <summary>
         /// Sync method base names whose async counterpart intentionally has a different shape, so
@@ -96,10 +96,7 @@ namespace Apache.Ignite.Core.Tests.ApiParity
         /// <c>TryGet(key, out value)</c> uses an <c>out</c> parameter that has no async equivalent;
         /// its async counterpart is <c>TryGetAsync(key)</c> returning <c>CacheResult&lt;TV&gt;</c>.
         /// </summary>
-        private static readonly HashSet<string> ShapeMismatchMembers = new HashSet<string>
-        {
-            "TryGet"
-        };
+        private static readonly HashSet<string> ShapeMismatchMembers = ["TryGet"];
 
         /// <summary>
         /// Tests that every sync IO method has a matching async overload.
@@ -197,10 +194,6 @@ namespace Apache.Ignite.Core.Tests.ApiParity
             }
         }
 
-        /// <summary>
-        /// Gets public instance methods declared directly on the interface, excluding property and
-        /// event accessors and obsolete members (deprecated APIs do not need async overloads).
-        /// </summary>
         private static MethodInfo[] GetApiMethods(Type type)
         {
             return type
@@ -209,9 +202,6 @@ namespace Apache.Ignite.Core.Tests.ApiParity
                 .ToArray();
         }
 
-        /// <summary>
-        /// Checks whether two methods have the same parameter types.
-        /// </summary>
         private static bool ParametersMatch(MethodInfo sync, MethodInfo async)
         {
             var syncParams = sync.GetParameters();
@@ -225,10 +215,6 @@ namespace Apache.Ignite.Core.Tests.ApiParity
             return !syncParams.Where((t, i) => t.ParameterType != asyncParams[i].ParameterType).Any();
         }
 
-        /// <summary>
-        /// Checks that the async method return type corresponds to the sync method return type:
-        /// <c>void</c> maps to <see cref="Task"/>, and <c>T</c> maps to <see cref="Task{T}"/>.
-        /// </summary>
         private static bool IsAsyncReturnType(MethodInfo sync, MethodInfo async)
         {
             var asyncReturn = async.ReturnType;
@@ -241,9 +227,6 @@ namespace Apache.Ignite.Core.Tests.ApiParity
             return asyncReturn.IsGenericType && asyncReturn.GetGenericTypeDefinition() == typeof(Task<>);
         }
 
-        /// <summary>
-        /// Gets a human-readable method signature for error reporting.
-        /// </summary>
         private static string GetSignature(MethodInfo method)
         {
             var args = string.Join(", ", method.GetParameters().Select(p => p.ParameterType.Name + " " + p.Name));

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ApiParity/ClientAsyncApiParityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ApiParity/ClientAsyncApiParityTest.cs
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2024 GridGain Systems, Inc. and Contributors.
+ *
+ * Licensed under the GridGain Community Edition License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.gridgain.com/products/software/community-edition/gridgain-community-edition-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Apache.Ignite.Core.Tests.ApiParity
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Apache.Ignite.Core.Client;
+    using Apache.Ignite.Core.Client.Cache;
+    using Apache.Ignite.Core.Client.DataStructures;
+    using Apache.Ignite.Core.Client.Services;
+    using NUnit.Framework;
+
+    /// <summary>
+    /// Verifies that every synchronous, IO-bound public API on the thin client interfaces has a
+    /// matching <c>*Async</c> overload (and vice versa). The thin client is IO-bound, so blocking
+    /// sync-only APIs are inconsistent and inefficient; this test prevents such gaps from being
+    /// reintroduced.
+    /// <para />
+    /// Local, non-IO facade methods (e.g. <c>GetCache</c>, <c>WithKeepBinary</c>, <c>ForServers</c>)
+    /// are intentionally sync-only and listed in <see cref="SyncOnlyMembers"/>.
+    /// <para />
+    /// Interfaces that are deliberately not covered yet (transactions, which are thread-bound, and
+    /// <see cref="Apache.Ignite.Core.Client.DataStructures.IIgniteSetClient{T}"/>, which implements the
+    /// BCL <c>ISet&lt;T&gt;</c>) are simply not listed in <see cref="Interfaces"/>.
+    /// </summary>
+    public class ClientAsyncApiParityTest
+    {
+        /// <summary>
+        /// Client interfaces that must expose full sync + async parity.
+        /// </summary>
+        private static readonly Type[] Interfaces =
+        {
+            typeof(IIgniteClient),
+            typeof(ICacheClient<,>),
+            typeof(IClientCluster),
+            typeof(IClientClusterGroup),
+            typeof(IServicesClient),
+            typeof(IAtomicLongClient)
+        };
+
+        /// <summary>
+        /// Members that are intentionally sync-only because they perform no server IO
+        /// (they create local wrappers, return local state, or build projections).
+        /// </summary>
+        private static readonly HashSet<string> SyncOnlyMembers = new HashSet<string>
+        {
+            // IIgniteClient: local facades and state.
+            "GetCache",
+            "GetCluster",
+            "GetBinary",
+            "GetTransactions",
+            "GetConfiguration",
+            "GetConnections",
+            "GetCompute",
+            "GetServices",
+            "GetDataStreamer",
+
+            // ICacheClient: local wrappers.
+            "WithKeepBinary",
+            "WithExpiryPolicy",
+
+            // IClientClusterGroup: local projections.
+            "ForAttribute",
+            "ForDotNet",
+            "ForServers",
+            "ForPredicate",
+
+            // IServicesClient: local proxy and wrappers.
+            "GetServiceProxy",
+            "WithServerKeepBinary"
+        };
+
+        /// <summary>
+        /// Sync method base names whose async counterpart intentionally has a different shape, so
+        /// strict parameter/return matching does not apply. These pairs still exist, they just
+        /// cannot mirror each other exactly.
+        /// <para />
+        /// <c>TryGet(key, out value)</c> uses an <c>out</c> parameter that has no async equivalent;
+        /// its async counterpart is <c>TryGetAsync(key)</c> returning <c>CacheResult&lt;TV&gt;</c>.
+        /// </summary>
+        private static readonly HashSet<string> ShapeMismatchMembers = new HashSet<string>
+        {
+            "TryGet"
+        };
+
+        /// <summary>
+        /// Tests that every sync IO method has a matching async overload.
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Interfaces))]
+        public void TestSyncMethodsHaveAsyncOverloads(Type type)
+        {
+            var methods = GetApiMethods(type);
+
+            var missing = new List<string>();
+
+            foreach (var method in methods)
+            {
+                if (method.Name.EndsWith("Async", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (SyncOnlyMembers.Contains(method.Name) || ShapeMismatchMembers.Contains(method.Name))
+                {
+                    continue;
+                }
+
+                var asyncName = method.Name + "Async";
+
+                var match = methods.FirstOrDefault(m =>
+                    m.Name == asyncName && ParametersMatch(method, m) && IsAsyncReturnType(method, m));
+
+                if (match == null)
+                {
+                    missing.Add(GetSignature(method));
+                }
+            }
+
+            if (missing.Count > 0)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine(type + " is missing async overloads for the following sync methods:");
+                foreach (var s in missing)
+                {
+                    sb.AppendLine("  " + s);
+                }
+
+                sb.AppendLine("Add an *Async overload, or add the method to SyncOnlyMembers if it performs no IO.");
+
+                Assert.Fail(sb.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Tests that every async method has a matching sync overload (no async-only IO methods).
+        /// </summary>
+        [Test]
+        [TestCaseSource(nameof(Interfaces))]
+        public void TestAsyncMethodsHaveSyncOverloads(Type type)
+        {
+            var methods = GetApiMethods(type);
+
+            var missing = new List<string>();
+
+            foreach (var method in methods)
+            {
+                if (!method.Name.EndsWith("Async", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var syncName = method.Name.Substring(0, method.Name.Length - "Async".Length);
+
+                if (ShapeMismatchMembers.Contains(syncName))
+                {
+                    continue;
+                }
+
+                var match = methods.FirstOrDefault(m =>
+                    m.Name == syncName && ParametersMatch(m, method) && IsAsyncReturnType(m, method));
+
+                if (match == null)
+                {
+                    missing.Add(GetSignature(method));
+                }
+            }
+
+            if (missing.Count > 0)
+            {
+                var sb = new StringBuilder();
+                sb.AppendLine(type + " is missing sync overloads for the following async methods:");
+                foreach (var s in missing)
+                {
+                    sb.AppendLine("  " + s);
+                }
+
+                Assert.Fail(sb.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Gets public instance methods declared directly on the interface, excluding property and
+        /// event accessors.
+        /// </summary>
+        private static MethodInfo[] GetApiMethods(Type type)
+        {
+            return type
+                .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+                .Where(m => !m.IsSpecialName)
+                .ToArray();
+        }
+
+        /// <summary>
+        /// Checks whether two methods have the same parameter types.
+        /// </summary>
+        private static bool ParametersMatch(MethodInfo sync, MethodInfo async)
+        {
+            var syncParams = sync.GetParameters();
+            var asyncParams = async.GetParameters();
+
+            if (syncParams.Length != asyncParams.Length)
+            {
+                return false;
+            }
+
+            return !syncParams.Where((t, i) => t.ParameterType != asyncParams[i].ParameterType).Any();
+        }
+
+        /// <summary>
+        /// Checks that the async method return type corresponds to the sync method return type:
+        /// <c>void</c> maps to <see cref="Task"/>, and <c>T</c> maps to <see cref="Task{T}"/>.
+        /// </summary>
+        private static bool IsAsyncReturnType(MethodInfo sync, MethodInfo async)
+        {
+            var asyncReturn = async.ReturnType;
+
+            if (sync.ReturnType == typeof(void))
+            {
+                return asyncReturn == typeof(Task);
+            }
+
+            return asyncReturn.IsGenericType && asyncReturn.GetGenericTypeDefinition() == typeof(Task<>);
+        }
+
+        /// <summary>
+        /// Gets a human-readable method signature for error reporting.
+        /// </summary>
+        private static string GetSignature(MethodInfo method)
+        {
+            var args = string.Join(", ", method.GetParameters().Select(p => p.ParameterType.Name + " " + p.Name));
+            return method.ReturnType.Name + " " + method.Name + "(" + args + ")";
+        }
+    }
+}

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ApiParity/ClientAsyncApiParityTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/ApiParity/ClientAsyncApiParityTest.cs
@@ -199,13 +199,13 @@ namespace Apache.Ignite.Core.Tests.ApiParity
 
         /// <summary>
         /// Gets public instance methods declared directly on the interface, excluding property and
-        /// event accessors.
+        /// event accessors and obsolete members (deprecated APIs do not need async overloads).
         /// </summary>
         private static MethodInfo[] GetApiMethods(Type type)
         {
             return type
                 .GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly)
-                .Where(m => !m.IsSpecialName)
+                .Where(m => !m.IsSpecialName && m.GetCustomAttribute<ObsoleteAttribute>() == null)
                 .ToArray();
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAsyncWrapper.cs
@@ -144,13 +144,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 #pragma warning disable 618
         public IQueryCursor<ICacheEntry<TK, TV>> Query(SqlQuery sqlQuery)
         {
-            return _cache.QueryAsync(sqlQuery).GetResult();
-        }
-
-        /** <inheritDoc /> */
-        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery)
-        {
-            return _cache.QueryAsync(sqlQuery);
+            return _cache.Query(sqlQuery);
         }
 #pragma warning restore 618
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAsyncWrapper.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAsyncWrapper.cs
@@ -131,21 +131,39 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /** <inheritDoc /> */
         public IQueryCursor<ICacheEntry<TK, TV>> Query(ScanQuery<TK, TV> scanQuery)
         {
-            return _cache.Query(scanQuery);
+            return _cache.QueryAsync(scanQuery).GetResult();
+        }
+
+        /** <inheritDoc /> */
+        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(ScanQuery<TK, TV> scanQuery)
+        {
+            return _cache.QueryAsync(scanQuery);
         }
 
         /** <inheritDoc /> */
 #pragma warning disable 618
         public IQueryCursor<ICacheEntry<TK, TV>> Query(SqlQuery sqlQuery)
         {
-            return _cache.Query(sqlQuery);
+            return _cache.QueryAsync(sqlQuery).GetResult();
+        }
+
+        /** <inheritDoc /> */
+        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery)
+        {
+            return _cache.QueryAsync(sqlQuery);
         }
 #pragma warning restore 618
 
         /** <inheritDoc /> */
         public IFieldsQueryCursor Query(SqlFieldsQuery sqlFieldsQuery)
         {
-            return _cache.Query(sqlFieldsQuery);
+            return _cache.QueryAsync(sqlFieldsQuery).GetResult();
+        }
+
+        /** <inheritDoc /> */
+        public Task<IFieldsQueryCursor> QueryAsync(SqlFieldsQuery sqlFieldsQuery)
+        {
+            return _cache.QueryAsync(sqlFieldsQuery);
         }
 
         /** <inheritDoc /> */
@@ -343,7 +361,13 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /** <inheritDoc /> */
         public CacheClientConfiguration GetConfiguration()
         {
-            return _cache.GetConfiguration();
+            return _cache.GetConfigurationAsync().GetResult();
+        }
+
+        /** <inheritDoc /> */
+        public Task<CacheClientConfiguration> GetConfigurationAsync()
+        {
+            return _cache.GetConfigurationAsync();
         }
 
         /** <inheritDoc /> */
@@ -361,7 +385,13 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /** <inheritDoc /> */
         public IContinuousQueryHandleClient QueryContinuous(ContinuousQueryClient<TK, TV> continuousQuery)
         {
-            throw new System.NotImplementedException();
+            return _cache.QueryContinuousAsync(continuousQuery).GetResult();
+        }
+
+        /** <inheritDoc /> */
+        public Task<IContinuousQueryHandleClient> QueryContinuousAsync(ContinuousQueryClient<TK, TV> continuousQuery)
+        {
+            return _cache.QueryContinuousAsync(continuousQuery);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -120,6 +120,29 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         }
 
         /// <summary>
+        /// Tests that the async continuous query API registers the listener and delivers events.
+        /// </summary>
+        [Test]
+        public async Task TestQueryContinuousAsync()
+        {
+            var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName);
+
+            var events = new List<ICacheEntryEvent<int, int>>();
+            var qry = new ContinuousQueryClient<int, int>(new DelegateListener<int, int>(events.Add));
+
+            using (await cache.QueryContinuousAsync(qry))
+            {
+                await cache.PutAsync(1, 1);
+                TestUtils.WaitForTrueCondition(() => events.Count == 1);
+
+                var evt = events.Single();
+                Assert.AreEqual(CacheEntryEventType.Created, evt.EventType);
+                Assert.AreEqual(1, evt.Key);
+                Assert.AreEqual(1, evt.Value);
+            }
+        }
+
+        /// <summary>
         /// Tests that default query settings have correct values.
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CreateCacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CreateCacheTest.cs
@@ -78,6 +78,33 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         }
 
         /// <summary>
+        /// Tests the async cache lifecycle APIs: CreateCacheAsync, GetOrCreateCacheAsync,
+        /// GetCacheNamesAsync, DestroyCacheAsync.
+        /// </summary>
+        [Test]
+        public void TestAsyncCacheLifecycle()
+        {
+            DestroyCaches();
+            Assert.AreEqual(0, Client.GetCacheNamesAsync().GetResult().Count);
+
+            var cacheA = Client.CreateCacheAsync<int, int>("a").GetResult();
+            Assert.AreEqual("a", cacheA.Name);
+            Assert.AreEqual("a", Client.GetCacheNamesAsync().GetResult().Single());
+
+            // GetOrCreateCacheAsync returns existing cache without error.
+            var cacheA2 = Client.GetOrCreateCacheAsync<int, int>("a").GetResult();
+            Assert.AreEqual("a", cacheA2.Name);
+
+            var cacheB = Client.GetOrCreateCacheAsync<int, int>(
+                new CacheClientConfiguration { Name = "b" }).GetResult();
+            Assert.AreEqual("b", cacheB.Name);
+            Assert.AreEqual(new[] {"a", "b"}, Client.GetCacheNamesAsync().GetResult().OrderBy(x => x).ToArray());
+
+            Client.DestroyCacheAsync("a").WaitResult();
+            Assert.AreEqual("b", Client.GetCacheNamesAsync().GetResult().Single());
+        }
+
+        /// <summary>
         /// Tests create from template.
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CreateCacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CreateCacheTest.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Cache.Expiry;
     using Apache.Ignite.Core.Client;
@@ -82,26 +83,25 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
         /// GetCacheNamesAsync, DestroyCacheAsync.
         /// </summary>
         [Test]
-        public void TestAsyncCacheLifecycle()
+        public async Task TestAsyncCacheLifecycle()
         {
             DestroyCaches();
-            Assert.AreEqual(0, Client.GetCacheNamesAsync().GetResult().Count);
+            Assert.AreEqual(0, (await Client.GetCacheNamesAsync()).Count);
 
-            var cacheA = Client.CreateCacheAsync<int, int>("a").GetResult();
+            var cacheA = await Client.CreateCacheAsync<int, int>("a");
             Assert.AreEqual("a", cacheA.Name);
-            Assert.AreEqual("a", Client.GetCacheNamesAsync().GetResult().Single());
+            Assert.AreEqual("a", (await Client.GetCacheNamesAsync()).Single());
 
-            // GetOrCreateCacheAsync returns existing cache without error.
-            var cacheA2 = Client.GetOrCreateCacheAsync<int, int>("a").GetResult();
+            var cacheA2 = await Client.GetOrCreateCacheAsync<int, int>("a");
             Assert.AreEqual("a", cacheA2.Name);
 
-            var cacheB = Client.GetOrCreateCacheAsync<int, int>(
-                new CacheClientConfiguration { Name = "b" }).GetResult();
+            var cacheB = await Client.GetOrCreateCacheAsync<int, int>(
+                new CacheClientConfiguration { Name = "b" });
             Assert.AreEqual("b", cacheB.Name);
-            Assert.AreEqual(new[] {"a", "b"}, Client.GetCacheNamesAsync().GetResult().OrderBy(x => x).ToArray());
+            Assert.AreEqual(new[] {"a", "b"}, (await Client.GetCacheNamesAsync()).OrderBy(x => x).ToArray());
 
-            Client.DestroyCacheAsync("a").WaitResult();
-            Assert.AreEqual("b", Client.GetCacheNamesAsync().GetResult().Single());
+            await Client.DestroyCacheAsync("a");
+            Assert.AreEqual("b", (await Client.GetCacheNamesAsync()).Single());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CreateCacheTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CreateCacheTest.cs
@@ -98,10 +98,19 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var cacheB = await Client.GetOrCreateCacheAsync<int, int>(
                 new CacheClientConfiguration { Name = "b" });
             Assert.AreEqual("b", cacheB.Name);
-            Assert.AreEqual(new[] {"a", "b"}, (await Client.GetCacheNamesAsync()).OrderBy(x => x).ToArray());
+
+            var cacheC = await Client.CreateCacheAsync<int, int>(new CacheClientConfiguration { Name = "c" });
+            Assert.AreEqual("c", cacheC.Name);
+
+            // GetConfigurationAsync.
+            var cfgC = await cacheC.GetConfigurationAsync();
+            Assert.AreEqual("c", cfgC.Name);
+
+            Assert.AreEqual(
+                new[] {"a", "b", "c"}, (await Client.GetCacheNamesAsync()).OrderBy(x => x).ToArray());
 
             await Client.DestroyCacheAsync("a");
-            Assert.AreEqual("b", (await Client.GetCacheNamesAsync()).Single());
+            Assert.AreEqual(new[] {"b", "c"}, (await Client.GetCacheNamesAsync()).OrderBy(x => x).ToArray());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ScanQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ScanQueryTest.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Query;
@@ -103,6 +104,26 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                 query.Local = true;
                 var localRes = clientCache.Query(query).ToList();
                 Assert.Less(localRes.Count, cache.GetSize());
+            }
+        }
+
+        /// <summary>
+        /// Tests async scan query returns the same results as the sync one.
+        /// </summary>
+        [Test]
+        public async Task TestQueryAsync()
+        {
+            var cache = GetPersonCache();
+
+            using (var client = GetClient())
+            {
+                var clientCache = client.GetCache<int, Person>(CacheName);
+
+                var cursor = await clientCache.QueryAsync(new ScanQuery<int, Person>());
+
+                Assert.AreEqual(
+                    cache.Select(x => x.Value.Name).OrderBy(x => x).ToArray(),
+                    cursor.GetAll().Select(x => x.Value.Name).OrderBy(x => x).ToArray());
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Client;
     using NUnit.Framework;
@@ -86,6 +87,20 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             qry.EnableDistributedJoins = true;
             Assert.AreEqual(Count, cache.Query(qry).Count());
 #pragma warning restore 618
+        }
+
+        /// <summary>
+        /// Tests that the async fields query returns the same results as the sync one.
+        /// </summary>
+        [Test]
+        public async Task TestFieldsQueryAsync()
+        {
+            var cache = GetClientCache<Person>();
+
+            var cursor = await cache.QueryAsync(new SqlFieldsQuery("select Id from Person"));
+
+            CollectionAssert.AreEquivalent(Enumerable.Range(1, Count), cursor.Select(x => (int) x[0]));
+            Assert.AreEqual("ID", cursor.FieldNames.Single());
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCacheAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCacheAdapter.cs
@@ -124,11 +124,6 @@ namespace Apache.Ignite.Core.Tests.Client
             return _cache.Query(sqlQuery);
         }
 
-        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery)
-        {
-            return Task.FromResult(_cache.Query(sqlQuery));
-        }
-
         public IFieldsQueryCursor Query(SqlFieldsQuery sqlFieldsQuery)
         {
             return _cache.Query(sqlFieldsQuery);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCacheAdapter.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/ClientServerCacheAdapter.cs
@@ -114,14 +114,29 @@ namespace Apache.Ignite.Core.Tests.Client
             return _cache.Query(scanQuery);
         }
 
+        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(ScanQuery<TK, TV> scanQuery)
+        {
+            return Task.FromResult(_cache.Query(scanQuery));
+        }
+
         public IQueryCursor<ICacheEntry<TK, TV>> Query(SqlQuery sqlQuery)
         {
             return _cache.Query(sqlQuery);
         }
 
+        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery)
+        {
+            return Task.FromResult(_cache.Query(sqlQuery));
+        }
+
         public IFieldsQueryCursor Query(SqlFieldsQuery sqlFieldsQuery)
         {
             return _cache.Query(sqlFieldsQuery);
+        }
+
+        public Task<IFieldsQueryCursor> QueryAsync(SqlFieldsQuery sqlFieldsQuery)
+        {
+            return Task.FromResult(_cache.Query(sqlFieldsQuery));
         }
 
         public CacheResult<TV> GetAndPut(TK key, TV val)
@@ -289,6 +304,11 @@ namespace Apache.Ignite.Core.Tests.Client
             throw new NotSupportedException();
         }
 
+        public Task<CacheClientConfiguration> GetConfigurationAsync()
+        {
+            throw new NotSupportedException();
+        }
+
         public ICacheClient<TK1, TV1> WithKeepBinary<TK1, TV1>()
         {
             throw new NotSupportedException();
@@ -300,6 +320,11 @@ namespace Apache.Ignite.Core.Tests.Client
         }
 
         public IContinuousQueryHandleClient QueryContinuous(ContinuousQueryClient<TK, TV> continuousQuery)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IContinuousQueryHandleClient> QueryContinuousAsync(ContinuousQueryClient<TK, TV> continuousQuery)
         {
             throw new NotImplementedException();
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
@@ -45,6 +45,26 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         }
 
         /// <summary>
+        /// Test thin client cluster group async APIs return the same nodes as the sync ones.
+        /// </summary>
+        [Test]
+        public void TestGetNodesAsyncReturnsSameNodesAsThickOne()
+        {
+            var nodes = Ignition.GetIgnite().GetCluster().GetNodes();
+            var clientNodesAsync = Client.GetCluster().GetNodesAsync().GetResult();
+
+            Assert.IsNotEmpty(clientNodesAsync);
+            AssertNodesAreEqual(nodes, clientNodesAsync);
+
+            var node = Ignition.GetIgnite().GetCluster().GetNode();
+            var nodeAsync = Client.GetCluster().GetNodeAsync().GetResult();
+            AssertNodesAreEqual(node, nodeAsync);
+
+            var byIdAsync = Client.GetCluster().GetNodeAsync(node.Id).GetResult();
+            AssertNodesAreEqual(node, byIdAsync);
+        }
+
+        /// <summary>
         /// Test thin client cluster group returns the same node as thick one.
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Cluster;
     using Apache.Ignite.Core.Impl.Client.Cluster;
@@ -48,19 +49,19 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         /// Test thin client cluster group async APIs return the same nodes as the sync ones.
         /// </summary>
         [Test]
-        public void TestGetNodesAsyncReturnsSameNodesAsThickOne()
+        public async Task TestGetNodesAsyncReturnsSameNodesAsThickOne()
         {
             var nodes = Ignition.GetIgnite().GetCluster().GetNodes();
-            var clientNodesAsync = Client.GetCluster().GetNodesAsync().GetResult();
+            var clientNodesAsync = await Client.GetCluster().GetNodesAsync();
 
             Assert.IsNotEmpty(clientNodesAsync);
             AssertNodesAreEqual(nodes, clientNodesAsync);
 
             var node = Ignition.GetIgnite().GetCluster().GetNode();
-            var nodeAsync = Client.GetCluster().GetNodeAsync().GetResult();
+            var nodeAsync = await Client.GetCluster().GetNodeAsync();
             AssertNodesAreEqual(node, nodeAsync);
 
-            var byIdAsync = Client.GetCluster().GetNodeAsync(node.Id).GetResult();
+            var byIdAsync = await Client.GetCluster().GetNodeAsync(node.Id);
             AssertNodesAreEqual(node, byIdAsync);
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterGroupTests.cs
@@ -151,17 +151,23 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         {
             var invalidNodeIds = new[] {Guid.Empty};
             var clusterGroup = (ClientClusterGroup) Client.GetCluster();
+            var oldNodeIds = clusterGroup.GetNodes().Select(x => x.Id).ToArray();
 
             var cfg = GetIgniteConfiguration();
             cfg.AutoGenerateIgniteInstanceName = true;
 
-            clusterGroup.UpdateTopology(1000L, invalidNodeIds);
+            try
+            {
+                clusterGroup.UpdateTopology(1000L, invalidNodeIds);
 
-            TestDelegate action = () => clusterGroup.GetNode();
-
-            ArgumentException exception = Assert.Throws<ArgumentException>(action);
-            Assert.AreEqual("Unable to find node with id='00000000-0000-0000-0000-000000000000'",
-                exception.Message);
+                ArgumentException exception = Assert.Throws<ArgumentException>(() => clusterGroup.GetNode());
+                Assert.AreEqual("Unable to find node with id='00000000-0000-0000-0000-000000000000'",
+                    exception.Message);
+            }
+            finally
+            {
+                clusterGroup.UpdateTopology(1001L, oldNodeIds);
+            }
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterTests.cs
@@ -101,6 +101,26 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         }
 
         /// <summary>
+        /// Test cluster activation and WAL state change via async APIs.
+        /// </summary>
+        [Test]
+        public void TestAsyncClusterAndWalOperations()
+        {
+            var clientCluster = GetClientCluster();
+
+            clientCluster.SetActiveAsync(true).WaitResult();
+            Assert.IsTrue(clientCluster.IsActiveAsync().GetResult());
+            Assert.IsTrue(GetCluster().IsActive());
+
+            clientCluster.DisableWalAsync(PersistentCache).GetResult();
+            Assert.IsFalse(clientCluster.IsWalEnabledAsync(PersistentCache).GetResult());
+
+            Assert.IsTrue(clientCluster.EnableWalAsync(PersistentCache).GetResult());
+            Assert.IsTrue(clientCluster.IsWalEnabledAsync(PersistentCache).GetResult());
+            Assert.IsTrue(GetCluster().IsWalEnabled(PersistentCache));
+        }
+
+        /// <summary>
         /// Test enable WAL.
         /// </summary>
         [Test]

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cluster/ClientClusterTests.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.Core.Tests.Client.Cluster
 {
     using System;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Cluster;
@@ -104,19 +105,19 @@ namespace Apache.Ignite.Core.Tests.Client.Cluster
         /// Test cluster activation and WAL state change via async APIs.
         /// </summary>
         [Test]
-        public void TestAsyncClusterAndWalOperations()
+        public async Task TestAsyncClusterAndWalOperations()
         {
             var clientCluster = GetClientCluster();
 
-            clientCluster.SetActiveAsync(true).WaitResult();
-            Assert.IsTrue(clientCluster.IsActiveAsync().GetResult());
+            await clientCluster.SetActiveAsync(true);
+            Assert.IsTrue(await clientCluster.IsActiveAsync());
             Assert.IsTrue(GetCluster().IsActive());
 
-            clientCluster.DisableWalAsync(PersistentCache).GetResult();
-            Assert.IsFalse(clientCluster.IsWalEnabledAsync(PersistentCache).GetResult());
+            await clientCluster.DisableWalAsync(PersistentCache);
+            Assert.IsFalse(await clientCluster.IsWalEnabledAsync(PersistentCache));
 
-            Assert.IsTrue(clientCluster.EnableWalAsync(PersistentCache).GetResult());
-            Assert.IsTrue(clientCluster.IsWalEnabledAsync(PersistentCache).GetResult());
+            Assert.IsTrue(await clientCluster.EnableWalAsync(PersistentCache));
+            Assert.IsTrue(await clientCluster.IsWalEnabledAsync(PersistentCache));
             Assert.IsTrue(GetCluster().IsWalEnabled(PersistentCache));
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/AtomicLongClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/AtomicLongClientTests.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
 {
     using System;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.DataStructures;
@@ -41,28 +42,28 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
         }
 
         [Test]
-        public void TestAsyncOperationsMatchSyncBehavior()
+        public async Task TestAsyncOperationsMatchSyncBehavior()
         {
-            var atomicLong = Client.GetAtomicLongAsync(TestUtils.TestName, 42, true).GetResult();
+            var atomicLong = await Client.GetAtomicLongAsync(TestUtils.TestName, 42, true);
 
             Assert.IsNotNull(atomicLong);
-            Assert.AreEqual(42, atomicLong.ReadAsync().GetResult());
-            Assert.AreEqual(43, atomicLong.IncrementAsync().GetResult());
-            Assert.AreEqual(53, atomicLong.AddAsync(10).GetResult());
-            Assert.AreEqual(52, atomicLong.DecrementAsync().GetResult());
-            Assert.AreEqual(52, atomicLong.ExchangeAsync(100).GetResult());
-            Assert.AreEqual(100, atomicLong.CompareExchangeAsync(7, 100).GetResult());
-            Assert.AreEqual(7, atomicLong.ReadAsync().GetResult());
+            Assert.AreEqual(42, await atomicLong.ReadAsync());
+            Assert.AreEqual(43, await atomicLong.IncrementAsync());
+            Assert.AreEqual(53, await atomicLong.AddAsync(10));
+            Assert.AreEqual(52, await atomicLong.DecrementAsync());
+            Assert.AreEqual(52, await atomicLong.ExchangeAsync(100));
+            Assert.AreEqual(100, await atomicLong.CompareExchangeAsync(7, 100));
+            Assert.AreEqual(7, await atomicLong.ReadAsync());
 
-            Assert.IsFalse(atomicLong.IsClosedAsync().GetResult());
-            atomicLong.CloseAsync().WaitResult();
-            Assert.IsTrue(atomicLong.IsClosedAsync().GetResult());
+            Assert.IsFalse(await atomicLong.IsClosedAsync());
+            await atomicLong.CloseAsync();
+            Assert.IsTrue(await atomicLong.IsClosedAsync());
         }
 
         [Test]
-        public void TestGetAtomicLongAsyncReturnsNullWhenDoesNotExistAndCreateIsFalse()
+        public async Task TestGetAtomicLongAsyncReturnsNullWhenDoesNotExistAndCreateIsFalse()
         {
-            var atomicLong = Client.GetAtomicLongAsync(TestUtils.TestName, 0, false).GetResult();
+            var atomicLong = await Client.GetAtomicLongAsync(TestUtils.TestName, 0, false);
 
             Assert.IsNull(atomicLong);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/AtomicLongClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/AtomicLongClientTests.cs
@@ -41,6 +41,33 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
         }
 
         [Test]
+        public void TestAsyncOperationsMatchSyncBehavior()
+        {
+            var atomicLong = Client.GetAtomicLongAsync(TestUtils.TestName, 42, true).GetResult();
+
+            Assert.IsNotNull(atomicLong);
+            Assert.AreEqual(42, atomicLong.ReadAsync().GetResult());
+            Assert.AreEqual(43, atomicLong.IncrementAsync().GetResult());
+            Assert.AreEqual(53, atomicLong.AddAsync(10).GetResult());
+            Assert.AreEqual(52, atomicLong.DecrementAsync().GetResult());
+            Assert.AreEqual(52, atomicLong.ExchangeAsync(100).GetResult());
+            Assert.AreEqual(100, atomicLong.CompareExchangeAsync(7, 100).GetResult());
+            Assert.AreEqual(7, atomicLong.ReadAsync().GetResult());
+
+            Assert.IsFalse(atomicLong.IsClosedAsync().GetResult());
+            atomicLong.CloseAsync().WaitResult();
+            Assert.IsTrue(atomicLong.IsClosedAsync().GetResult());
+        }
+
+        [Test]
+        public void TestGetAtomicLongAsyncReturnsNullWhenDoesNotExistAndCreateIsFalse()
+        {
+            var atomicLong = Client.GetAtomicLongAsync(TestUtils.TestName, 0, false).GetResult();
+
+            Assert.IsNull(atomicLong);
+        }
+
+        [Test]
         public void TestCreateIgnoresInitialValueWhenAlreadyExists()
         {
             var atomicLong = Client.GetAtomicLong(TestUtils.TestName, 42, true);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/AtomicLongClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/AtomicLongClientTests.cs
@@ -69,6 +69,23 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
         }
 
         [Test]
+        public async Task TestGetAtomicLongAsyncWithConfiguration()
+        {
+            var cfg = new AtomicClientConfiguration
+            {
+                AtomicSequenceReserveSize = 32,
+                Backups = 2,
+                CacheMode = CacheMode.Partitioned,
+                GroupName = "atomics-partitioned-async"
+            };
+
+            var atomicLong = await Client.GetAtomicLongAsync(TestUtils.TestName, cfg, 42, true);
+
+            Assert.IsNotNull(atomicLong);
+            Assert.AreEqual(42, await atomicLong.ReadAsync());
+        }
+
+        [Test]
         public void TestCreateIgnoresInitialValueWhenAlreadyExists()
         {
             var atomicLong = Client.GetAtomicLong(TestUtils.TestName, 42, true);

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.DataStructures;
@@ -34,10 +35,10 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
     public class IgniteSetClientTests : ClientTestBase
     {
         [Test]
-        public void TestGetIgniteSetAsyncCreatesSet()
+        public async Task TestGetIgniteSetAsyncCreatesSet()
         {
-            var set = Client.GetIgniteSetAsync<int>(nameof(TestGetIgniteSetAsyncCreatesSet),
-                GetCollectionConfiguration()).GetResult();
+            var set = await Client.GetIgniteSetAsync<int>(nameof(TestGetIgniteSetAsyncCreatesSet),
+                GetCollectionConfiguration());
 
             Assert.IsNotNull(set);
             Assert.AreEqual(nameof(TestGetIgniteSetAsyncCreatesSet), set.Name);
@@ -46,7 +47,7 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
             Assert.IsTrue(set.Contains(1));
 
             // Existing set is returned without configuration.
-            var existing = Client.GetIgniteSetAsync<int>(nameof(TestGetIgniteSetAsyncCreatesSet), null).GetResult();
+            var existing = await Client.GetIgniteSetAsync<int>(nameof(TestGetIgniteSetAsyncCreatesSet), null);
             Assert.IsNotNull(existing);
             Assert.IsTrue(existing.Contains(1));
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/DataStructures/IgniteSetClientTests.cs
@@ -34,6 +34,24 @@ namespace Apache.Ignite.Core.Tests.Client.DataStructures
     public class IgniteSetClientTests : ClientTestBase
     {
         [Test]
+        public void TestGetIgniteSetAsyncCreatesSet()
+        {
+            var set = Client.GetIgniteSetAsync<int>(nameof(TestGetIgniteSetAsyncCreatesSet),
+                GetCollectionConfiguration()).GetResult();
+
+            Assert.IsNotNull(set);
+            Assert.AreEqual(nameof(TestGetIgniteSetAsyncCreatesSet), set.Name);
+
+            set.Add(1);
+            Assert.IsTrue(set.Contains(1));
+
+            // Existing set is returned without configuration.
+            var existing = Client.GetIgniteSetAsync<int>(nameof(TestGetIgniteSetAsyncCreatesSet), null).GetResult();
+            Assert.IsNotNull(existing);
+            Assert.IsTrue(existing.Contains(1));
+        }
+
+        [Test]
         public void TestCreateAddContainsRemove()
         {
             var set = Client.GetIgniteSet<int>(nameof(TestCreateAddContainsRemove),

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Services/ServicesClientTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Services/ServicesClientTest.cs
@@ -585,6 +585,26 @@ namespace Apache.Ignite.Core.Tests.Client.Services
             Assert.AreEqual(svc.PlatformType, svc1.PlatformType);
         }
 
+        [Test]
+        public void TestGetServiceDescriptorsAsync()
+        {
+            DeployAndGetTestService();
+
+            var svcs = Client.GetServices().GetServiceDescriptorsAsync().GetResult();
+
+            Assert.AreEqual(1, svcs.Count);
+            Assert.AreEqual(ServiceName, svcs.First().Name);
+
+            var svc = Client.GetServices().GetServiceDescriptorAsync(ServiceName).GetResult();
+
+            Assert.AreEqual(ServiceName, svc.Name);
+            Assert.AreEqual(
+                "org.apache.ignite.internal.processors.platform.dotnet.PlatformDotNetServiceImpl",
+                svc.ServiceClass
+            );
+            Assert.AreEqual(PlatformType.DotNet, svc.PlatformType);
+        }
+
         /// <summary>
         /// Deploys test service and returns client-side proxy.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Services/ServicesClientTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Services/ServicesClientTest.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Core.Tests.Client.Services
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Services;
@@ -586,16 +587,16 @@ namespace Apache.Ignite.Core.Tests.Client.Services
         }
 
         [Test]
-        public void TestGetServiceDescriptorsAsync()
+        public async Task TestGetServiceDescriptorsAsync()
         {
             DeployAndGetTestService();
 
-            var svcs = Client.GetServices().GetServiceDescriptorsAsync().GetResult();
+            var svcs = await Client.GetServices().GetServiceDescriptorsAsync();
 
             Assert.AreEqual(1, svcs.Count);
             Assert.AreEqual(ServiceName, svcs.First().Name);
 
-            var svc = Client.GetServices().GetServiceDescriptorAsync(ServiceName).GetResult();
+            var svc = await Client.GetServices().GetServiceDescriptorAsync(ServiceName);
 
             Assert.AreEqual(ServiceName, svc.Name);
             Assert.AreEqual(

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/ICacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/ICacheClient.cs
@@ -169,15 +169,6 @@ namespace Apache.Ignite.Core.Client.Cache
         IQueryCursor<ICacheEntry<TK, TV>> Query(SqlQuery sqlQuery);
 
         /// <summary>
-        /// Executes an SQL query.
-        /// </summary>
-        /// <param name="sqlQuery">SQL query.</param>
-        /// <returns>Query cursor.</returns>
-        [Obsolete("Use SqlFieldsQuery instead. For strongly-typed queries use Apache.Ignite.Linq. " +
-                  "SqlQuery is a limited subset of SqlFieldsQuery.")]
-        Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery);
-
-        /// <summary>
         /// Executes an SQL Fields query.
         /// </summary>
         /// <param name="sqlFieldsQuery">SQL query.</param>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/ICacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/ICacheClient.cs
@@ -153,6 +153,13 @@ namespace Apache.Ignite.Core.Client.Cache
         IQueryCursor<ICacheEntry<TK, TV>> Query(ScanQuery<TK, TV> scanQuery);
 
         /// <summary>
+        /// Executes a Scan query.
+        /// </summary>
+        /// <param name="scanQuery">Scan query.</param>
+        /// <returns>Query cursor.</returns>
+        Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(ScanQuery<TK, TV> scanQuery);
+
+        /// <summary>
         /// Executes an SQL query.
         /// </summary>
         /// <param name="sqlQuery">SQL query.</param>
@@ -162,11 +169,27 @@ namespace Apache.Ignite.Core.Client.Cache
         IQueryCursor<ICacheEntry<TK, TV>> Query(SqlQuery sqlQuery);
 
         /// <summary>
+        /// Executes an SQL query.
+        /// </summary>
+        /// <param name="sqlQuery">SQL query.</param>
+        /// <returns>Query cursor.</returns>
+        [Obsolete("Use SqlFieldsQuery instead. For strongly-typed queries use Apache.Ignite.Linq. " +
+                  "SqlQuery is a limited subset of SqlFieldsQuery.")]
+        Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery);
+
+        /// <summary>
         /// Executes an SQL Fields query.
         /// </summary>
         /// <param name="sqlFieldsQuery">SQL query.</param>
         /// <returns>Query cursor.</returns>
         IFieldsQueryCursor Query(SqlFieldsQuery sqlFieldsQuery);
+
+        /// <summary>
+        /// Executes an SQL Fields query.
+        /// </summary>
+        /// <param name="sqlFieldsQuery">SQL query.</param>
+        /// <returns>Query cursor.</returns>
+        Task<IFieldsQueryCursor> QueryAsync(SqlFieldsQuery sqlFieldsQuery);
 
         /// <summary>
         /// Associates the specified value with the specified key in this cache,
@@ -418,6 +441,12 @@ namespace Apache.Ignite.Core.Client.Cache
         CacheClientConfiguration GetConfiguration();
 
         /// <summary>
+        /// Gets the cache configuration.
+        /// </summary>
+        /// <returns>Cache configuration.</returns>
+        Task<CacheClientConfiguration> GetConfigurationAsync();
+
+        /// <summary>
         /// Gets cache with KeepBinary mode enabled, changing key and/or value types if necessary.
         /// You can only change key/value types when transitioning from non-binary to binary cache;
         /// Changing type of binary cache is not allowed and will throw an <see cref="InvalidOperationException"/>.
@@ -445,5 +474,12 @@ namespace Apache.Ignite.Core.Client.Cache
         /// <param name="continuousQuery">Continuous query.</param>
         /// <returns>Handle to stop the query execution.</returns>
         IContinuousQueryHandleClient QueryContinuous(ContinuousQueryClient<TK, TV> continuousQuery);
+
+        /// <summary>
+        /// Starts the continuous query execution.
+        /// </summary>
+        /// <param name="continuousQuery">Continuous query.</param>
+        /// <returns>Handle to stop the query execution.</returns>
+        Task<IContinuousQueryHandleClient> QueryContinuousAsync(ContinuousQueryClient<TK, TV> continuousQuery);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/DataStructures/IAtomicLongClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/DataStructures/IAtomicLongClient.cs
@@ -16,6 +16,8 @@
 
 namespace Apache.Ignite.Core.Client.DataStructures
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Represents a distributed atomic long value.
     /// <para />
@@ -38,10 +40,22 @@ namespace Apache.Ignite.Core.Client.DataStructures
         long Read();
 
         /// <summary>
+        /// Returns current value.
+        /// </summary>
+        /// <returns>Current value of the atomic long.</returns>
+        Task<long> ReadAsync();
+
+        /// <summary>
         /// Increments current value and returns result.
         /// </summary>
         /// <returns>Current value of the atomic long.</returns>
         long Increment();
+
+        /// <summary>
+        /// Increments current value and returns result.
+        /// </summary>
+        /// <returns>Current value of the atomic long.</returns>
+        Task<long> IncrementAsync();
 
         /// <summary>
         /// Adds specified value to the current value and returns result.
@@ -51,10 +65,23 @@ namespace Apache.Ignite.Core.Client.DataStructures
         long Add(long value);
 
         /// <summary>
+        /// Adds specified value to the current value and returns result.
+        /// </summary>
+        /// <param name="value">The value to add.</param>
+        /// <returns>Current value of the atomic long.</returns>
+        Task<long> AddAsync(long value);
+
+        /// <summary>
         /// Decrements current value and returns result.
         /// </summary>
         /// <returns>Current value of the atomic long.</returns>
         long Decrement();
+
+        /// <summary>
+        /// Decrements current value and returns result.
+        /// </summary>
+        /// <returns>Current value of the atomic long.</returns>
+        Task<long> DecrementAsync();
 
         /// <summary>
         /// Sets current value to a specified value and returns the original value.
@@ -62,6 +89,13 @@ namespace Apache.Ignite.Core.Client.DataStructures
         /// <param name="value">The value to set.</param>
         /// <returns>Original value of the atomic long.</returns>
         long Exchange(long value);
+
+        /// <summary>
+        /// Sets current value to a specified value and returns the original value.
+        /// </summary>
+        /// <param name="value">The value to set.</param>
+        /// <returns>Original value of the atomic long.</returns>
+        Task<long> ExchangeAsync(long value);
 
         /// <summary>
         /// Compares current value with specified value for equality and, if they are equal, replaces current value.
@@ -72,14 +106,34 @@ namespace Apache.Ignite.Core.Client.DataStructures
         long CompareExchange(long value, long comparand);
 
         /// <summary>
+        /// Compares current value with specified value for equality and, if they are equal, replaces current value.
+        /// </summary>
+        /// <param name="value">The value to set.</param>
+        /// <param name="comparand">The value that is compared to the current value.</param>
+        /// <returns>Original value of the atomic long.</returns>
+        Task<long> CompareExchangeAsync(long value, long comparand);
+
+        /// <summary>
         /// Determines whether this instance was removed from cache.
         /// </summary>
         /// <returns>True if this atomic was removed from cache; otherwise, false.</returns>
         bool IsClosed();
 
         /// <summary>
+        /// Determines whether this instance was removed from cache.
+        /// </summary>
+        /// <returns>True if this atomic was removed from cache; otherwise, false.</returns>
+        Task<bool> IsClosedAsync();
+
+        /// <summary>
         /// Closes this instance.
         /// </summary>
         void Close();
+
+        /// <summary>
+        /// Closes this instance.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task CloseAsync();
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IClientCluster.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IClientCluster.cs
@@ -16,6 +16,8 @@
 
 namespace Apache.Ignite.Core.Client
 {
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Represents whole cluster (group of all nodes in a cluster).
     /// </summary>
@@ -27,12 +29,27 @@ namespace Apache.Ignite.Core.Client
         void SetActive(bool isActive);
 
         /// <summary>
+        /// Changes Ignite grid state to active or inactive.
+        /// </summary>
+        /// <param name="isActive">Whether the grid should be active.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task SetActiveAsync(bool isActive);
+
+        /// <summary>
         /// Determines whether this grid is in active state.
         /// </summary>
         /// <returns>
         ///  <c>true</c> if the grid is active; otherwise, <c>false</c>.
         /// </returns>
         bool IsActive();
+
+        /// <summary>
+        /// Determines whether this grid is in active state.
+        /// </summary>
+        /// <returns>
+        ///  <c>true</c> if the grid is active; otherwise, <c>false</c>.
+        /// </returns>
+        Task<bool> IsActiveAsync();
 
         /// <summary>
         /// Disables write-ahead logging for specified cache. When WAL is disabled, changes are not logged to disk.
@@ -51,6 +68,22 @@ namespace Apache.Ignite.Core.Client
         bool DisableWal(string cacheName);
 
         /// <summary>
+        /// Disables write-ahead logging for specified cache. When WAL is disabled, changes are not logged to disk.
+        /// This significantly improves cache update speed.The drawback is absence of local crash-recovery guarantees.
+        /// If node is crashed, local content of WAL-disabled cache will be cleared on restart
+        /// to avoid data corruption.
+        /// <para />
+        /// Internally this method will wait for all current cache operations to finish and prevent new cache
+        /// operations from being executed.Then checkpoint is initiated to flush all data to disk.Control is returned
+        /// to the callee when all dirty pages are prepared for checkpoint, but not necessarily flushed to disk.
+        /// <para />
+        /// WAL state can be changed only for persistent caches.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache.</param>
+        /// <returns>Whether WAL was enabled by this call.</returns>
+        Task<bool> DisableWalAsync(string cacheName);
+
+        /// <summary>
         /// Enables write-ahead logging for specified cache. Restoring crash-recovery guarantees of a previous call to
         /// <see cref="DisableWal"/>.
         /// <para />
@@ -65,9 +98,30 @@ namespace Apache.Ignite.Core.Client
         bool EnableWal(string cacheName);
 
         /// <summary>
+        /// Enables write-ahead logging for specified cache. Restoring crash-recovery guarantees of a previous call to
+        /// <see cref="DisableWalAsync"/>.
+        /// <para />
+        /// Internally this method will wait for all current cache operations to finish and prevent new cache
+        /// operations from being executed. Then checkpoint is initiated to flush all data to disk.
+        /// Control is returned to the callee when all data is persisted to disk.
+        /// <para />
+        /// WAL state can be changed only for persistent caches.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache.</param>
+        /// <returns>Whether WAL was disabled by this call.</returns>
+        Task<bool> EnableWalAsync(string cacheName);
+
+        /// <summary>
         /// Determines whether write-ahead logging is enabled for specified cache.
         /// </summary>
         /// <param name="cacheName">Name of the cache.</param>
         bool IsWalEnabled(string cacheName);
+
+        /// <summary>
+        /// Determines whether write-ahead logging is enabled for specified cache.
+        /// </summary>
+        /// <param name="cacheName">Name of the cache.</param>
+        /// <returns>Whether WAL is enabled for the specified cache.</returns>
+        Task<bool> IsWalEnabledAsync(string cacheName);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IClientClusterGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IClientClusterGroup.cs
@@ -19,6 +19,7 @@ namespace Apache.Ignite.Core.Client
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client.Compute;
     using Apache.Ignite.Core.Client.Services;
 
@@ -80,6 +81,12 @@ namespace Apache.Ignite.Core.Client
         ICollection<IClientClusterNode> GetNodes();
 
         /// <summary>
+        /// Gets read-only collections of nodes in this projection.
+        /// </summary>
+        /// <returns>All nodes in this projection.</returns>
+        Task<ICollection<IClientClusterNode>> GetNodesAsync();
+
+        /// <summary>
         /// Gets a node for given ID from this grid projection.
         /// </summary>
         /// <param name="id">Node ID.</param>
@@ -88,11 +95,25 @@ namespace Apache.Ignite.Core.Client
         IClientClusterNode? GetNode(Guid id);
 
         /// <summary>
+        /// Gets a node for given ID from this grid projection.
+        /// </summary>
+        /// <param name="id">Node ID.</param>
+        /// <returns>Node with given ID from this projection or null if such node does not
+        /// exist in this projection.</returns>
+        Task<IClientClusterNode?> GetNodeAsync(Guid id);
+
+        /// <summary>
         /// Gets first node from the list of nodes in this projection.
         /// </summary>
         /// <returns>Node.</returns>
         [SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate", Justification = "Semantics.")]
         IClientClusterNode? GetNode();
+
+        /// <summary>
+        /// Gets first node from the list of nodes in this projection.
+        /// </summary>
+        /// <returns>Node.</returns>
+        Task<IClientClusterNode?> GetNodeAsync();
 
         /// <summary>
         /// Gets compute functionality over this grid projection. All operations

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
@@ -319,7 +319,7 @@ namespace Apache.Ignite.Core.Client
         /// Gets or creates an Ignite set with the specified name.
         /// </summary>
         /// <param name="name">Name.</param>
-        /// <param name="configuration">Configuration. When null, gets and existing set by name;
+        /// <param name="configuration">Configuration. When null, gets an existing set by name;
         /// otherwise, creates a new set with the specified configuration.</param>
         /// <typeparam name="T">Element type.</typeparam>
         /// <returns>Ignite set.</returns>
@@ -329,7 +329,7 @@ namespace Apache.Ignite.Core.Client
         /// Gets or creates an Ignite set with the specified name.
         /// </summary>
         /// <param name="name">Name.</param>
-        /// <param name="configuration">Configuration. When null, gets and existing set by name;
+        /// <param name="configuration">Configuration. When null, gets an existing set by name;
         /// otherwise, creates a new set with the specified configuration.</param>
         /// <typeparam name="T">Element type.</typeparam>
         /// <returns>Ignite set.</returns>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
@@ -293,7 +293,7 @@ namespace Apache.Ignite.Core.Client
         /// or null if it does not exist and <paramref name="create"/> is <c>false</c>.</returns>
         IAtomicLongClient? GetAtomicLong(
             string name,
-            AtomicClientConfiguration configuration,
+            AtomicClientConfiguration? configuration,
             long initialValue,
             bool create);
 
@@ -311,7 +311,7 @@ namespace Apache.Ignite.Core.Client
         /// or null if it does not exist and <paramref name="create"/> is <c>false</c>.</returns>
         Task<IAtomicLongClient?> GetAtomicLongAsync(
             string name,
-            AtomicClientConfiguration configuration,
+            AtomicClientConfiguration? configuration,
             long initialValue,
             bool create);
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/IIgniteClient.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Client
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Net;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client.Cache;
     using Apache.Ignite.Core.Client.Compute;
@@ -64,6 +65,16 @@ namespace Apache.Ignite.Core.Client
             where TK : notnull;
 
         /// <summary>
+        /// Gets existing cache with the given name or creates new one using template configuration.
+        /// </summary>
+        /// <typeparam name="TK">Cache key type.</typeparam>
+        /// <typeparam name="TV">Cache value type.</typeparam>
+        /// <param name="name">Cache name.</param>
+        /// <returns>Existing or newly created cache.</returns>
+        Task<ICacheClient<TK, TV>> GetOrCreateCacheAsync<TK, TV>(string name)
+            where TK : notnull;
+
+        /// <summary>
         /// Gets existing cache with the given name or creates new one using provided configuration.
         /// </summary>
         /// <typeparam name="TK">Cache key type.</typeparam>
@@ -71,6 +82,16 @@ namespace Apache.Ignite.Core.Client
         /// <param name="configuration">Cache configuration.</param>
         /// <returns>Existing or newly created cache.</returns>
         ICacheClient<TK, TV> GetOrCreateCache<TK, TV>(CacheClientConfiguration configuration)
+            where TK : notnull;
+
+        /// <summary>
+        /// Gets existing cache with the given name or creates new one using provided configuration.
+        /// </summary>
+        /// <typeparam name="TK">Cache key type.</typeparam>
+        /// <typeparam name="TV">Cache value type.</typeparam>
+        /// <param name="configuration">Cache configuration.</param>
+        /// <returns>Existing or newly created cache.</returns>
+        Task<ICacheClient<TK, TV>> GetOrCreateCacheAsync<TK, TV>(CacheClientConfiguration configuration)
             where TK : notnull;
 
         /// <summary>
@@ -84,6 +105,16 @@ namespace Apache.Ignite.Core.Client
             where TK : notnull;
 
         /// <summary>
+        /// Dynamically starts new cache using template configuration.
+        /// </summary>
+        /// <typeparam name="TK">Cache key type.</typeparam>
+        /// <typeparam name="TV">Cache value type.</typeparam>
+        /// <param name="name">Cache name.</param>
+        /// <returns>Existing or newly created cache.</returns>
+        Task<ICacheClient<TK, TV>> CreateCacheAsync<TK, TV>(string name)
+            where TK : notnull;
+
+        /// <summary>
         /// Dynamically starts new cache using provided configuration.
         /// </summary>
         /// <typeparam name="TK">Cache key type.</typeparam>
@@ -94,10 +125,26 @@ namespace Apache.Ignite.Core.Client
             where TK : notnull;
 
         /// <summary>
+        /// Dynamically starts new cache using provided configuration.
+        /// </summary>
+        /// <typeparam name="TK">Cache key type.</typeparam>
+        /// <typeparam name="TV">Cache value type.</typeparam>
+        /// <param name="configuration">Cache configuration.</param>
+        /// <returns>Existing or newly created cache.</returns>
+        Task<ICacheClient<TK, TV>> CreateCacheAsync<TK, TV>(CacheClientConfiguration configuration)
+            where TK : notnull;
+
+        /// <summary>
         /// Gets the collection of names of currently available caches, or empty collection if there are no caches.
         /// </summary>
         /// <returns>Collection of names of currently available caches.</returns>
         ICollection<string> GetCacheNames();
+
+        /// <summary>
+        /// Gets the collection of names of currently available caches, or empty collection if there are no caches.
+        /// </summary>
+        /// <returns>Collection of names of currently available caches.</returns>
+        Task<ICollection<string>> GetCacheNamesAsync();
 
         /// <summary>
         /// Gets Ignite cluster.
@@ -111,6 +158,14 @@ namespace Apache.Ignite.Core.Client
         /// </summary>
         /// <param name="name">The name of the cache to stop.</param>
         void DestroyCache(string name);
+
+        /// <summary>
+        /// Destroys dynamically created (with <see cref="CreateCacheAsync{TK,TV}(string)"/> or
+        /// <see cref="GetOrCreateCacheAsync{TK,TV}(string)"/>) cache.
+        /// </summary>
+        /// <param name="name">The name of the cache to stop.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task DestroyCacheAsync(string name);
 
         /// <summary>
         /// Gets Ignite binary services.
@@ -216,6 +271,19 @@ namespace Apache.Ignite.Core.Client
         /// Creates a new atomic long if it does not exist and <paramref name="create"/> is true.
         /// </summary>
         /// <param name="name">Name of the atomic long.</param>
+        /// <param name="initialValue">
+        /// Initial value for the atomic long. Ignored if <paramref name="create"/> is false.
+        /// </param>
+        /// <param name="create">Flag indicating whether atomic long should be created if it does not exist.</param>
+        /// <returns>Atomic long instance with the specified name,
+        /// or null if it does not exist and <paramref name="create"/> is <c>false</c>.</returns>
+        Task<IAtomicLongClient?> GetAtomicLongAsync(string name, long initialValue, bool create);
+
+        /// <summary>
+        /// Gets an atomic long with the specified name.
+        /// Creates a new atomic long if it does not exist and <paramref name="create"/> is true.
+        /// </summary>
+        /// <param name="name">Name of the atomic long.</param>
         /// <param name="configuration">Configuration.</param>
         /// <param name="initialValue">
         /// Initial value for the atomic long. Ignored if <paramref name="create"/> is false.
@@ -230,6 +298,24 @@ namespace Apache.Ignite.Core.Client
             bool create);
 
         /// <summary>
+        /// Gets an atomic long with the specified name.
+        /// Creates a new atomic long if it does not exist and <paramref name="create"/> is true.
+        /// </summary>
+        /// <param name="name">Name of the atomic long.</param>
+        /// <param name="configuration">Configuration.</param>
+        /// <param name="initialValue">
+        /// Initial value for the atomic long. Ignored if <paramref name="create"/> is false.
+        /// </param>
+        /// <param name="create">Flag indicating whether atomic long should be created if it does not exist.</param>
+        /// <returns>Atomic long instance with the specified name,
+        /// or null if it does not exist and <paramref name="create"/> is <c>false</c>.</returns>
+        Task<IAtomicLongClient?> GetAtomicLongAsync(
+            string name,
+            AtomicClientConfiguration configuration,
+            long initialValue,
+            bool create);
+
+        /// <summary>
         /// Gets or creates an Ignite set with the specified name.
         /// </summary>
         /// <param name="name">Name.</param>
@@ -238,5 +324,15 @@ namespace Apache.Ignite.Core.Client
         /// <typeparam name="T">Element type.</typeparam>
         /// <returns>Ignite set.</returns>
         IIgniteSetClient<T>? GetIgniteSet<T>(string name, CollectionClientConfiguration? configuration);
+
+        /// <summary>
+        /// Gets or creates an Ignite set with the specified name.
+        /// </summary>
+        /// <param name="name">Name.</param>
+        /// <param name="configuration">Configuration. When null, gets and existing set by name;
+        /// otherwise, creates a new set with the specified configuration.</param>
+        /// <typeparam name="T">Element type.</typeparam>
+        /// <returns>Ignite set.</returns>
+        Task<IIgniteSetClient<T>?> GetIgniteSetAsync<T>(string name, CollectionClientConfiguration? configuration);
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Services/IServicesClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Services/IServicesClient.cs
@@ -17,6 +17,7 @@
 namespace Apache.Ignite.Core.Client.Services
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Ignite distributed services client.
@@ -46,11 +47,24 @@ namespace Apache.Ignite.Core.Client.Services
         ICollection<IClientServiceDescriptor> GetServiceDescriptors();
 
         /// <summary>
+        /// Gets metadata about all deployed services in the grid.
+        /// </summary>
+        /// <returns>Metadata about all deployed services in the grid.</returns>
+        Task<ICollection<IClientServiceDescriptor>> GetServiceDescriptorsAsync();
+
+        /// <summary>
         /// Gets metadata about service deployed in the grid.
         /// </summary>
         /// <param name="serviceName">Service name.</param>
         /// <returns>Metadata about all deployed services in the grid.</returns>
         IClientServiceDescriptor GetServiceDescriptor(string serviceName);
+
+        /// <summary>
+        /// Gets metadata about service deployed in the grid.
+        /// </summary>
+        /// <param name="serviceName">Service name.</param>
+        /// <returns>Metadata about all deployed services in the grid.</returns>
+        Task<IClientServiceDescriptor> GetServiceDescriptorAsync(string serviceName);
 
         /// <summary>
         /// Returns an instance with binary mode enabled.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -287,19 +287,6 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         }
 
         /** <inheritDoc /> */
-        [Obsolete]
-        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery)
-        {
-            IgniteArgumentCheck.NotNull(sqlQuery, "sqlQuery");
-            IgniteArgumentCheck.NotNull(sqlQuery.Sql, "sqlQuery.Sql");
-            IgniteArgumentCheck.NotNull(sqlQuery.QueryType, "sqlQuery.QueryType");
-
-            return DoOutInOpAsync(ClientOp.QuerySql, w => WriteSqlQuery(w.Writer, sqlQuery),
-                ctx => (IQueryCursor<ICacheEntry<TK, TV>>) new ClientQueryCursor<TK, TV>(
-                    ctx.Socket, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QuerySqlCursorGetPage));
-        }
-
-        /** <inheritDoc /> */
         public IFieldsQueryCursor Query(SqlFieldsQuery sqlFieldsQuery)
         {
             IgniteArgumentCheck.NotNull(sqlFieldsQuery, "sqlFieldsQuery");

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/CacheClient.cs
@@ -262,6 +262,18 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         }
 
         /** <inheritDoc /> */
+        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(ScanQuery<TK, TV> scanQuery)
+        {
+            IgniteArgumentCheck.NotNull(scanQuery, "scanQuery");
+
+            // Filter is a binary object for all platforms.
+            // For .NET it is a CacheEntryFilterHolder with a predefined id (BinaryTypeId.CacheEntryPredicateHolder).
+            return DoOutInOpAsync(ClientOp.QueryScan, w => WriteScanQuery(w.Writer, scanQuery),
+                ctx => (IQueryCursor<ICacheEntry<TK, TV>>) new ClientQueryCursor<TK, TV>(
+                    ctx.Socket, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QueryScanCursorGetPage));
+        }
+
+        /** <inheritDoc /> */
         [Obsolete]
         public IQueryCursor<ICacheEntry<TK, TV>> Query(SqlQuery sqlQuery)
         {
@@ -275,6 +287,19 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         }
 
         /** <inheritDoc /> */
+        [Obsolete]
+        public Task<IQueryCursor<ICacheEntry<TK, TV>>> QueryAsync(SqlQuery sqlQuery)
+        {
+            IgniteArgumentCheck.NotNull(sqlQuery, "sqlQuery");
+            IgniteArgumentCheck.NotNull(sqlQuery.Sql, "sqlQuery.Sql");
+            IgniteArgumentCheck.NotNull(sqlQuery.QueryType, "sqlQuery.QueryType");
+
+            return DoOutInOpAsync(ClientOp.QuerySql, w => WriteSqlQuery(w.Writer, sqlQuery),
+                ctx => (IQueryCursor<ICacheEntry<TK, TV>>) new ClientQueryCursor<TK, TV>(
+                    ctx.Socket, ctx.Stream.ReadLong(), _keepBinary, ctx.Stream, ClientOp.QuerySqlCursorGetPage));
+        }
+
+        /** <inheritDoc /> */
         public IFieldsQueryCursor Query(SqlFieldsQuery sqlFieldsQuery)
         {
             IgniteArgumentCheck.NotNull(sqlFieldsQuery, "sqlFieldsQuery");
@@ -283,6 +308,17 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             return DoOutInOp(ClientOp.QuerySqlFields,
                 ctx => WriteSqlFieldsQuery(ctx, sqlFieldsQuery),
                 ctx => GetFieldsCursor(ctx));
+        }
+
+        /** <inheritDoc /> */
+        public Task<IFieldsQueryCursor> QueryAsync(SqlFieldsQuery sqlFieldsQuery)
+        {
+            IgniteArgumentCheck.NotNull(sqlFieldsQuery, "sqlFieldsQuery");
+            IgniteArgumentCheck.NotNull(sqlFieldsQuery.Sql, "sqlFieldsQuery.Sql");
+
+            return DoOutInOpAsync(ClientOp.QuerySqlFields,
+                ctx => WriteSqlFieldsQuery(ctx, sqlFieldsQuery),
+                ctx => (IFieldsQueryCursor) GetFieldsCursor(ctx));
         }
 
         /** <inheritDoc /> */
@@ -597,6 +633,13 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
         }
 
         /** <inheritDoc /> */
+        public Task<CacheClientConfiguration> GetConfigurationAsync()
+        {
+            return DoOutInOpAsync(ClientOp.CacheGetConfiguration, null,
+                ctx => new CacheClientConfiguration(ctx.Stream, ctx.Features));
+        }
+
+        /** <inheritDoc /> */
         CacheConfiguration ICacheInternal.GetConfiguration()
         {
             return GetConfiguration().ToCacheConfiguration();
@@ -642,6 +685,15 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             IgniteArgumentCheck.NotNull(continuousQuery.Listener, "continuousQuery.Listener");
 
             return QueryContinuousInternal(continuousQuery);
+        }
+
+        /** <inheritDoc /> */
+        public Task<IContinuousQueryHandleClient> QueryContinuousAsync(ContinuousQueryClient<TK, TV> continuousQuery)
+        {
+            IgniteArgumentCheck.NotNull(continuousQuery, "continuousQuery");
+            IgniteArgumentCheck.NotNull(continuousQuery.Listener, "continuousQuery.Listener");
+
+            return QueryContinuousInternalAsync(continuousQuery);
         }
 
         /** <inheritDoc /> */
@@ -1070,17 +1122,37 @@ namespace Apache.Ignite.Core.Impl.Client.Cache
             return DoOutInOp(
                 ClientOp.QueryContinuous,
                 ctx => WriteContinuousQuery(ctx, continuousQuery),
-                ctx =>
-                {
-                    var queryId = ctx.Stream.ReadLong();
+                ctx => ReadContinuousQueryHandle(ctx, listener));
+        }
 
-                    var qryHandle = new ClientContinuousQueryHandle(ctx.Socket, queryId);
+        /// <summary>
+        /// Starts the continuous query asynchronously.
+        /// </summary>
+        private Task<IContinuousQueryHandleClient> QueryContinuousInternalAsync(
+            ContinuousQueryClient<TK, TV> continuousQuery)
+        {
+            var listener = continuousQuery.Listener;
 
-                    ctx.Socket.AddNotificationHandler(queryId,
-                        (stream, err) => HandleContinuousQueryEvents(stream, err, listener, qryHandle));
+            return DoOutInOpAsync(
+                ClientOp.QueryContinuous,
+                ctx => WriteContinuousQuery(ctx, continuousQuery),
+                ctx => (IContinuousQueryHandleClient) ReadContinuousQueryHandle(ctx, listener));
+        }
 
-                    return qryHandle;
-                });
+        /// <summary>
+        /// Reads the continuous query handle from the response and registers the notification handler.
+        /// </summary>
+        private ClientContinuousQueryHandle ReadContinuousQueryHandle(
+            ClientResponseContext ctx, ICacheEntryEventListener<TK, TV>? listener)
+        {
+            var queryId = ctx.Stream.ReadLong();
+
+            var qryHandle = new ClientContinuousQueryHandle(ctx.Socket, queryId);
+
+            ctx.Socket.AddNotificationHandler(queryId,
+                (stream, err) => HandleContinuousQueryEvents(stream, err, listener, qryHandle));
+
+            return qryHandle;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cluster/ClientCluster.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cluster/ClientCluster.cs
@@ -19,6 +19,7 @@
 namespace Apache.Ignite.Core.Impl.Client.Cluster
 {
     using System;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Impl.Common;
 
@@ -44,9 +45,21 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         }
 
         /** <inheritdoc /> */
+        public Task SetActiveAsync(bool isActive)
+        {
+            return DoOutInOpAsync<object>(ClientOp.ClusterChangeState, ctx => ctx.Stream.WriteBool(isActive), null);
+        }
+
+        /** <inheritdoc /> */
         public bool IsActive()
         {
             return DoOutInOp(ClientOp.ClusterIsActive, null, ctx => ctx.Stream.ReadBool());
+        }
+
+        /** <inheritdoc /> */
+        public Task<bool> IsActiveAsync()
+        {
+            return DoOutInOpAsync(ClientOp.ClusterIsActive, null, ctx => ctx.Stream.ReadBool());
         }
 
         /** <inheritdoc /> */
@@ -54,13 +67,17 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         {
             IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
 
-            Action<ClientRequestContext> action = ctx =>
-            {
-                ctx.Writer.WriteString(cacheName);
-                ctx.Writer.WriteBoolean(false);
-            };
-            
-            return DoOutInOp(ClientOp.ClusterChangeWalState, action, ctx => ctx.Stream.ReadBool());
+            return DoOutInOp(ClientOp.ClusterChangeWalState, ctx => WriteWalState(ctx, cacheName, false),
+                ctx => ctx.Stream.ReadBool());
+        }
+
+        /** <inheritdoc /> */
+        public Task<bool> DisableWalAsync(string cacheName)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
+
+            return DoOutInOpAsync(ClientOp.ClusterChangeWalState, ctx => WriteWalState(ctx, cacheName, false),
+                ctx => ctx.Stream.ReadBool());
         }
 
         /** <inheritdoc /> */
@@ -68,13 +85,17 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         {
             IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
 
-            Action<ClientRequestContext> action = ctx =>
-            {
-                ctx.Writer.WriteString(cacheName);
-                ctx.Writer.WriteBoolean(true);
-            };
-            
-            return DoOutInOp(ClientOp.ClusterChangeWalState, action, ctx => ctx.Stream.ReadBool());
+            return DoOutInOp(ClientOp.ClusterChangeWalState, ctx => WriteWalState(ctx, cacheName, true),
+                ctx => ctx.Stream.ReadBool());
+        }
+
+        /** <inheritdoc /> */
+        public Task<bool> EnableWalAsync(string cacheName)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
+
+            return DoOutInOpAsync(ClientOp.ClusterChangeWalState, ctx => WriteWalState(ctx, cacheName, true),
+                ctx => ctx.Stream.ReadBool());
         }
 
         /** <inheritdoc /> */
@@ -83,6 +104,24 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
             IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
 
             return DoOutInOp(ClientOp.ClusterGetWalState, ctx => ctx.Writer.WriteString(cacheName), ctx => ctx.Stream.ReadBool());
+        }
+
+        /** <inheritdoc /> */
+        public Task<bool> IsWalEnabledAsync(string cacheName)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(cacheName, "cacheName");
+
+            return DoOutInOpAsync(ClientOp.ClusterGetWalState, ctx => ctx.Writer.WriteString(cacheName),
+                ctx => ctx.Stream.ReadBool());
+        }
+
+        /// <summary>
+        /// Writes the change WAL state request.
+        /// </summary>
+        private static void WriteWalState(ClientRequestContext ctx, string cacheName, bool enable)
+        {
+            ctx.Writer.WriteString(cacheName);
+            ctx.Writer.WriteBoolean(enable);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cluster/ClientClusterGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cluster/ClientClusterGroup.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Threading;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Cluster;
@@ -120,6 +121,12 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         }
 
         /** <inheritDoc /> */
+        public async Task<ICollection<IClientClusterNode>> GetNodesAsync()
+        {
+            return await RefreshNodesAsync().ConfigureAwait(false);
+        }
+
+        /** <inheritDoc /> */
         public IClientClusterNode? GetNode(Guid id)
         {
             if (id == Guid.Empty)
@@ -131,9 +138,30 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         }
 
         /** <inheritDoc /> */
+        public async Task<IClientClusterNode?> GetNodeAsync(Guid id)
+        {
+            if (id == Guid.Empty)
+            {
+                throw new ArgumentException("Node id should not be empty.");
+            }
+
+            var nodes = await RefreshNodesAsync().ConfigureAwait(false);
+
+            return nodes.FirstOrDefault(node => node.Id == id);
+        }
+
+        /** <inheritDoc /> */
         public IClientClusterNode? GetNode()
         {
             return GetNodes().FirstOrDefault();
+        }
+
+        /** <inheritDoc /> */
+        public async Task<IClientClusterNode?> GetNodeAsync()
+        {
+            var nodes = await RefreshNodesAsync().ConfigureAwait(false);
+
+            return nodes.FirstOrDefault();
         }
 
         /** <inheritDoc /> */
@@ -163,6 +191,33 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
                 RequestNodesInfo(topology.Item2);
             }
 
+            return BuildNodesList();
+        }
+
+        /// <summary>
+        /// Refresh projection nodes asynchronously.
+        /// </summary>
+        /// <returns>Nodes.</returns>
+        private async Task<IList<IClientClusterNode>> RefreshNodesAsync()
+        {
+            long oldTopVer = Interlocked.Read(ref _topVer);
+
+            var topology = await RequestTopologyInformationAsync(oldTopVer).ConfigureAwait(false);
+            if (topology != null)
+            {
+                UpdateTopology(topology.Item1, topology.Item2);
+                await RequestNodesInfoAsync(topology.Item2).ConfigureAwait(false);
+            }
+
+            return BuildNodesList();
+        }
+
+        /// <summary>
+        /// Builds the resulting nodes list from the current topology snapshot, applying the predicate.
+        /// </summary>
+        /// <returns>Nodes.</returns>
+        private IList<IClientClusterNode> BuildNodesList()
+        {
             // No topology changes.
             Debug.Assert(_nodeIds != null, "At least one topology update should have occurred.");
 
@@ -186,25 +241,46 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         /// <returns>Topology version with nodes identifiers.</returns>rns>
         private Tuple<long, Guid[]>? RequestTopologyInformation(long oldTopVer)
         {
-            Action<ClientRequestContext> writeAction = ctx =>
+            return DoOutInOp(
+                ClientOp.ClusterGroupGetNodeIds,
+                ctx => WriteTopologyRequest(ctx, oldTopVer),
+                ReadTopologyInformation);
+        }
+
+        /// <summary>
+        /// Request topology information asynchronously.
+        /// </summary>
+        /// <returns>Topology version with nodes identifiers.</returns>
+        private Task<Tuple<long, Guid[]>?> RequestTopologyInformationAsync(long oldTopVer)
+        {
+            return DoOutInOpAsync(
+                ClientOp.ClusterGroupGetNodeIds,
+                ctx => WriteTopologyRequest(ctx, oldTopVer),
+                ReadTopologyInformation);
+        }
+
+        /// <summary>
+        /// Writes the topology information request.
+        /// </summary>
+        private void WriteTopologyRequest(ClientRequestContext ctx, long oldTopVer)
+        {
+            ctx.Stream.WriteLong(oldTopVer);
+            _projection.Write(ctx.Writer);
+        }
+
+        /// <summary>
+        /// Reads the topology information response.
+        /// </summary>
+        private static Tuple<long, Guid[]>? ReadTopologyInformation(ClientResponseContext ctx)
+        {
+            if (!ctx.Stream.ReadBool())
             {
-                ctx.Stream.WriteLong(oldTopVer);
-                _projection.Write(ctx.Writer);
-            };
+                // No topology changes.
+                return null;
+            }
 
-            Func<ClientResponseContext, Tuple<long, Guid[]>?> readFunc = ctx =>
-            {
-                if (!ctx.Stream.ReadBool())
-                {
-                    // No topology changes.
-                    return null;
-                }
-
-                long remoteTopVer = ctx.Stream.ReadLong();
-                return Tuple.Create(remoteTopVer, ReadNodeIds(ctx.Reader));
-            };
-
-            return DoOutInOp(ClientOp.ClusterGroupGetNodeIds, writeAction, readFunc);
+            long remoteTopVer = ctx.Stream.ReadLong();
+            return Tuple.Create(remoteTopVer, ReadNodeIds(ctx.Reader));
         }
 
         /// <summary>
@@ -255,6 +331,37 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         /// <returns>Collection of <see cref="IClusterNode"/> instances.</returns>
         private void RequestNodesInfo(Guid[] nodeIds)
         {
+            var unknownNodes = GetUnknownNodes(nodeIds);
+
+            if (unknownNodes.Count > 0)
+            {
+                RequestRemoteNodesDetails(unknownNodes);
+            }
+        }
+
+        /// <summary>
+        /// Gets nodes information asynchronously.
+        /// This method will filter only unknown node ids that
+        /// have not been serialized inside IgniteClient before.
+        /// </summary>
+        /// <param name="nodeIds">Node ids array.</param>
+        private async Task RequestNodesInfoAsync(Guid[] nodeIds)
+        {
+            var unknownNodes = GetUnknownNodes(nodeIds);
+
+            if (unknownNodes.Count > 0)
+            {
+                await RequestRemoteNodesDetailsAsync(unknownNodes).ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Filters out node ids that are already known to the client.
+        /// </summary>
+        /// <param name="nodeIds">Node ids array.</param>
+        /// <returns>Unknown node ids.</returns>
+        private List<Guid> GetUnknownNodes(Guid[] nodeIds)
+        {
             var unknownNodes = new List<Guid>(nodeIds.Length);
             foreach (var nodeId in nodeIds)
             {
@@ -264,10 +371,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
                 }
             }
 
-            if (unknownNodes.Count > 0)
-            {
-                RequestRemoteNodesDetails(unknownNodes);
-            }
+            return unknownNodes;
         }
 
         /// <summary>
@@ -276,27 +380,46 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         /// <param name="ids">Node identifiers.</param>
         private void RequestRemoteNodesDetails(List<Guid> ids)
         {
-            Action<ClientRequestContext> writeAction = ctx =>
+            DoOutInOp(ClientOp.ClusterGroupGetNodesInfo,
+                ctx => WriteRemoteNodesDetailsRequest(ctx, ids),
+                ReadRemoteNodesDetails);
+        }
+
+        /// <summary>
+        /// Make remote API call to fetch node information asynchronously.
+        /// </summary>
+        /// <param name="ids">Node identifiers.</param>
+        private Task<bool> RequestRemoteNodesDetailsAsync(List<Guid> ids)
+        {
+            return DoOutInOpAsync(ClientOp.ClusterGroupGetNodesInfo,
+                ctx => WriteRemoteNodesDetailsRequest(ctx, ids),
+                ReadRemoteNodesDetails);
+        }
+
+        /// <summary>
+        /// Writes the remote nodes details request.
+        /// </summary>
+        private static void WriteRemoteNodesDetailsRequest(ClientRequestContext ctx, List<Guid> ids)
+        {
+            ctx.Stream.WriteInt(ids.Count);
+            foreach (var id in ids)
             {
-                ctx.Stream.WriteInt(ids.Count);
-                foreach (var id in ids)
-                {
-                    BinaryUtils.WriteGuid(id, ctx.Stream);
-                }
-            };
+                BinaryUtils.WriteGuid(id, ctx.Stream);
+            }
+        }
 
-            Func<ClientResponseContext, bool> readFunc = ctx =>
+        /// <summary>
+        /// Reads the remote nodes details response.
+        /// </summary>
+        private bool ReadRemoteNodesDetails(ClientResponseContext ctx)
+        {
+            var cnt = ctx.Stream.ReadInt();
+            for (var i = 0; i < cnt; i++)
             {
-                var cnt = ctx.Stream.ReadInt();
-                for (var i = 0; i < cnt; i++)
-                {
-                    _ignite.SaveClientClusterNode(ctx.Reader);
-                }
+                _ignite.SaveClientClusterNode(ctx.Reader);
+            }
 
-                return true;
-            };
-
-            DoOutInOp(ClientOp.ClusterGroupGetNodesInfo, writeAction, readFunc);
+            return true;
         }
 
 
@@ -307,6 +430,15 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
             Func<ClientResponseContext, T> readFunc)
         {
             return _ignite.Socket.DoOutInOp(opId, writeAction, readFunc, HandleError<T>);
+        }
+
+        /// <summary>
+        /// Does the out in op asynchronously.
+        /// </summary>
+        protected Task<T> DoOutInOpAsync<T>(ClientOp opId, Action<ClientRequestContext> writeAction,
+            Func<ClientResponseContext, T> readFunc)
+        {
+            return _ignite.Socket.DoOutInOpAsync(opId, writeAction, readFunc, HandleError<T>);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cluster/ClientClusterGroup.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cluster/ClientClusterGroup.cs
@@ -238,7 +238,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cluster
         /// <summary>
         /// Request topology information.
         /// </summary>
-        /// <returns>Topology version with nodes identifiers.</returns>rns>
+        /// <returns>Topology version with nodes identifiers.</returns>
         private Tuple<long, Guid[]>? RequestTopologyInformation(long oldTopVer)
         {
             return DoOutInOp(

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/DataStructures/AtomicLongClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/DataStructures/AtomicLongClient.cs
@@ -16,6 +16,7 @@
 
 namespace Apache.Ignite.Core.Impl.Client.DataStructures
 {
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client.DataStructures;
     using Apache.Ignite.Core.Impl.Binary;
 
@@ -70,9 +71,26 @@ namespace Apache.Ignite.Core.Impl.Client.DataStructures
         }
 
         /** <inheritDoc /> */
+        public Task<long> ReadAsync()
+        {
+            return _socket.DoOutInOpAffinityAsync(
+                ClientOp.AtomicLongValueGet,
+                ctx => WriteName(ctx),
+                r => r.Reader.ReadLong(),
+                _cacheId,
+                AffinityKey);
+        }
+
+        /** <inheritDoc /> */
         public long Increment()
         {
             return Add(1);
+        }
+
+        /** <inheritDoc /> */
+        public Task<long> IncrementAsync()
+        {
+            return AddAsync(1);
         }
 
         /** <inheritDoc /> */
@@ -91,15 +109,51 @@ namespace Apache.Ignite.Core.Impl.Client.DataStructures
         }
 
         /** <inheritDoc /> */
+        public Task<long> AddAsync(long value)
+        {
+            return _socket.DoOutInOpAffinityAsync(
+                ClientOp.AtomicLongValueAddAndGet,
+                ctx =>
+                {
+                    WriteName(ctx);
+                    ctx.Writer.WriteLong(value);
+                },
+                r => r.Reader.ReadLong(),
+                _cacheId,
+                AffinityKey);
+        }
+
+        /** <inheritDoc /> */
         public long Decrement()
         {
             return Add(-1);
         }
 
         /** <inheritDoc /> */
+        public Task<long> DecrementAsync()
+        {
+            return AddAsync(-1);
+        }
+
+        /** <inheritDoc /> */
         public long Exchange(long value)
         {
             return _socket.DoOutInOpAffinity(
+                ClientOp.AtomicLongValueGetAndSet,
+                ctx =>
+                {
+                    WriteName(ctx);
+                    ctx.Writer.WriteLong(value);
+                },
+                r => r.Reader.ReadLong(),
+                _cacheId,
+                AffinityKey);
+        }
+
+        /** <inheritDoc /> */
+        public Task<long> ExchangeAsync(long value)
+        {
+            return _socket.DoOutInOpAffinityAsync(
                 ClientOp.AtomicLongValueGetAndSet,
                 ctx =>
                 {
@@ -128,6 +182,22 @@ namespace Apache.Ignite.Core.Impl.Client.DataStructures
         }
 
         /** <inheritDoc /> */
+        public Task<long> CompareExchangeAsync(long value, long comparand)
+        {
+            return _socket.DoOutInOpAffinityAsync(
+                ClientOp.AtomicLongValueCompareAndSetAndGet,
+                ctx =>
+                {
+                    WriteName(ctx);
+                    ctx.Writer.WriteLong(comparand);
+                    ctx.Writer.WriteLong(value);
+                },
+                r => r.Reader.ReadLong(),
+                _cacheId,
+                AffinityKey);
+        }
+
+        /** <inheritDoc /> */
         public bool IsClosed()
         {
             return _socket.DoOutInOpAffinity(
@@ -139,9 +209,31 @@ namespace Apache.Ignite.Core.Impl.Client.DataStructures
         }
 
         /** <inheritDoc /> */
+        public Task<bool> IsClosedAsync()
+        {
+            return _socket.DoOutInOpAffinityAsync(
+                ClientOp.AtomicLongExists,
+                ctx => WriteName(ctx),
+                r => !r.Reader.ReadBoolean(),
+                _cacheId,
+                AffinityKey);
+        }
+
+        /** <inheritDoc /> */
         public void Close()
         {
             _socket.DoOutInOpAffinity<object, string>(
+                ClientOp.AtomicLongRemove,
+                ctx => WriteName(ctx),
+                null,
+                _cacheId,
+                AffinityKey);
+        }
+
+        /** <inheritDoc /> */
+        public Task CloseAsync()
+        {
+            return _socket.DoOutInOpAffinityAsync<object, string>(
                 ClientOp.AtomicLongRemove,
                 ctx => WriteName(ctx),
                 null,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/IgniteClient.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Core.Impl.Client
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Net;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache.Configuration;
     using Apache.Ignite.Core.Client;
@@ -151,6 +152,18 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        public async Task<ICacheClient<TK, TV>> GetOrCreateCacheAsync<TK, TV>(string name)
+            where TK : notnull
+        {
+            IgniteArgumentCheck.NotNull(name, "name");
+
+            await DoOutOpAsync(ClientOp.CacheGetOrCreateWithName, ctx => ctx.Writer.WriteString(name))
+                .ConfigureAwait(false);
+
+            return GetCache<TK, TV>(name);
+        }
+
+        /** <inheritDoc /> */
         public ICacheClient<TK, TV> GetOrCreateCache<TK, TV>(CacheClientConfiguration configuration)
             where TK : notnull
         {
@@ -163,12 +176,37 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        public async Task<ICacheClient<TK, TV>> GetOrCreateCacheAsync<TK, TV>(CacheClientConfiguration configuration)
+            where TK : notnull
+        {
+            IgniteArgumentCheck.NotNull(configuration, "configuration");
+
+            await DoOutOpAsync(ClientOp.CacheGetOrCreateWithConfiguration,
+                    ctx => ClientCacheConfigurationSerializer.Write(ctx.Stream, configuration, ctx.Features))
+                .ConfigureAwait(false);
+
+            return GetCache<TK, TV>(configuration.Name!);
+        }
+
+        /** <inheritDoc /> */
         public ICacheClient<TK, TV> CreateCache<TK, TV>(string name)
             where TK : notnull
         {
             IgniteArgumentCheck.NotNull(name, "name");
 
             DoOutOp(ClientOp.CacheCreateWithName, ctx => ctx.Writer.WriteString(name));
+
+            return GetCache<TK, TV>(name);
+        }
+
+        /** <inheritDoc /> */
+        public async Task<ICacheClient<TK, TV>> CreateCacheAsync<TK, TV>(string name)
+            where TK : notnull
+        {
+            IgniteArgumentCheck.NotNull(name, "name");
+
+            await DoOutOpAsync(ClientOp.CacheCreateWithName, ctx => ctx.Writer.WriteString(name))
+                .ConfigureAwait(false);
 
             return GetCache<TK, TV>(name);
         }
@@ -186,9 +224,29 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        public async Task<ICacheClient<TK, TV>> CreateCacheAsync<TK, TV>(CacheClientConfiguration configuration)
+            where TK : notnull
+        {
+            IgniteArgumentCheck.NotNull(configuration, "configuration");
+
+            await DoOutOpAsync(ClientOp.CacheCreateWithConfiguration,
+                    ctx => ClientCacheConfigurationSerializer.Write(ctx.Stream, configuration, ctx.Features))
+                .ConfigureAwait(false);
+
+            return GetCache<TK, TV>(configuration.Name!);
+        }
+
+        /** <inheritDoc /> */
         public ICollection<string> GetCacheNames()
         {
             return DoOutInOp(ClientOp.CacheGetNames, null, ctx => ctx.Reader.ReadStringCollection());
+        }
+
+        /** <inheritDoc /> */
+        public Task<ICollection<string>> GetCacheNamesAsync()
+        {
+            return DoOutInOpAsync(ClientOp.CacheGetNames, null,
+                ctx => (ICollection<string>) ctx.Reader.ReadStringCollection());
         }
 
         /** <inheritDoc /> */
@@ -203,6 +261,14 @@ namespace Apache.Ignite.Core.Impl.Client
             IgniteArgumentCheck.NotNull(name, "name");
 
             DoOutOp(ClientOp.CacheDestroy, ctx => ctx.Stream.WriteInt(BinaryUtils.GetCacheId(name)));
+        }
+
+        /** <inheritDoc /> */
+        public Task DestroyCacheAsync(string name)
+        {
+            IgniteArgumentCheck.NotNull(name, "name");
+
+            return DoOutOpAsync(ClientOp.CacheDestroy, ctx => ctx.Stream.WriteInt(BinaryUtils.GetCacheId(name)));
         }
 
         /** <inheritDoc /> */
@@ -332,26 +398,10 @@ namespace Apache.Ignite.Core.Impl.Client
 
             if (create)
             {
-                _socket.DoOutInOp<object>(ClientOp.AtomicLongCreate, ctx =>
-                {
-                    var w = ctx.Writer;
-
-                    w.WriteString(name);
-                    w.WriteLong(initialValue);
-
-                    if (configuration != null)
-                    {
-                        w.WriteBoolean(true);
-                        w.WriteInt(configuration.AtomicSequenceReserveSize);
-                        w.WriteByte((byte)configuration.CacheMode);
-                        w.WriteInt(configuration.Backups);
-                        w.WriteString(configuration.GroupName);
-                    }
-                    else
-                    {
-                        w.WriteBoolean(false);
-                    }
-                }, null);
+                _socket.DoOutInOp<object>(
+                    ClientOp.AtomicLongCreate,
+                    ctx => WriteAtomicLongCreate(ctx, name, initialValue, configuration),
+                    null);
             }
 
             var res = new AtomicLongClient(_socket, name, configuration?.GroupName);
@@ -366,42 +416,125 @@ namespace Apache.Ignite.Core.Impl.Client
         }
 
         /** <inheritDoc /> */
+        public Task<IAtomicLongClient?> GetAtomicLongAsync(string name, long initialValue, bool create)
+        {
+            return GetAtomicLongAsync(name, null, initialValue, create);
+        }
+
+        /** <inheritDoc /> */
+        public async Task<IAtomicLongClient?> GetAtomicLongAsync(
+            string name,
+            AtomicClientConfiguration? configuration,
+            long initialValue,
+            bool create)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(name, "name");
+
+            if (create)
+            {
+                await DoOutOpAsync(
+                        ClientOp.AtomicLongCreate,
+                        ctx => WriteAtomicLongCreate(ctx, name, initialValue, configuration))
+                    .ConfigureAwait(false);
+            }
+
+            var res = new AtomicLongClient(_socket, name, configuration?.GroupName);
+
+            if (!create && await res.IsClosedAsync().ConfigureAwait(false))
+            {
+                // Return null when specified atomic long does not exist to match thick API behavior.
+                return null;
+            }
+
+            return res;
+        }
+
+        /** <inheritDoc /> */
         public IIgniteSetClient<T>? GetIgniteSet<T>(string name, CollectionClientConfiguration? configuration)
         {
             IgniteArgumentCheck.NotNullOrEmpty(name, "name");
 
-            return _socket.DoOutInOp(ClientOp.SetGetOrCreate, ctx =>
+            return _socket.DoOutInOp(
+                ClientOp.SetGetOrCreate,
+                ctx => WriteIgniteSetGetOrCreate(ctx, name, configuration),
+                ctx => ReadIgniteSet<T>(ctx, name));
+        }
+
+        /** <inheritDoc /> */
+        public Task<IIgniteSetClient<T>?> GetIgniteSetAsync<T>(string name, CollectionClientConfiguration? configuration)
+        {
+            IgniteArgumentCheck.NotNullOrEmpty(name, "name");
+
+            return DoOutInOpAsync(
+                ClientOp.SetGetOrCreate,
+                ctx => WriteIgniteSetGetOrCreate(ctx, name, configuration),
+                ctx => ReadIgniteSet<T>(ctx, name));
+        }
+
+        /// <summary>
+        /// Writes the atomic long create request.
+        /// </summary>
+        private static void WriteAtomicLongCreate(
+            ClientRequestContext ctx, string name, long initialValue, AtomicClientConfiguration? configuration)
+        {
+            var w = ctx.Writer;
+
+            w.WriteString(name);
+            w.WriteLong(initialValue);
+
+            if (configuration != null)
             {
-                var w = ctx.Writer;
-
-                w.WriteString(name);
-
-                if (configuration != null)
-                {
-                    w.WriteBoolean(true);
-                    w.WriteByte((byte)configuration.AtomicityMode);
-                    w.WriteByte((byte)configuration.CacheMode);
-                    w.WriteInt(configuration.Backups);
-                    w.WriteString(configuration.GroupName);
-                    w.WriteBoolean(configuration.Colocated);
-                }
-                else
-                {
-                    w.WriteBoolean(false);
-                }
-
-            }, ctx =>
+                w.WriteBoolean(true);
+                w.WriteInt(configuration.AtomicSequenceReserveSize);
+                w.WriteByte((byte)configuration.CacheMode);
+                w.WriteInt(configuration.Backups);
+                w.WriteString(configuration.GroupName);
+            }
+            else
             {
-                if (!ctx.Reader.ReadBoolean())
-                {
-                    return null;
-                }
+                w.WriteBoolean(false);
+            }
+        }
 
-                var colocated = ctx.Reader.ReadBoolean();
-                var cacheId = ctx.Reader.ReadInt();
+        /// <summary>
+        /// Writes the Ignite set get-or-create request.
+        /// </summary>
+        private static void WriteIgniteSetGetOrCreate(
+            ClientRequestContext ctx, string name, CollectionClientConfiguration? configuration)
+        {
+            var w = ctx.Writer;
 
-                return new IgniteSetClient<T>(_socket, name, colocated, cacheId);
-            });
+            w.WriteString(name);
+
+            if (configuration != null)
+            {
+                w.WriteBoolean(true);
+                w.WriteByte((byte)configuration.AtomicityMode);
+                w.WriteByte((byte)configuration.CacheMode);
+                w.WriteInt(configuration.Backups);
+                w.WriteString(configuration.GroupName);
+                w.WriteBoolean(configuration.Colocated);
+            }
+            else
+            {
+                w.WriteBoolean(false);
+            }
+        }
+
+        /// <summary>
+        /// Reads the Ignite set get-or-create response.
+        /// </summary>
+        private IIgniteSetClient<T>? ReadIgniteSet<T>(ClientResponseContext ctx, string name)
+        {
+            if (!ctx.Reader.ReadBoolean())
+            {
+                return null;
+            }
+
+            var colocated = ctx.Reader.ReadBoolean();
+            var cacheId = ctx.Reader.ReadInt();
+
+            return new IgniteSetClient<T>(_socket, name, colocated, cacheId);
         }
 
         /** <inheritDoc /> */
@@ -523,6 +656,23 @@ namespace Apache.Ignite.Core.Impl.Client
         private void DoOutOp(ClientOp opId, Action<ClientRequestContext>? writeAction = null)
         {
             DoOutInOp<object>(opId, writeAction, null);
+        }
+
+        /// <summary>
+        /// Does the out in op asynchronously.
+        /// </summary>
+        private Task<T> DoOutInOpAsync<T>(ClientOp opId, Action<ClientRequestContext>? writeAction,
+            Func<ClientResponseContext, T>? readFunc)
+        {
+            return _socket.DoOutInOpAsync(opId, writeAction, readFunc);
+        }
+
+        /// <summary>
+        /// Does the out op asynchronously.
+        /// </summary>
+        private Task DoOutOpAsync(ClientOp opId, Action<ClientRequestContext>? writeAction = null)
+        {
+            return DoOutInOpAsync<object>(opId, writeAction, null);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Services/ServicesClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Services/ServicesClient.cs
@@ -22,6 +22,7 @@ namespace Apache.Ignite.Core.Impl.Client.Services
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Reflection;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Services;
     using Apache.Ignite.Core.Impl.Binary;
@@ -97,16 +98,16 @@ namespace Apache.Ignite.Core.Impl.Client.Services
             return _ignite.Socket.DoOutInOp(
                 ClientOp.ServiceGetDescriptors,
                 ctx => { },
-                ctx =>
-                {
-                    var cnt = ctx.Reader.ReadInt();
-                    var res = new List<IClientServiceDescriptor>(cnt);
+                ReadDescriptors);
+        }
 
-                    for (var i = 0; i < cnt; i++)
-                        res.Add(new ClientServiceDescriptor(ctx.Reader));
-
-                    return res;
-                });
+        /** <inheritdoc /> */
+        public Task<ICollection<IClientServiceDescriptor>> GetServiceDescriptorsAsync()
+        {
+            return _ignite.Socket.DoOutInOpAsync(
+                ClientOp.ServiceGetDescriptors,
+                ctx => { },
+                ReadDescriptors);
         }
 
         /** <inheritdoc /> */
@@ -116,6 +117,29 @@ namespace Apache.Ignite.Core.Impl.Client.Services
                 ClientOp.ServiceGetDescriptor,
                 ctx => ctx.Writer.WriteString(serviceName),
                 ctx => new ClientServiceDescriptor(ctx.Reader));
+        }
+
+        /** <inheritdoc /> */
+        public Task<IClientServiceDescriptor> GetServiceDescriptorAsync(string serviceName)
+        {
+            return _ignite.Socket.DoOutInOpAsync(
+                ClientOp.ServiceGetDescriptor,
+                ctx => ctx.Writer.WriteString(serviceName),
+                ctx => (IClientServiceDescriptor) new ClientServiceDescriptor(ctx.Reader));
+        }
+
+        /// <summary>
+        /// Reads the service descriptor collection from the response.
+        /// </summary>
+        private static ICollection<IClientServiceDescriptor> ReadDescriptors(ClientResponseContext ctx)
+        {
+            var cnt = ctx.Reader.ReadInt();
+            var res = new List<IClientServiceDescriptor>(cnt);
+
+            for (var i = 0; i < cnt; i++)
+                res.Add(new ClientServiceDescriptor(ctx.Reader));
+
+            return res;
         }
 
         /** <inheritdoc /> */


### PR DESCRIPTION
Add missing async overloads to thin client APIs.

- Add async overloads to `IIgniteClient`: `GetOrCreateCacheAsync`, `CreateCacheAsync`, `GetCacheNamesAsync`, `DestroyCacheAsync`, `GetAtomicLongAsync`, `GetIgniteSetAsync`.
- Add async overloads to `ICacheClient`: `QueryAsync` (scan + SQL fields), `GetConfigurationAsync`, `QueryContinuousAsync`.
- Add async overloads to `IClientCluster`: `SetActiveAsync`, `IsActiveAsync`, `DisableWalAsync`, `EnableWalAsync`, `IsWalEnabledAsync`.
- Add async overloads to `IClientClusterGroup`: `GetNodesAsync`, `GetNodeAsync`.
- Add async overloads to `IServicesClient`: `GetServiceDescriptorsAsync`, `GetServiceDescriptorAsync`.
- Add async overloads to `IAtomicLongClient`: `ReadAsync`, `IncrementAsync`, `AddAsync`, `DecrementAsync`, `ExchangeAsync`, `CompareExchangeAsync`, `IsClosedAsync`, `CloseAsync`.
- Add `ClientAsyncApiParityTest` to enforce sync/async parity.
- Leave transactions sync-only (thread-bound) and skip `IIgniteSetClient<T> ISet` members.