### PR TITLE
GG-49131 - examples are moved to separate repo

### DIFF
--- a/assembly/release-apache-ignite-base.xml
+++ b/assembly/release-apache-ignite-base.xml
@@ -163,7 +163,7 @@
         </fileSet>
 
         <fileSet>
-            <directory>examples</directory>
+            <directory>${gg8.examples.dir}/examples</directory>
             <outputDirectory>/examples</outputDirectory>
             <includes>
                 <include>rest/**</include>
@@ -179,7 +179,7 @@
         </fileSet>
 
         <fileSet>
-            <directory>examples</directory>
+            <directory>${gg8.examples.dir}/examples</directory>
             <outputDirectory>/examples</outputDirectory>
             <includes>
                 <include>config/**</include>

--- a/assembly/release-apache-ignite-zos.xml
+++ b/assembly/release-apache-ignite-zos.xml
@@ -41,11 +41,5 @@
             <outputDirectory>/examples</outputDirectory>
             <destName>pom.xml</destName>
         </file>
-
-        <file>
-            <source>${gg8.examples.dir}/examples/README.txt</source>
-            <outputDirectory>/examples</outputDirectory>
-            <destName>README.txt</destName>
-        </file>
     </files>
 </assembly>

--- a/assembly/release-apache-ignite-zos.xml
+++ b/assembly/release-apache-ignite-zos.xml
@@ -37,13 +37,13 @@
 
     <files>
         <file>
-            <source>examples/pom-standalone.xml</source>
+            <source>${gg8.examples.dir}/examples/pom.xml</source>
             <outputDirectory>/examples</outputDirectory>
             <destName>pom.xml</destName>
         </file>
 
         <file>
-            <source>examples/README.txt</source>
+            <source>${gg8.examples.dir}/examples/README.txt</source>
             <outputDirectory>/examples</outputDirectory>
             <destName>README.txt</destName>
         </file>

--- a/assembly/release-apache-ignite.xml
+++ b/assembly/release-apache-ignite.xml
@@ -42,11 +42,5 @@
             <outputDirectory>/examples</outputDirectory>
             <destName>pom.xml</destName>
         </file>
-
-        <file>
-            <source>${gg8.examples.dir}/examples/README.txt</source>
-            <outputDirectory>/examples</outputDirectory>
-            <destName>README.txt</destName>
-        </file>
     </files>
 </assembly>

--- a/assembly/release-apache-ignite.xml
+++ b/assembly/release-apache-ignite.xml
@@ -38,13 +38,13 @@
 
     <files>
         <file>
-            <source>examples/pom-standalone.xml</source>
+            <source>${gg8.examples.dir}/examples/pom.xml</source>
             <outputDirectory>/examples</outputDirectory>
             <destName>pom.xml</destName>
         </file>
 
         <file>
-            <source>examples/README.txt</source>
+            <source>${gg8.examples.dir}/examples/README.txt</source>
             <outputDirectory>/examples</outputDirectory>
             <destName>README.txt</destName>
         </file>

--- a/assembly/release-gridgain-ml.xml
+++ b/assembly/release-gridgain-ml.xml
@@ -42,13 +42,13 @@
         </file>
 
         <file>
-            <source>examples-ml/pom-standalone.xml</source>
+            <source>${gg8.examples.dir}/examples-ml/pom.xml</source>
             <outputDirectory>/examples-ml</outputDirectory>
             <destName>pom.xml</destName>
         </file>
 
         <file>
-            <source>examples-ml/README.txt</source>
+            <source>${gg8.examples.dir}/examples-ml/README.txt</source>
             <outputDirectory>/examples-ml</outputDirectory>
             <destName>README.txt</destName>
         </file>
@@ -64,7 +64,7 @@
         </fileSet>
 
         <fileSet>
-            <directory>examples-ml</directory>
+            <directory>${gg8.examples.dir}/examples-ml</directory>
             <outputDirectory>/examples-ml</outputDirectory>
             <includes>
                 <include>config/**</include>

--- a/assembly/release-gridgain-ml.xml
+++ b/assembly/release-gridgain-ml.xml
@@ -46,12 +46,6 @@
             <outputDirectory>/examples-ml</outputDirectory>
             <destName>pom.xml</destName>
         </file>
-
-        <file>
-            <source>${gg8.examples.dir}/examples-ml/README.txt</source>
-            <outputDirectory>/examples-ml</outputDirectory>
-            <destName>README.txt</destName>
-        </file>
     </files>
 
     <fileSets>

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,7 @@
         <profile>
             <id>all-java</id> <!-- used to update project versions and check all modules compilation -->
             <modules> <!-- sorted alphabetically -->
+                <!-- these modules moved to gg8-examples repo -->
                 <!--module>examples</module-->
                 <!--module>examples-ml</module-->
                 <module>modules/benchmarks</module>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
             <id>all-java</id> <!-- used to update project versions and check all modules compilation -->
             <modules> <!-- sorted alphabetically -->
                 <!-- these modules moved to gg8-examples repo -->
+                <!-- packaging will work when gg8-examples is cloned next to this repo -->
                 <!--module>examples</module-->
                 <!--module>examples-ml</module-->
                 <module>modules/benchmarks</module>

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
         <tag>HEAD</tag>
     </scm>
 
+    <properties>
+        <gg8.examples.dir>../gg8-examples</gg8.examples.dir>
+    </properties>
+
     <modules>
         <module>modules/apache-license-gen</module>
         <module>parent</module>
@@ -136,8 +140,8 @@
         <profile>
             <id>all-java</id> <!-- used to update project versions and check all modules compilation -->
             <modules> <!-- sorted alphabetically -->
-                <module>examples</module>
-                <module>examples-ml</module>
+                <!--module>examples</module-->
+                <!--module>examples-ml</module-->
                 <module>modules/benchmarks</module>
                 <module>modules/compatibility</module>
                 <module>modules/geospatial</module>
@@ -539,12 +543,12 @@
                                             </fileset>
                                         </replaceregexp>
 
-                                        <replaceregexp file="${release.dir}/examples/pom.xml" byline="true">
+                                        <replaceregexp file="${gg8.examples.dir}/examples/pom.xml" byline="true">
                                             <regexp pattern="to_be_replaced_by_ignite_version" />
                                             <substitution expression="${project.version}" />
                                         </replaceregexp>
 
-                                        <replaceregexp file="${release.dir}/examples-ml/pom.xml" byline="true">
+                                        <replaceregexp file="${gg8.examples.dir}/examples-ml/pom.xml" byline="true">
                                             <regexp pattern="to_be_replaced_by_ignite_version" />
                                             <substitution expression="${project.version}" />
                                         </replaceregexp>
@@ -712,8 +716,8 @@
         <profile>
             <id>examples</id>
             <modules>
-                <module>examples</module>
-                <module>examples-ml</module>
+                <!--module>examples</module-->
+                <!--module>examples-ml</module-->
             </modules>
         </profile>
 


### PR DESCRIPTION
this change will work if gg8-examples repo is cloned in a folder next to gridgain repo