### PR TITLE
GG-48492 .NET: Adopt IAsyncDisposable

### DIFF
--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTransactionalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTransactionalTest.cs
@@ -286,6 +286,83 @@ namespace Apache.Ignite.Core.Tests.Cache
             Assert.IsNull(Transactions.Tx);
         }
 
+#if NETCOREAPP
+        /// <summary>
+        /// Tests that disposing a transaction asynchronously with <c>await using</c> (without an explicit commit)
+        /// rolls back the changes.
+        /// </summary>
+        [Test]
+        public async Task TestTxDisposeAsyncRollsBack()
+        {
+            var cache = Cache();
+
+            await cache.PutAsync(1, 1);
+            await cache.PutAsync(2, 2);
+
+            Assert.IsNull(Transactions.Tx);
+
+            await using (Transactions.TxStart())
+            {
+                await cache.PutAsync(1, 10);
+                await cache.PutAsync(2, 20);
+            }
+
+            Assert.AreEqual(1, await cache.GetAsync(1));
+            Assert.AreEqual(2, await cache.GetAsync(2));
+
+            Assert.IsNull(Transactions.Tx);
+        }
+
+        /// <summary>
+        /// Tests that committing a transaction before async disposal with <c>await using</c> preserves the changes.
+        /// </summary>
+        [Test]
+        public async Task TestTxCommitThenDisposeAsync()
+        {
+            var cache = Cache();
+
+            cache.Put(1, 1);
+            cache.Put(2, 2);
+
+            await using (var tx = Transactions.TxStart())
+            {
+                cache.Put(1, 10);
+                cache.Put(2, 20);
+
+                tx.Commit();
+            }
+
+            Assert.AreEqual(10, cache.Get(1));
+            Assert.AreEqual(20, cache.Get(2));
+
+            Assert.IsNull(Transactions.Tx);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IAsyncDisposable.DisposeAsync"/> rolls the transaction back and is idempotent
+        /// (a second async or synchronous dispose is a no-op).
+        /// </summary>
+        [Test]
+        public async Task TestTxDisposeAsyncIsIdempotent()
+        {
+            var cache = Cache();
+
+            cache.Put(1, 1);
+
+            var tx = Transactions.TxStart();
+            cache.Put(1, 10);
+
+            await tx.DisposeAsync();
+
+            // Idempotent: repeated async dispose and synchronous dispose are no-ops.
+            await tx.DisposeAsync();
+            tx.Dispose();
+
+            Assert.AreEqual(1, cache.Get(1));
+            Assert.IsNull(Transactions.Tx);
+        }
+#endif
+
         /// <summary>
         /// Tests all concurrency and isolation modes with and without timeout.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTransactionalTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Cache/CacheAbstractTransactionalTest.cs
@@ -321,19 +321,19 @@ namespace Apache.Ignite.Core.Tests.Cache
         {
             var cache = Cache();
 
-            cache.Put(1, 1);
-            cache.Put(2, 2);
+            await cache.PutAsync(1, 1);
+            await cache.PutAsync(2, 2);
 
             await using (var tx = Transactions.TxStart())
             {
-                cache.Put(1, 10);
-                cache.Put(2, 20);
+                await cache.PutAsync(1, 10);
+                await cache.PutAsync(2, 20);
 
-                tx.Commit();
+                await tx.CommitAsync();
             }
 
-            Assert.AreEqual(10, cache.Get(1));
-            Assert.AreEqual(20, cache.Get(2));
+            Assert.AreEqual(10, await cache.GetAsync(1));
+            Assert.AreEqual(20, await cache.GetAsync(2));
 
             Assert.IsNull(Transactions.Tx);
         }
@@ -347,10 +347,10 @@ namespace Apache.Ignite.Core.Tests.Cache
         {
             var cache = Cache();
 
-            cache.Put(1, 1);
+            await cache.PutAsync(1, 1);
 
             var tx = Transactions.TxStart();
-            cache.Put(1, 10);
+            await cache.PutAsync(1, 10);
 
             await tx.DisposeAsync();
 
@@ -358,7 +358,7 @@ namespace Apache.Ignite.Core.Tests.Cache
             await tx.DisposeAsync();
             tx.Dispose();
 
-            Assert.AreEqual(1, cache.Get(1));
+            Assert.AreEqual(1, await cache.GetAsync(1));
             Assert.IsNull(Transactions.Tx);
         }
 #endif

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAbstractTxTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/CacheClientAbstractTxTest.cs
@@ -273,6 +273,53 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             Assert.AreEqual(2, cache.Get(2));
         }
 
+#if NETCOREAPP
+        /// <summary>
+        /// Tests that disposing a transaction asynchronously with <c>await using</c> (without an explicit commit)
+        /// rolls back the changes.
+        /// </summary>
+        [Test]
+        public async Task TestTxDisposeAsyncRollsBack()
+        {
+            var cache = GetTransactionalCache();
+
+            await cache.PutAsync(1, 1);
+            await cache.PutAsync(2, 2);
+
+            await using (Client.GetTransactions().TxStart())
+            {
+                await cache.PutAsync(1, 10);
+                await cache.PutAsync(2, 20);
+            }
+
+            Assert.AreEqual(1, await cache.GetAsync(1));
+            Assert.AreEqual(2, await cache.GetAsync(2));
+        }
+
+        /// <summary>
+        /// Tests that committing a transaction before async disposal with <c>await using</c> preserves the changes.
+        /// </summary>
+        [Test]
+        public async Task TestTxCommitThenDisposeAsync()
+        {
+            var cache = GetTransactionalCache();
+
+            await cache.PutAsync(1, 1);
+            await cache.PutAsync(2, 2);
+
+            await using (var tx = Client.GetTransactions().TxStart())
+            {
+                await cache.PutAsync(1, 10);
+                await cache.PutAsync(2, 20);
+
+                tx.Commit();
+            }
+
+            Assert.AreEqual(10, await cache.GetAsync(1));
+            Assert.AreEqual(20, await cache.GetAsync(2));
+        }
+#endif
+
         /// <summary>
         /// Tests that client can't start multiple transactions in one thread.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -119,6 +119,63 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             }
         }
 
+#if NETCOREAPP
+        /// <summary>
+        /// Tests that exiting an <c>await using</c> block disposes the continuous query handle asynchronously
+        /// and stops the query: no events are delivered after disposal.
+        /// </summary>
+        [Test]
+        public async Task TestAwaitUsingStopsContinuousQuery()
+        {
+            var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName);
+
+            var events = new ConcurrentQueue<ICacheEntryEvent<int, int>>();
+            var qry = new ContinuousQueryClient<int, int>(new DelegateListener<int, int>(events.Enqueue));
+
+            await using (cache.QueryContinuous(qry))
+            {
+                await cache.PutAsync(1, 1);
+                TestUtils.WaitForTrueCondition(() => events.Count == 1);
+            }
+
+            // Query is stopped: the notification listener is removed and further updates are not delivered.
+            Assert.IsEmpty(Client.GetActiveNotificationListeners());
+
+            cache.Put(2, 2);
+            Thread.Sleep(100);
+            Assert.AreEqual(1, events.Count);
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IContinuousQueryHandleClient.DisposeAsync"/> stops the query and is idempotent
+        /// (a second async or synchronous dispose is a no-op).
+        /// </summary>
+        [Test]
+        public async Task TestDisposeAsyncStopsContinuousQueryAndIsIdempotent()
+        {
+            var cache = Client.GetOrCreateCache<int, int>(TestUtils.TestName);
+
+            var events = new ConcurrentQueue<ICacheEntryEvent<int, int>>();
+            var qry = new ContinuousQueryClient<int, int>(new DelegateListener<int, int>(events.Enqueue));
+
+            var handle = cache.QueryContinuous(qry);
+            await cache.PutAsync(1, 1);
+            TestUtils.WaitForTrueCondition(() => events.Count == 1);
+
+            await handle.DisposeAsync();
+
+            // Idempotent: repeated async dispose and synchronous dispose are no-ops.
+            await handle.DisposeAsync();
+            handle.Dispose();
+
+            Assert.IsEmpty(Client.GetActiveNotificationListeners());
+
+            await cache.PutAsync(2, 2);
+            Thread.Sleep(100);
+            Assert.AreEqual(1, events.Count);
+        }
+#endif
+
         /// <summary>
         /// Tests that default query settings have correct values.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ContinuousQueryTest.cs
@@ -141,7 +141,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             // Query is stopped: the notification listener is removed and further updates are not delivered.
             Assert.IsEmpty(Client.GetActiveNotificationListeners());
 
-            cache.Put(2, 2);
+            await cache.PutAsync(2, 2);
             Thread.Sleep(100);
             Assert.AreEqual(1, events.Count);
         }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ScanQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ScanQueryTest.cs
@@ -286,6 +286,71 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             c2.Dispose();
             c3.Dispose();
         }
+
+        /// <summary>
+        /// Tests that <see cref="System.IAsyncDisposable.DisposeAsync"/> is a no-op for a cursor that has
+        /// already been drained by <c>GetAll</c> (the server closes the cursor when the last page is read,
+        /// so no redundant resource-close request is sent).
+        /// </summary>
+        [Test]
+        public async Task TestDisposeAsyncAfterGetAllIsNoOp()
+        {
+            var cache = GetPersonCache();
+
+            using var client = GetClient();
+            var clientCache = client.GetCache<int, Person>(CacheName);
+            var qry = new ScanQuery<int, Person>();
+
+            var cursor = clientCache.Query(qry);
+
+            // GetAll drains all pages; the server-side cursor is closed automatically on the last page.
+            Assert.AreEqual(cache.GetSize(), cursor.GetAll().Count);
+
+            // DisposeAsync must not send a resource-close for the already-closed cursor (would throw otherwise).
+            await cursor.DisposeAsync();
+
+            // The slot was never leaked: all cursors can still be opened.
+            await using (clientCache.Query(qry))
+            await using (clientCache.Query(qry))
+            await using (clientCache.Query(qry))
+            {
+                Assert.Throws<IgniteClientException>(() => clientCache.Query(qry));
+            }
+        }
+
+        /// <summary>
+        /// Tests that async and synchronous disposal can be mixed in any order on the same cursor:
+        /// the server-side cursor is closed exactly once and the slot is freed.
+        /// </summary>
+        [Test]
+        public async Task TestDisposeAsyncAndDisposeAreInterchangeable()
+        {
+            GetPersonCache();
+
+            using var client = GetClient();
+            var clientCache = client.GetCache<int, Person>(CacheName);
+            var qry = new ScanQuery<int, Person>();
+
+            // DisposeAsync first, then synchronous Dispose is a no-op.
+            var cursor = clientCache.Query(qry);
+            await cursor.DisposeAsync();
+            cursor.Dispose();
+
+            // Synchronous Dispose first, then DisposeAsync is a no-op.
+            cursor = clientCache.Query(qry);
+            cursor.Dispose();
+            await cursor.DisposeAsync();
+
+            // Both cursors were closed: the connection is back to zero open cursors.
+            var c1 = clientCache.Query(qry);
+            var c2 = clientCache.Query(qry);
+            var c3 = clientCache.Query(qry);
+            Assert.Throws<IgniteClientException>(() => clientCache.Query(qry));
+
+            c1.Dispose();
+            c2.Dispose();
+            c3.Dispose();
+        }
 #endif
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ScanQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/ScanQueryTest.cs
@@ -20,6 +20,9 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+#if NETCOREAPP
+    using System.Threading.Tasks;
+#endif
     using Apache.Ignite.Core.Binary;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Query;
@@ -243,6 +246,47 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
                 c3.Dispose();
             }
         }
+
+#if NETCOREAPP
+        /// <summary>
+        /// Tests that <c>await using</c> and <see cref="System.IAsyncDisposable.DisposeAsync"/> close the
+        /// server-side cursor asynchronously, freeing up a cursor slot just like synchronous disposal.
+        /// </summary>
+        [Test]
+        public async Task TestAwaitUsingClosesServerCursor()
+        {
+            GetPersonCache();
+
+            using var client = GetClient();
+            var clientCache = client.GetCache<int, Person>(CacheName);
+            var qry = new ScanQuery<int, Person>();
+
+            // MaxCursors = 3: open the maximum number of cursors.
+            var c1 = clientCache.Query(qry);
+            var c2 = clientCache.Query(qry);
+            var c3 = clientCache.Query(qry);
+
+            Assert.Throws<IgniteClientException>(() => clientCache.Query(qry));
+
+            // Async dispose frees a server-side cursor slot; awaiting guarantees the close completed.
+            await c1.DisposeAsync();
+
+            // A new cursor can be opened now, and exiting await using closes it again.
+            await using (clientCache.Query(qry))
+            {
+                Assert.Throws<IgniteClientException>(() => clientCache.Query(qry));
+            }
+
+            // Idempotent: a second async dispose is a no-op.
+            await c1.DisposeAsync();
+
+            c1 = clientCache.Query(qry);
+
+            c1.Dispose();
+            c2.Dispose();
+            c3.Dispose();
+        }
+#endif
 
         /// <summary>
         /// Gets the string cache.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
@@ -318,7 +318,7 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             var cursor = cache.Query(qry);
 
             // Read a single row, leaving the server-side cursor open (more pages remain).
-            var enumerator = cursor.GetEnumerator();
+            using var enumerator = cursor.GetEnumerator();
             Assert.IsTrue(enumerator.MoveNext());
 
             // DisposeAsync closes the still-open server cursor without blocking; repeated dispose is a no-op.

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Cache/SqlQueryTest.cs
@@ -18,6 +18,9 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
 {
     using System;
     using System.Linq;
+#if NETCOREAPP
+    using System.Threading.Tasks;
+#endif
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Client;
     using NUnit.Framework;
@@ -283,5 +286,49 @@ namespace Apache.Ignite.Core.Tests.Client.Cache
             Assert.IsTrue((bool)res[1]);
             Assert.AreEqual(label, (string)res[2]);
         }
+
+#if NETCOREAPP
+        /// <summary>
+        /// Tests that a fields query cursor (<c>ClientFieldsQueryCursor</c>) can be disposed with
+        /// <c>await using</c>, returning all rows and closing the server-side cursor asynchronously.
+        /// </summary>
+        [Test]
+        public async Task TestAwaitUsingFieldsQueryCursor()
+        {
+            var cache = GetClientCache<Person>();
+
+            var qry = new SqlFieldsQuery("select Id from Person");
+
+            await using var cursor = cache.Query(qry);
+
+            CollectionAssert.AreEquivalent(Enumerable.Range(1, Count), cursor.Select(x => (int)x[0]));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="System.IAsyncDisposable.DisposeAsync"/> closes a fields query cursor that is
+        /// still open on the server (only partially enumerated), and is idempotent.
+        /// </summary>
+        [Test]
+        public async Task TestDisposeAsyncClosesOpenFieldsQueryCursor()
+        {
+            var cache = GetClientCache<Person>();
+
+            // Small page size keeps the server-side cursor open so DisposeAsync sends a real close request.
+            var qry = new SqlFieldsQuery("select Id from Person") { PageSize = 1 };
+            var cursor = cache.Query(qry);
+
+            // Read a single row, leaving the server-side cursor open (more pages remain).
+            var enumerator = cursor.GetEnumerator();
+            Assert.IsTrue(enumerator.MoveNext());
+
+            // DisposeAsync closes the still-open server cursor without blocking; repeated dispose is a no-op.
+            await cursor.DisposeAsync();
+            await cursor.DisposeAsync();
+            cursor.Dispose();
+
+            // Cursor is disposed: further iteration throws.
+            Assert.Throws<ObjectDisposedException>(() => enumerator.MoveNext());
+        }
+#endif
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Client/Datastream/DataStreamerClientTest.cs
@@ -785,6 +785,49 @@ namespace Apache.Ignite.Core.Tests.Client.Datastream
             Assert.AreEqual(3, await cache.GetAsync(3));
         }
 
+        /// <summary>
+        /// Tests that exiting an <c>await using</c> block disposes the streamer asynchronously and
+        /// flushes buffered data into the cache.
+        /// </summary>
+        [Test]
+        public async Task TestStreamingAwaitUsing()
+        {
+            var cache = GetClientCache<int>();
+
+            await using (var streamer = Client.GetDataStreamer<int, int>(cache.Name))
+            {
+                streamer.Add(1, 1);
+                streamer.Add(2, 2);
+            }
+
+            Assert.AreEqual(2, await cache.GetSizeAsync());
+            Assert.AreEqual(1, await cache.GetAsync(1));
+            Assert.AreEqual(2, await cache.GetAsync(2));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IDataStreamerClient{TK,TV}.DisposeAsync"/> flushes buffered data, closes the
+        /// streamer, and can be called multiple times.
+        /// </summary>
+        [Test]
+        public async Task TestDisposeAsyncFlushesDataAndClosesStreamer()
+        {
+            var cache = GetClientCache<int>();
+
+            var streamer = Client.GetDataStreamer<int, int>(cache.Name);
+            streamer.Add(1, 1);
+
+            Assert.IsFalse(streamer.IsClosed);
+
+            await streamer.DisposeAsync();
+
+            Assert.IsTrue(streamer.IsClosed);
+            Assert.AreEqual(1, await cache.GetAsync(1));
+
+            // DisposeAsync is idempotent.
+            await streamer.DisposeAsync();
+        }
+
 #endif
 
         internal static void CheckArrayPoolLeak<TK, TV>(IDataStreamerClient<TK, TV> streamer)

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
@@ -931,7 +931,6 @@ namespace Apache.Ignite.Core.Tests.Dataload
 
             Assert.AreEqual(-1, await _cache.GetAsync(1));
             Assert.AreEqual(-100, await _cache.GetAsync(100));
-            Assert.IsFalse(await _cache.ContainsKeyAsync(101));
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core.Tests/Dataload/DataStreamerTest.cs
@@ -914,6 +914,47 @@ namespace Apache.Ignite.Core.Tests.Dataload
                 await ldr.FlushAsync();
             }
         }
+
+        /// <summary>
+        /// Tests that exiting an <c>await using</c> block disposes the streamer asynchronously and
+        /// flushes buffered data into the cache.
+        /// </summary>
+        [Test]
+        public async Task TestStreamerAwaitUsing()
+        {
+            await using (var ldr = _grid.GetDataStreamer<int, int>(CacheName))
+            {
+                ldr.AllowOverwrite = true;
+
+                ldr.Add(Enumerable.Range(1, 100).ToDictionary(x => x, x => -x));
+            }
+
+            Assert.AreEqual(-1, await _cache.GetAsync(1));
+            Assert.AreEqual(-100, await _cache.GetAsync(100));
+            Assert.IsFalse(await _cache.ContainsKeyAsync(101));
+        }
+
+        /// <summary>
+        /// Tests that <see cref="IDataStreamer{TK,TV}.DisposeAsync"/> flushes buffered data, completes the
+        /// streamer task, and can be called multiple times.
+        /// </summary>
+        [Test]
+        public async Task TestDisposeAsyncFlushesDataAndCompletesTask()
+        {
+            var ldr = _grid.GetDataStreamer<int, int>(CacheName);
+            ldr.AllowOverwrite = true;
+            ldr.Add(1, -1);
+
+            Assert.IsFalse(ldr.Task.IsCompleted);
+
+            await ldr.DisposeAsync();
+
+            Assert.IsTrue(ldr.Task.IsCompleted);
+            Assert.AreEqual(-1, await _cache.GetAsync(1));
+
+            // DisposeAsync is idempotent.
+            await ldr.DisposeAsync();
+        }
 #endif
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -25,11 +25,6 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
 
-    <!-- Required for IAsyncDisposable and IAsyncEnumerable. -->
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
-    </ItemGroup>
-
     <!--
     NOTE: Microsoft.CodeAnalysis.NetAnalyzers is the new replacement for FxCopAnalyzers,
     but it has some issues on older SDKs (https://github.com/dotnet/roslyn-analyzers/issues/4776).
@@ -54,6 +49,11 @@
     <None Include="GridGain.Ignite.targets" Pack="true" PackagePath="build" Link="build\%(Filename)%(Extension)" />
     <None Include="..\..\..\..\config\java.util.logging.properties" Pack="true" PackagePath="build\output\config" Link="build\output\config\%(Filename)%(Extension)" />
     <None Include="NuGet\LINQPad\*.*" Pack="true" PackagePath="linqpad-samples" Link="linqpad-samples\%(Filename)%(Extension)" />
+  </ItemGroup>
+
+  <!-- Required for IAsyncDisposable and IAsyncEnumerable. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
   </ItemGroup>
 
 </Project>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -25,12 +25,10 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
 
-    <!--
-    IAsyncDisposable and the non-generic ValueTask are part of the BCL on net8.0+ but not on
-    netstandard2.0; this package back-fills them (it pulls in System.Threading.Tasks.Extensions).
-    -->
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"
-                      Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+    <!-- Required for IAsyncDisposable and IAsyncEnumerable. -->
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="10.0.8" />
+    </ItemGroup>
 
     <!--
     NOTE: Microsoft.CodeAnalysis.NetAnalyzers is the new replacement for FxCopAnalyzers,

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Apache.Ignite.Core.csproj
@@ -26,6 +26,13 @@
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
 
     <!--
+    IAsyncDisposable and the non-generic ValueTask are part of the BCL on net8.0+ but not on
+    netstandard2.0; this package back-fills them (it pulls in System.Threading.Tasks.Extensions).
+    -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0"
+                      Condition="'$(TargetFramework)' == 'netstandard2.0'" />
+
+    <!--
     NOTE: Microsoft.CodeAnalysis.NetAnalyzers is the new replacement for FxCopAnalyzers,
     but it has some issues on older SDKs (https://github.com/dotnet/roslyn-analyzers/issues/4776).
     NOTE: Don't upgrade to 3.x - it does not work on some older 2.x SDKs

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/IQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/IQueryCursor.cs
@@ -25,11 +25,15 @@ namespace Apache.Ignite.Core.Cache.Query
     /// all entries using <see cref="IQueryCursor{T}.GetAll()"/> method.
     /// <para />
     /// Note that you get enumerator or call <c>GetAll()</c> method only once during
-    /// cursor lifetime. Any further attempts to get enumerator or all entries will result 
+    /// cursor lifetime. Any further attempts to get enumerator or all entries will result
     /// in exception.
+    /// <para />
+    /// Closing and disposing: <see cref="IDisposable.Dispose"/> closes the server-side cursor synchronously.
+    /// To avoid blocking threads when exiting a <c>using()</c> block, use <c>await using</c>
+    /// (see <see cref="IAsyncDisposable.DisposeAsync"/>), which closes the cursor asynchronously.
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
-    public interface IQueryCursor<T> : IEnumerable<T>, IDisposable
+    public interface IQueryCursor<T> : IEnumerable<T>, IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Gets all query results. Use this method when you know in advance that query 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/IQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Cache/Query/IQueryCursor.cs
@@ -27,10 +27,6 @@ namespace Apache.Ignite.Core.Cache.Query
     /// Note that you get enumerator or call <c>GetAll()</c> method only once during
     /// cursor lifetime. Any further attempts to get enumerator or all entries will result
     /// in exception.
-    /// <para />
-    /// Closing and disposing: <see cref="IDisposable.Dispose"/> closes the server-side cursor synchronously.
-    /// To avoid blocking threads when exiting a <c>using()</c> block, use <c>await using</c>
-    /// (see <see cref="IAsyncDisposable.DisposeAsync"/>), which closes the cursor asynchronously.
     /// </summary>
     [SuppressMessage("Microsoft.Naming", "CA1710:IdentifiersShouldHaveCorrectSuffix")]
     public interface IQueryCursor<T> : IEnumerable<T>, IDisposable, IAsyncDisposable

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/IContinuousQueryHandleClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/IContinuousQueryHandleClient.cs
@@ -20,7 +20,8 @@ namespace Apache.Ignite.Core.Client.Cache.Query.Continuous
 
     /// <summary>
     /// Represents a continuous query handle.
-    /// Call <see cref="IAsyncDisposable.DisposeAsync"/> to stop the continuous query.
+    /// Call <see cref="IAsyncDisposable.DisposeAsync"/> (or <see cref="IDisposable.Dispose"/>)
+    /// to stop the continuous query.
     /// </summary>
     public interface IContinuousQueryHandleClient : IDisposable, IAsyncDisposable
     {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/IContinuousQueryHandleClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Cache/Query/Continuous/IContinuousQueryHandleClient.cs
@@ -19,9 +19,10 @@ namespace Apache.Ignite.Core.Client.Cache.Query.Continuous
     using System;
 
     /// <summary>
-    /// Represents a continuous query handle. Call <see cref="IDisposable.Dispose"/> to stop the continuous query.
+    /// Represents a continuous query handle.
+    /// Call <see cref="IAsyncDisposable.DisposeAsync"/> to stop the continuous query.
     /// </summary>
-    public interface IContinuousQueryHandleClient : IDisposable
+    public interface IContinuousQueryHandleClient : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Occurs when continuous query gets disconnected.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
@@ -29,6 +29,10 @@ namespace Apache.Ignite.Core.Client.Datastream
     /// Note that streamer send data to remote nodes asynchronously, so cache updates can be reordered.
     /// <para />
     /// Instances of the implementing class are thread-safe: data can be added from multiple threads.
+    /// <para />
+    /// Closing and disposing: <see cref="IDisposable.Dispose"/> method calls <see cref="Close"/><c>(false)</c>;
+    /// <see cref="IAsyncDisposable.DisposeAsync"/> calls <see cref="CloseAsync"/><c>(false)</c>.
+    /// This will flush any remaining data to the cache.
     /// </summary>
     public interface IDataStreamerClient<TK, TV> : IDisposable, IAsyncDisposable
         where TK : notnull

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
@@ -32,9 +32,10 @@ namespace Apache.Ignite.Core.Client.Datastream
     /// <para />
     /// Closing and disposing: <see cref="IDisposable.Dispose"/> method calls <see cref="Close"/><c>(false)</c>.
     /// This will flush any remaining data to the cache synchronously.
-    /// To avoid blocking threads when exiting <c>using()</c> block, use <see cref="CloseAsync"/>.
+    /// To avoid blocking threads when exiting <c>using()</c> block, use <c>await using</c>
+    /// (see <see cref="IAsyncDisposable.DisposeAsync"/>) or call <see cref="CloseAsync"/> explicitly.
     /// </summary>
-    public interface IDataStreamerClient<TK, TV> : IDisposable
+    public interface IDataStreamerClient<TK, TV> : IDisposable, IAsyncDisposable
         where TK : notnull
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Datastream/IDataStreamerClient.cs
@@ -29,11 +29,6 @@ namespace Apache.Ignite.Core.Client.Datastream
     /// Note that streamer send data to remote nodes asynchronously, so cache updates can be reordered.
     /// <para />
     /// Instances of the implementing class are thread-safe: data can be added from multiple threads.
-    /// <para />
-    /// Closing and disposing: <see cref="IDisposable.Dispose"/> method calls <see cref="Close"/><c>(false)</c>.
-    /// This will flush any remaining data to the cache synchronously.
-    /// To avoid blocking threads when exiting <c>using()</c> block, use <c>await using</c>
-    /// (see <see cref="IAsyncDisposable.DisposeAsync"/>) or call <see cref="CloseAsync"/> explicitly.
     /// </summary>
     public interface IDataStreamerClient<TK, TV> : IDisposable, IAsyncDisposable
         where TK : notnull

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Client/Transactions/ITransactionClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Client/Transactions/ITransactionClient.cs
@@ -22,7 +22,7 @@ namespace Apache.Ignite.Core.Client.Transactions
     /// <summary>
     /// Thin client transaction.
     /// </summary>
-    public interface ITransactionClient : IDisposable
+    public interface ITransactionClient : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// Gets the transaction concurrency mode.

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Datastream/IDataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Datastream/IDataStreamer.cs
@@ -80,6 +80,11 @@ namespace Apache.Ignite.Core.Datastream
     /// </list>
     /// <para/>
     /// All members are thread-safe and may be used concurrently from multiple threads.
+    /// <para/>
+    /// Closing and disposing: <see cref="IDisposable.Dispose"/> calls <see cref="Close"/><c>(false)</c>,
+    /// flushing any remaining data to the cache synchronously. <see cref="IAsyncDisposable.DisposeAsync"/>
+    /// flushes the remaining data asynchronously before closing, so it does not block the calling thread
+    /// while data is sent to the cluster.
     /// </summary>
     public interface IDataStreamer<TK, TV> : IDisposable, IAsyncDisposable
         where TK : notnull

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Datastream/IDataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Datastream/IDataStreamer.cs
@@ -80,11 +80,6 @@ namespace Apache.Ignite.Core.Datastream
     /// </list>
     /// <para/>
     /// All members are thread-safe and may be used concurrently from multiple threads.
-    /// <para />
-    /// Closing and disposing: <see cref="IDisposable.Dispose"/> calls <see cref="Close"/><c>(false)</c>,
-    /// flushing any remaining data into the cache synchronously. To avoid blocking threads when exiting a
-    /// <c>using()</c> block, use <c>await using</c> (see <see cref="IAsyncDisposable.DisposeAsync"/>), which
-    /// flushes the remaining data asynchronously.
     /// </summary>
     public interface IDataStreamer<TK, TV> : IDisposable, IAsyncDisposable
         where TK : notnull

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Datastream/IDataStreamer.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Datastream/IDataStreamer.cs
@@ -80,8 +80,13 @@ namespace Apache.Ignite.Core.Datastream
     /// </list>
     /// <para/>
     /// All members are thread-safe and may be used concurrently from multiple threads.
+    /// <para />
+    /// Closing and disposing: <see cref="IDisposable.Dispose"/> calls <see cref="Close"/><c>(false)</c>,
+    /// flushing any remaining data into the cache synchronously. To avoid blocking threads when exiting a
+    /// <c>using()</c> block, use <c>await using</c> (see <see cref="IAsyncDisposable.DisposeAsync"/>), which
+    /// flushes the remaining data asynchronously.
     /// </summary>
-    public interface IDataStreamer<TK, TV> : IDisposable
+    public interface IDataStreamer<TK, TV> : IDisposable, IAsyncDisposable
         where TK : notnull
     {
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/PlatformCacheQueryCursor.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/PlatformCacheQueryCursor.cs
@@ -20,6 +20,7 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
     using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Impl.Cache.Platform;
@@ -91,6 +92,15 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
         {
             ReleaseUnmanagedResources();
             GC.SuppressFinalize(this);
+        }
+
+        /** <inheritdoc /> */
+        public ValueTask DisposeAsync()
+        {
+            // Platform cache iteration is local: there is no asynchronous counterpart, so dispose synchronously.
+            Dispose();
+
+            return default;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/QueryCursorBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Cache/Query/QueryCursorBase.cs
@@ -22,9 +22,12 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
     using System.Collections;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Cache.Query;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
+    using Apache.Ignite.Core.Impl.Common;
 
     /// <summary>
     /// Abstract query cursor implementation.
@@ -304,6 +307,50 @@ namespace Apache.Ignite.Core.Impl.Cache.Query
 
                 _disposed = true;
             }
+        }
+
+        /** <inheritdoc /> */
+        [SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly",
+            Justification = "GC.SuppressFinalize is valid in DisposeAsync; the analyzer only recognizes Dispose.")]
+        public async ValueTask DisposeAsync()
+        {
+            Task task = null;
+
+            lock (_syncRoot)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                // When _hasNext is false, cursor is already disposed by the server.
+                if (_hasNext)
+                {
+                    // Initiate the close under the lock; await its completion without blocking a thread.
+                    task = DisposeAsyncCore();
+                }
+
+                GC.SuppressFinalize(this);
+
+                _disposed = true;
+            }
+
+            if (task != null)
+            {
+                await task.ConfigureAwait(false);
+            }
+        }
+
+        /// <summary>
+        /// Releases the server-side cursor and returns a task that completes when the resource is closed.
+        /// The default implementation has no asynchronous counterpart and falls back to the synchronous
+        /// <see cref="Dispose(bool)"/>.
+        /// </summary>
+        protected virtual Task DisposeAsyncCore()
+        {
+            Dispose(true);
+
+            return TaskRunner.CompletedTask;
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientContinuousQueryHandle.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientContinuousQueryHandle.cs
@@ -19,6 +19,7 @@
 namespace Apache.Ignite.Core.Impl.Client.Cache.Query
 {
     using System;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client.Cache.Query.Continuous;
 
     /// <summary>
@@ -70,6 +71,35 @@ namespace Apache.Ignite.Core.Impl.Client.Cache.Query
 
                 _disposed = true;
             }
+        }
+
+        /** <inheritdoc /> */
+        public async ValueTask DisposeAsync()
+        {
+            Task task;
+
+            lock (_disposeSyncRoot)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+
+                if (_socket.IsDisposed)
+                {
+                    return;
+                }
+
+                // Initiate the close request under the lock; await its completion without blocking a thread.
+                task = _socket.DoOutInOpAsync<object>(ClientOp.ResourceClose,
+                    ctx => ctx.Writer.WriteLong(_queryId), _ => null);
+
+                _socket.RemoveNotificationHandler(_queryId);
+            }
+
+            await task.ConfigureAwait(false);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientQueryCursorBase.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Cache/Query/ClientQueryCursorBase.cs
@@ -18,6 +18,7 @@ namespace Apache.Ignite.Core.Impl.Client.Cache.Query
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Impl.Binary;
     using Apache.Ignite.Core.Impl.Binary.IO;
     using Apache.Ignite.Core.Impl.Cache.Query;
@@ -85,6 +86,14 @@ namespace Apache.Ignite.Core.Impl.Client.Cache.Query
             {
                 base.Dispose(disposing);
             }
+        }
+
+        /** <inheritdoc /> */
+        protected override Task DisposeAsyncCore()
+        {
+            // Close the server-side cursor without blocking a thread on the network round-trip.
+            return _socket.DoOutInOpAsync<object>(ClientOp.ResourceClose,
+                ctx => ctx.Writer.WriteLong(_cursorId), _ => null!);
         }
     }
 }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Datastream/DataStreamerClient.cs
@@ -129,6 +129,12 @@ namespace Apache.Ignite.Core.Impl.Client.Datastream
         }
 
         /** <inheritdoc /> */
+        public ValueTask DisposeAsync()
+        {
+            return new ValueTask(CloseAsync(cancel: false));
+        }
+
+        /** <inheritdoc /> */
         public string CacheName
         {
             get { return _cacheName; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Transactions/TransactionClient.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Client/Transactions/TransactionClient.cs
@@ -17,9 +17,12 @@
 namespace Apache.Ignite.Core.Impl.Client.Transactions
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
+    using System.Threading.Tasks;
     using Apache.Ignite.Core.Client;
     using Apache.Ignite.Core.Client.Transactions;
+    using Apache.Ignite.Core.Impl.Common;
     using Apache.Ignite.Core.Transactions;
 
     /// <summary>
@@ -106,6 +109,28 @@ namespace Apache.Ignite.Core.Impl.Client.Transactions
             }
         }
 
+        /** <inheritdoc /> */
+        [SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly",
+            Justification = "GC.SuppressFinalize is valid in DisposeAsync; the analyzer only recognizes Dispose.")]
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await CloseAsync(false).ConfigureAwait(false);
+            }
+            catch
+            {
+                if (!_socket.IsDisposed)
+                {
+                    throw;
+                }
+            }
+            finally
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
         /// <summary>
         /// Transaction Id.
         /// </summary>
@@ -157,6 +182,28 @@ namespace Apache.Ignite.Core.Impl.Client.Transactions
                     _closed = true;
                 }
             }
+        }
+
+        /// <summary>
+        /// Closes the transaction asynchronously.
+        /// </summary>
+        private Task CloseAsync(bool commit)
+        {
+            if (_closed)
+            {
+                return TaskRunner.CompletedTask;
+            }
+
+            // Mark as closed up front (matches the synchronous Close, which sets the flag even on failure).
+            _closed = true;
+
+            return Socket.DoOutInOpAsync<object?>(ClientOp.TxEnd,
+                ctx =>
+                {
+                    ctx.Writer.WriteInt(_id);
+                    ctx.Writer.WriteBoolean(commit);
+                },
+                _ => null);
         }
 
         /// <summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Datastream/DataStreamerImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Datastream/DataStreamerImpl.cs
@@ -628,6 +628,24 @@ namespace Apache.Ignite.Core.Impl.Datastream
         }
 
         /** <inheritDoc /> */
+        public async ValueTask DisposeAsync()
+        {
+            // Flush remaining buffered data asynchronously so that the calling thread is not blocked
+            // while data is sent to the cluster. The subsequent Dispose() only finalizes the (already
+            // flushed) streamer, which is fast local cleanup, and also suppresses finalization.
+            var batch = _batch;
+
+            if (batch != null)
+            {
+                Flush0(batch, false, PlcFlush);
+
+                await batch.GetThisAndPreviousCompletionTask().ConfigureAwait(false);
+            }
+
+            Dispose();
+        }
+
+        /** <inheritDoc /> */
         public IDataStreamer<TK1, TV1> WithKeepBinary<TK1, TV1>()
             where TK1 : notnull
         {

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Transactions/Transaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Transactions/Transaction.cs
@@ -47,6 +47,14 @@ namespace Apache.Ignite.Core.Impl.Transactions
         }
 
         /** <inheritDoc /> */
+        [SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly",
+            Justification = "There is no finalizer.")]
+        public ValueTask DisposeAsync()
+        {
+            return _tx.DisposeAsync();
+        }
+
+        /** <inheritDoc /> */
         public Guid NodeId
         {
             get { return _tx.NodeId; }

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Transactions/TransactionImpl.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Transactions/TransactionImpl.cs
@@ -30,7 +30,7 @@ namespace Apache.Ignite.Core.Impl.Transactions
     /// <summary>
     /// Grid cache transaction implementation.
     /// </summary>
-    internal sealed class TransactionImpl : IDisposable
+    internal sealed class TransactionImpl : IDisposable, IAsyncDisposable
     {
         /** Metadatas. */
         private object[] _metas;
@@ -417,6 +417,27 @@ namespace Apache.Ignite.Core.Impl.Transactions
             }
         }
 
+        /** <inheritdoc /> */
+        [SuppressMessage("Microsoft.Usage", "CA1816:CallGCSuppressFinalizeCorrectly",
+            Justification = "GC.SuppressFinalize is valid in DisposeAsync; the analyzer only recognizes Dispose.")]
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes",
+            Justification = "DisposeAsync should not throw.")]
+        public async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await CloseAsync().ConfigureAwait(false);
+            }
+            catch (IgniteIllegalStateException)
+            {
+                _state = new StateHolder(TransactionState.Unknown);
+            }
+            finally
+            {
+                GC.SuppressFinalize(this);
+            }
+        }
+
         /// <summary>
         /// Gets a value indicating whether this transaction is closed.
         /// </summary>
@@ -465,6 +486,19 @@ namespace Apache.Ignite.Core.Impl.Transactions
             lock (this)
             {
                 _state = _state ?? new StateHolder((TransactionState) _txs.TxClose(this));
+            }
+        }
+
+        /// <summary>
+        /// Closes the transaction asynchronously, rolling it back unless it has already been completed.
+        /// Unlike <see cref="RollbackAsync"/>, this is a no-op when the transaction is already closed,
+        /// matching the synchronous <see cref="Close"/> used by <see cref="Dispose"/>.
+        /// </summary>
+        private Task CloseAsync()
+        {
+            lock (this)
+            {
+                return IsClosed ? TaskRunner.CompletedTask : CloseWhenComplete(_txs.RollbackAsync(this));
             }
         }
 

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Transactions/TransactionRollbackOnlyProxy.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Impl/Transactions/TransactionRollbackOnlyProxy.cs
@@ -223,6 +223,16 @@ namespace Apache.Ignite.Core.Impl.Transactions
             }
         }
 
+        /** <inheritDoc /> */
+        public ValueTask DisposeAsync()
+        {
+            // There is no asynchronous counterpart for removing a rollback-only view (it is local cleanup,
+            // not a transaction outcome), so perform the synchronous dispose and return a completed task.
+            Dispose();
+
+            return default;
+        }
+
         /// <summary>
         /// Unique transaction view ID.
         /// </summary>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Transactions/ITransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Transactions/ITransaction.cs
@@ -88,10 +88,6 @@ namespace Apache.Ignite.Core.Transactions
     /// and distributed locking are not supported. Disabling transactions and locking allows to achieve much higher
     /// performance and throughput ratios. It is recommended that <c>CacheAtomicityMode.TRANSACTIONAL</c> mode
     /// is used whenever full <c>ACID</c>-compliant transactions are not needed.
-    /// <para />
-    /// Closing and disposing: <see cref="IDisposable.Dispose"/> rolls the transaction back synchronously
-    /// unless it has already been committed. To avoid blocking threads when exiting a <c>using()</c> block,
-    /// use <c>await using</c> (see <see cref="IAsyncDisposable.DisposeAsync"/>), which rolls back asynchronously.
     /// <example>
     ///     You can use cache transactions as follows:
     ///     <code>

--- a/modules/platforms/dotnet/Apache.Ignite.Core/Transactions/ITransaction.cs
+++ b/modules/platforms/dotnet/Apache.Ignite.Core/Transactions/ITransaction.cs
@@ -88,6 +88,10 @@ namespace Apache.Ignite.Core.Transactions
     /// and distributed locking are not supported. Disabling transactions and locking allows to achieve much higher
     /// performance and throughput ratios. It is recommended that <c>CacheAtomicityMode.TRANSACTIONAL</c> mode
     /// is used whenever full <c>ACID</c>-compliant transactions are not needed.
+    /// <para />
+    /// Closing and disposing: <see cref="IDisposable.Dispose"/> rolls the transaction back synchronously
+    /// unless it has already been committed. To avoid blocking threads when exiting a <c>using()</c> block,
+    /// use <c>await using</c> (see <see cref="IAsyncDisposable.DisposeAsync"/>), which rolls back asynchronously.
     /// <example>
     ///     You can use cache transactions as follows:
     ///     <code>
@@ -108,7 +112,7 @@ namespace Apache.Ignite.Core.Transactions
     ///     </code>
     /// </example>
     /// </summary>
-    public interface ITransaction : IDisposable
+    public interface ITransaction : IDisposable, IAsyncDisposable
     {
         /// <summary>
         /// ID of the node on which this transaction started.


### PR DESCRIPTION
Add `IAsyncDisposable` support where disposal is IO-bound, so callers can do `await using` and avoid blocking threads.

- Implement `IAsyncDisposable` on `IDataStreamer`, `IDataStreamerClient`, `ITransaction`, `ITransactionClient`, `IContinuousQueryHandleClient`, and `IQueryCursor`.
- Reference `Microsoft.Bcl.AsyncInterfaces` on `netstandard2.0`.