### PR TITLE
[reference — do not merge] GG-49160 Vector search: index/query config surface + data-row link in LuceneIndex SPI

### DIFF
--- a/modules/core/src/main/java/org/apache/ignite/cache/QueryEntity.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/QueryEntity.java
@@ -707,6 +707,8 @@ public class QueryEntity implements Serializable {
                 vectIdx.setIndexType(idx.type());
                 vectIdx.setFieldNames(idx.fields(), true);
                 vectIdx.setSimilarityFunction(idx.similarityFunction());
+                vectIdx.setM(idx.m());
+                vectIdx.setEfConstruction(idx.efConstruction());
 
                 idxs.add(vectIdx);
             }
@@ -906,7 +908,7 @@ public class QueryEntity implements Serializable {
             desc.addFieldToTextIndex(prop.fullName());
 
         if (vecAnn != null)
-            desc.addFieldToVectorIndex(prop.fullName(), vecAnn.similarityFunction());
+            desc.addFieldToVectorIndex(prop.fullName(), vecAnn.similarityFunction(), vecAnn.m(), vecAnn.efConstruction());
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/cache/QueryIndex.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/QueryIndex.java
@@ -60,6 +60,12 @@ public class QueryIndex implements Serializable {
      */
     private SimilarityFunction similarityFunction;
 
+    /** HNSW max connections per node for VECTOR index ({@code 0} — engine default). */
+    private int m;
+
+    /** HNSW build-time beam width for VECTOR index ({@code 0} — engine default). */
+    private int efConstruction;
+
     /**
      * Creates an empty index. Should be populated via setters.
      */
@@ -284,6 +290,48 @@ public class QueryIndex implements Serializable {
      */
     public SimilarityFunction getSimilarityFunction() {
         return similarityFunction;
+    }
+
+    /**
+     * Gets HNSW max connections per node for VECTOR index.
+     *
+     * @return M, or {@code 0} for the engine default.
+     */
+    public int getM() {
+        return m;
+    }
+
+    /**
+     * Sets HNSW max connections per node for VECTOR index.
+     *
+     * @param m M, or {@code 0} for the engine default.
+     * @return {@code this} for chaining.
+     */
+    public QueryIndex setM(int m) {
+        this.m = m;
+
+        return this;
+    }
+
+    /**
+     * Gets HNSW build-time beam width for VECTOR index.
+     *
+     * @return efConstruction, or {@code 0} for the engine default.
+     */
+    public int getEfConstruction() {
+        return efConstruction;
+    }
+
+    /**
+     * Sets HNSW build-time beam width for VECTOR index.
+     *
+     * @param efConstruction efConstruction, or {@code 0} for the engine default.
+     * @return {@code this} for chaining.
+     */
+    public QueryIndex setEfConstruction(int efConstruction) {
+        this.efConstruction = efConstruction;
+
+        return this;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/VectorQuery.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/VectorQuery.java
@@ -79,6 +79,9 @@ public final class VectorQuery<K, V> extends Query<Cache.Entry<K, V>> {
     /** threshold, the threshold for cosine similarity. */
     private float threshold = -1;
 
+    /** Search-time beam width (efSearch); {@code 0} — use the engine default. */
+    private int efSearch;
+
     /**
      * Constructs query for the given search vector.
      *
@@ -216,6 +219,28 @@ public final class VectorQuery<K, V> extends Query<Cache.Entry<K, V>> {
      */
     public float getThreshold() {
         return threshold;
+    }
+
+    /**
+     * Sets the search-time beam width (efSearch). Higher values improve recall at
+     * the cost of latency. Must be at least {@code k} to take effect.
+     *
+     * @param efSearch efSearch, or {@code 0} to use the engine default.
+     * @return {@code this} For chaining.
+     */
+    public VectorQuery<K, V> setEfSearch(int efSearch) {
+        this.efSearch = efSearch;
+
+        return this;
+    }
+
+    /**
+     * Gets the search-time beam width (efSearch).
+     *
+     * @return efSearch, or {@code 0} if the engine default is used.
+     */
+    public int getEfSearch() {
+        return efSearch;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/cache/query/annotations/QueryVectorField.java
+++ b/modules/core/src/main/java/org/apache/ignite/cache/query/annotations/QueryVectorField.java
@@ -41,4 +41,19 @@ public @interface QueryVectorField {
      */
     SimilarityFunction similarityFunction() default SimilarityFunction.COSINE;
 
+    /**
+     * HNSW max connections per node (M) for the vector index built over this field.
+     * Higher values improve recall at the cost of memory and build time.
+     *
+     * @return M, or {@code 0} (default) to use the engine default.
+     */
+    int m() default 0;
+
+    /**
+     * HNSW beam width used while building the vector index (efConstruction).
+     * Higher values improve graph quality at the cost of build time.
+     *
+     * @return efConstruction, or {@code 0} (default) to use the engine default.
+     */
+    int efConstruction() default 0;
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/LuceneIndex.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/LuceneIndex.java
@@ -90,4 +90,34 @@ public interface LuceneIndex extends AutoCloseable {
      */
     public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> vectorQuery(String field, float[] qryVector,
         int k, float threshold, int efSearch, IndexingQueryFilter filters) throws IgniteCheckedException;
+
+    /**
+     * Destroys the index: like {@link #close()}, but additionally drops any persistent
+     * state the index keeps. Called when the cache is destroyed (as opposed to a node
+     * stop / cache close, where persistent index state must survive).
+     */
+    public default void destroy() throws Exception {
+        close();
+    }
+
+    /**
+     * Asks the index whether it needs the row-scan rebuild after a restart. An index
+     * that restored itself from its own persistent state (e.g. a vector graph
+     * snapshot) returns {@code false} and the scan is skipped.
+     *
+     * @return {@code True} if the index must be rebuilt from cache rows.
+     */
+    public default boolean needsRebuild() {
+        return true;
+    }
+
+    /**
+     * Invoked early in the node-stop sequence, before cache stop and before the
+     * database manager blocks checkpoint-lock acquisition — the last point where an
+     * index can still write persistent state (e.g. its parting graph snapshot) that
+     * the final checkpoint of a graceful stop will flush.
+     */
+    public default void beforeNodeStop() {
+        // No-op.
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/LuceneIndex.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/LuceneIndex.java
@@ -50,10 +50,13 @@ public interface LuceneIndex extends AutoCloseable {
      * @param v Value.
      * @param ver Version.
      * @param expires Expiration time.
+     * @param link Data-row link of the entry ({@code 0} if not available) — lets the index
+     *     materialize results by a direct row read instead of duplicating key/value bytes.
      * @throws IgniteCheckedException If failed.
      */
     @SuppressWarnings("ConstantConditions")
-    public void store(CacheObject k, CacheObject v, GridCacheVersion ver, long expires) throws IgniteCheckedException;
+    public void store(CacheObject k, CacheObject v, GridCacheVersion ver, long expires, long link)
+        throws IgniteCheckedException;
 
     /**
      * Removes entry for given key from this index.

--- a/modules/core/src/main/java/org/apache/ignite/internal/cache/query/LuceneIndex.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/cache/query/LuceneIndex.java
@@ -78,10 +78,13 @@ public interface LuceneIndex extends AutoCloseable {
      * Runs lucene vector query over this index.
      *
      * @param qryVector Query as vector.
+     * @param k Number of nearest neighbours to return.
+     * @param threshold Minimum similarity score, or a negative value for no threshold.
+     * @param efSearch Search-time beam width, or {@code 0} for the engine default.
      * @param filters Filters over result.
      * @return Query result.
      * @throws IgniteCheckedException If failed.
      */
     public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> vectorQuery(String field, float[] qryVector,
-        int k, float threshold, IndexingQueryFilter filters) throws IgniteCheckedException;
+        int k, float threshold, int efSearch, IndexingQueryFilter filters) throws IgniteCheckedException;
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxyImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/IgniteCacheProxyImpl.java
@@ -542,7 +542,8 @@ public class IgniteCacheProxyImpl<K, V> extends AsyncSupportAdapter<IgniteCache<
         if (filter instanceof VectorQuery) {
             VectorQuery p = (VectorQuery)filter;
 
-            qry = ctx.queries().createVectorQuery(p.getType(), p.getField(), p.getClauseVector(), p.getK(), p.getThreshold(), isKeepBinary);
+            qry = ctx.queries().createVectorQuery(p.getType(), p.getField(), p.getClauseVector(), p.getK(),
+                p.getThreshold(), p.getEfSearch(), isKeepBinary);
 
             if (grp != null)
                 qry.projection(grp);

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PageIO.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/persistence/tree/io/PageIO.java
@@ -19,6 +19,8 @@ package org.apache.ignite.internal.processors.cache.persistence.tree.io;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.ignite.IgniteCheckedException;
 import org.apache.ignite.internal.metric.IndexPageType;
 import org.apache.ignite.internal.metric.IoStatisticsHolder;
@@ -609,6 +611,23 @@ public abstract class PageIO {
         testIO = io;
     }
 
+    /** Externally registered page IOs (e.g. plugin-provided page types) by type. */
+    private static final Map<Integer, IOVersions<? extends PageIO>> EXT_IOS = new ConcurrentHashMap<>();
+
+    /**
+     * Registers externally provided page IO versions (e.g. plugin page types), so that
+     * generic code (diagnostics, page dumps, recovery) can resolve them through
+     * {@link #getPageIO(int, int)}. Registration is idempotent for the same instance;
+     * conflicting registrations for one type are a programming error.
+     *
+     * @param ios IO versions to register.
+     */
+    public static void registerExtension(IOVersions<? extends PageIO> ios) {
+        IOVersions<? extends PageIO> old = EXT_IOS.putIfAbsent(ios.getType(), ios);
+
+        assert old == null || old == ios : "Conflicting page IO registration for type: " + ios.getType();
+    }
+
     /**
      * @return Type.
      */
@@ -737,6 +756,11 @@ public abstract class PageIO {
                     if (testIO.type == type && testIO.ver == ver)
                         return (Q)testIO;
                 }
+
+                IOVersions<? extends PageIO> extIos = EXT_IOS.get(type);
+
+                if (extIos != null)
+                    return (Q)extIos.forVersion(ver);
 
                 return (Q)getBPlusIO(type, ver);
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryAdapter.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryAdapter.java
@@ -155,6 +155,9 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
     /** Threshold for cosine similarity in case of vector query. */
     private final float threshold;
 
+    /** Search-time beam width in case of vector query ({@code 0} — engine default). */
+    private final int efSearch;
+
     /**
      * @param cctx Context.
      * @param type Query type.
@@ -196,6 +199,7 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
         qryVector = null;
         k = -1;
         threshold = 0.5f;
+        efSearch = 0;
     }
 
     /**
@@ -242,6 +246,7 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
         qryVector = null;
         k = -1;
         threshold = 0.5f;
+        efSearch = 0;
     }
 
     /**
@@ -267,6 +272,7 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
         @Nullable float[] qryVector,
         int k,
         float threshold,
+        int efSearch,
         @Nullable IgniteBiPredicate<Object, Object> filter,
         @Nullable Integer part,
         boolean incMeta,
@@ -285,6 +291,7 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
         this.qryVector = qryVector;
         this.k = k;
         this.threshold = threshold;
+        this.efSearch = efSearch;
         this.filter = filter;
         this.part = part;
         this.incMeta = incMeta;
@@ -357,6 +364,7 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
         qryVector = null;
         k = -1;
         threshold = 0.5f;
+        efSearch = 0;
     }
 
     /**
@@ -385,6 +393,13 @@ public class GridCacheQueryAdapter<T> implements CacheQuery<T> {
      */
     public float threshold() {
         return threshold;
+    }
+
+    /**
+     * @return Search-time beam width in case of vector query ({@code 0} — engine default).
+     */
+    public int efSearch() {
+        return efSearch;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryManager.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/GridCacheQueryManager.java
@@ -649,7 +649,7 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
                     }
 
                     iter = qryProc.queryVector(cacheName, qry.fieldName(), qry.queryVector(), qry.k(), qry.threshold(),
-                        qry.queryClassName(), filter(qry));
+                        qry.efSearch(), qry.queryClassName(), filter(qry));
 
                     break;
 
@@ -2783,6 +2783,7 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
             null,
             -1,
             0.5f,
+            0,
             null,
             null,
             false,
@@ -2880,6 +2881,7 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
                 null,
                 -1,
                 0.5f,
+                0,
                 null,
                 null,
                 false,
@@ -2896,7 +2898,7 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
      * @return Created query.
      */
     public CacheQuery<Map.Entry<K, V>> createVectorQuery(String clsName, String field, float[] vector,
-        int k, float threshold, boolean keepBinary) {
+        int k, float threshold, int efSearch, boolean keepBinary) {
         A.notNull(clsName, "clsName");
         A.notNull(field, "field");
         A.notNull(vector, "vector");
@@ -2909,6 +2911,7 @@ public abstract class GridCacheQueryManager<K, V> extends GridCacheManagerAdapte
             vector,
             k,
             threshold,
+            efSearch,
             null,
             null,
             false,

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/QueryEntityIndexDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/QueryEntityIndexDescriptor.java
@@ -53,6 +53,12 @@ public class QueryEntityIndexDescriptor implements GridQueryIndexDescriptor {
      */
     private SimilarityFunction similarityFunction;
 
+    /** HNSW max connections per node for VECTOR index ({@code 0} — engine default). */
+    private int m;
+
+    /** HNSW build-time beam width for VECTOR index ({@code 0} — engine default). */
+    private int efConstruction;
+
     /** Fields which should be indexed in descending order. */
     private Collection<String> descendings;
 
@@ -74,6 +80,29 @@ public class QueryEntityIndexDescriptor implements GridQueryIndexDescriptor {
     QueryEntityIndexDescriptor(QueryIndexType type, SimilarityFunction similarityFunction) {
         this(type, -1);
         this.similarityFunction = similarityFunction;
+    }
+
+    /**
+     * @param type               Type.
+     * @param similarityFunction Vector Similarity Function for VECTOR Indexes.
+     * @param m                  HNSW max connections per node ({@code 0} — engine default).
+     * @param efConstruction     HNSW build-time beam width ({@code 0} — engine default).
+     */
+    QueryEntityIndexDescriptor(QueryIndexType type, SimilarityFunction similarityFunction, int m, int efConstruction) {
+        this(type, similarityFunction);
+
+        this.m = m;
+        this.efConstruction = efConstruction;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int m() {
+        return m;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int efConstruction() {
+        return efConstruction;
     }
 
     /**

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/QueryEntityTypeDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/cache/query/QueryEntityTypeDescriptor.java
@@ -154,10 +154,12 @@ public class QueryEntityTypeDescriptor {
      *
      * @param field              Field name.
      * @param similarityFunction Vector Similarity Function for VECTOR index.
+     * @param m                  HNSW max connections per node ({@code 0} — engine default).
+     * @param efConstruction     HNSW build-time beam width ({@code 0} — engine default).
      */
-    public void addFieldToVectorIndex(String field, SimilarityFunction similarityFunction) {
+    public void addFieldToVectorIndex(String field, SimilarityFunction similarityFunction, int m, int efConstruction) {
         if (vectorIdx == null) {
-            vectorIdx = new QueryEntityIndexDescriptor(QueryIndexType.VECTOR, similarityFunction);
+            vectorIdx = new QueryEntityIndexDescriptor(QueryIndexType.VECTOR, similarityFunction, m, efConstruction);
 
             indexes.put(QueryIndexType.VECTOR.name(), vectorIdx);
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheSetImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/datastructures/GridCacheSetImpl.java
@@ -201,7 +201,7 @@ public class GridCacheSetImpl<T> extends AbstractCollection<T> implements Ignite
             }
 
             CacheQuery qry = new GridCacheQueryAdapter<>(ctx, SET, null, null, null, null,
-                -1, 0.5f, new GridSetQueryPredicate<>(id, collocated), collocated ? hdrPart : null,
+                -1, 0.5f, 0, new GridSetQueryPredicate<>(id, collocated), collocated ? hdrPart : null,
                 false, false, null);
 
             Collection<ClusterNode> nodes = dataNodes(ctx.affinity().affinityTopologyVersion());
@@ -475,7 +475,7 @@ public class GridCacheSetImpl<T> extends AbstractCollection<T> implements Ignite
      */
     @SuppressWarnings("unchecked")
     private WeakReferenceCloseableIterator<T> sharedCacheIterator(boolean keepBinary) throws IgniteCheckedException {
-        CacheQuery qry = new GridCacheQueryAdapter<>(ctx, SET, null, null, null, null, -1, 0.5f,
+        CacheQuery qry = new GridCacheQueryAdapter<>(ctx, SET, null, null, null, null, -1, 0.5f, 0,
             new GridSetQueryPredicate<>(id, collocated), collocated ? hdrPart : null,
             false, keepBinary, null);
 

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryIndexDescriptor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryIndexDescriptor.java
@@ -68,4 +68,22 @@ public interface GridQueryIndexDescriptor {
      * @return Similarity Function.
      */
     public SimilarityFunction similarityFunction();
+
+    /**
+     * Returns HNSW max connections per node for VECTOR index.
+     *
+     * @return M, or {@code 0} for the engine default.
+     */
+    public default int m() {
+        return 0;
+    }
+
+    /**
+     * Returns HNSW build-time beam width for VECTOR index.
+     *
+     * @return efConstruction, or {@code 0} for the engine default.
+     */
+    public default int efConstruction() {
+        return 0;
+    }
 }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryIndexing.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryIndexing.java
@@ -178,7 +178,8 @@ public interface GridQueryIndexing {
      * @throws IgniteCheckedException If failed.
      */
     public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> queryLocalVector(String schemaName, String cacheName,
-        String field, float[] qryVector, int k, float threshold, String typeName, IndexingQueryFilter filter) throws IgniteCheckedException;
+        String field, float[] qryVector, int k, float threshold, int efSearch, String typeName,
+        IndexingQueryFilter filter) throws IgniteCheckedException;
 
     /**
      * Create new index locally.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryIndexing.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryIndexing.java
@@ -433,6 +433,16 @@ public interface GridQueryIndexing {
     public void onKernalStop();
 
     /**
+     * Invoked early in the graceful node-stop sequence, before cache stop and before
+     * the database manager blocks checkpoint-lock acquisition — the last point where
+     * indexes can write persistent state (e.g. a parting vector-graph snapshot) that
+     * the final checkpoint will flush.
+     */
+    public default void beforeNodeStop() {
+        // No-op.
+    }
+
+    /**
      * Gets database schema from cache name.
      *
      * @param cacheName Cache name. {@code null} would be converted to an empty string.

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -3475,7 +3475,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
      * @throws IgniteCheckedException If failed.
      */
     public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> queryVector(String cacheName, String field,
-        float[] qryVector, int k, float threshold, String resType, IndexingQueryFilter filters) throws IgniteCheckedException {
+        float[] qryVector, int k, float threshold, int efSearch, String resType, IndexingQueryFilter filters)
+        throws IgniteCheckedException {
         checkEnabled();
 
         if (!busyLock.enterBusy())
@@ -3490,7 +3491,8 @@ public class GridQueryProcessor extends GridProcessorAdapter {
                         String typeName = typeName(cacheName, resType);
                         String schemaName = idx.schema(cacheName);
 
-                        return idx.queryLocalVector(schemaName, cacheName, field, qryVector, k, threshold, typeName, filters);
+                        return idx.queryLocalVector(schemaName, cacheName, field, qryVector, k, threshold, efSearch,
+                            typeName, filters);
                     }
                 }, true);
         }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/GridQueryProcessor.java
@@ -336,6 +336,19 @@ public class GridQueryProcessor extends GridProcessorAdapter {
     @Override public void onKernalStop(boolean cancel) {
         super.onKernalStop(cancel);
 
+        // On graceful stop, let indexes flush persistent state while the checkpoint
+        // lock is still grantable — the guaranteed final checkpoint will carry it to
+        // disk. On forced stop the final checkpoint is skipped anyway, and any torn
+        // index state self-invalidates on restart.
+        if (!cancel && idx != null) {
+            try {
+                idx.beforeNodeStop();
+            }
+            catch (Throwable t) {
+                U.warn(log, "Failed to flush index state on node stop.", t);
+            }
+        }
+
         if (cancel && idx != null) {
             try {
                 while (!busyLock.tryBlock(500))

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryIndexDescriptorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryIndexDescriptorImpl.java
@@ -65,6 +65,12 @@ public class QueryIndexDescriptorImpl implements GridQueryIndexDescriptor {
      */
     private SimilarityFunction similarityFunction;
 
+    /** HNSW max connections per node for VECTOR index ({@code 0} — engine default). */
+    private int m;
+
+    /** HNSW build-time beam width for VECTOR index ({@code 0} — engine default). */
+    private int efConstruction;
+
     /**
      * Constructor.
      *
@@ -94,6 +100,25 @@ public class QueryIndexDescriptorImpl implements GridQueryIndexDescriptor {
     public QueryIndexDescriptorImpl(QueryTypeDescriptorImpl typDesc, String name, QueryIndexType type, int inlineSize, SimilarityFunction similarityFunction) {
         this(typDesc, name, type, inlineSize);
         this.similarityFunction = similarityFunction;
+    }
+
+    /**
+     * Constructor for VECTOR index.
+     *
+     * @param typDesc            Type descriptor.
+     * @param name               Index name.
+     * @param type               Type.
+     * @param inlineSize         Inline size.
+     * @param similarityFunction Vector Similarity Function for VECTOR index.
+     * @param m                  HNSW max connections per node ({@code 0} — engine default).
+     * @param efConstruction     HNSW build-time beam width ({@code 0} — engine default).
+     */
+    public QueryIndexDescriptorImpl(QueryTypeDescriptorImpl typDesc, String name, QueryIndexType type, int inlineSize,
+        SimilarityFunction similarityFunction, int m, int efConstruction) {
+        this(typDesc, name, type, inlineSize, similarityFunction);
+
+        this.m = m;
+        this.efConstruction = efConstruction;
     }
 
     /**
@@ -127,6 +152,16 @@ public class QueryIndexDescriptorImpl implements GridQueryIndexDescriptor {
     /** {@inheritDoc} */
     @Override public SimilarityFunction similarityFunction() {
         return similarityFunction;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int m() {
+        return m;
+    }
+
+    /** {@inheritDoc} */
+    @Override public int efConstruction() {
+        return efConstruction;
     }
 
     /** {@inheritDoc} */

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryTypeDescriptorImpl.java
@@ -375,11 +375,14 @@ public class QueryTypeDescriptorImpl implements GridQueryTypeDescriptor {
      *
      * @param field Field name.
      * @param similarityFunction Vector Similarity Function for VECTOR index.
+     * @param m HNSW max connections per node ({@code 0} — engine default).
+     * @param efConstruction HNSW build-time beam width ({@code 0} — engine default).
      * @throws IgniteCheckedException If failed.
      */
-    public void addFieldToVectorIndex(String field, SimilarityFunction similarityFunction) throws IgniteCheckedException {
+    public void addFieldToVectorIndex(String field, SimilarityFunction similarityFunction, int m, int efConstruction)
+        throws IgniteCheckedException {
         if (vectorIdx == null)
-            vectorIdx = new QueryIndexDescriptorImpl(this, null, QueryIndexType.VECTOR, 0, similarityFunction);
+            vectorIdx = new QueryIndexDescriptorImpl(this, null, QueryIndexType.VECTOR, 0, similarityFunction, m, efConstruction);
 
         vectorIdx.addField(field, 0, false);
     }

--- a/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
+++ b/modules/core/src/main/java/org/apache/ignite/internal/processors/query/QueryUtils.java
@@ -860,7 +860,7 @@ public class QueryUtils {
                 if (idxTyp == QueryIndexType.FULLTEXT)
                     d.addFieldToTextIndex(field);
                 else
-                    d.addFieldToVectorIndex(field, idx.getSimilarityFunction());
+                    d.addFieldToVectorIndex(field, idx.getSimilarityFunction(), idx.getM(), idx.getEfConstruction());
             }
         }
         else if (idxTyp != null)

--- a/modules/core/src/test/java/org/apache/ignite/internal/processors/query/DummyQueryIndexing.java
+++ b/modules/core/src/test/java/org/apache/ignite/internal/processors/query/DummyQueryIndexing.java
@@ -135,6 +135,7 @@ public class DummyQueryIndexing implements GridQueryIndexing {
         float[] qryVector,
         int k,
         float threshold,
+        int efSearch,
         String typeName,
         IndexingQueryFilter filter
     ) throws IgniteCheckedException {

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2Schema.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2Schema.java
@@ -112,9 +112,10 @@ public class H2Schema {
      * Drop table.
      *
      * @param tbl Table to be removed.
+     * @param destroy {@code True} when the cache is destroyed (drop persistent index state).
      */
-    public void drop(H2TableDescriptor tbl) {
-        tbl.onDrop();
+    public void drop(H2TableDescriptor tbl, boolean destroy) {
+        tbl.onDrop(destroy);
 
         tbls.remove(tbl.tableName());
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2TableDescriptor.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/H2TableDescriptor.java
@@ -452,10 +452,24 @@ public class H2TableDescriptor {
 
     /**
      * Handle drop.
+     *
+     * @param destroy {@code True} when the cache is destroyed — the index drops its
+     *      persistent state; {@code false} on node stop / cache close — it survives.
      */
-    void onDrop() {
+    void onDrop(boolean destroy) {
         tbl.destroy();
 
-        U.closeQuiet(luceneIdx);
+        if (luceneIdx != null) {
+            if (destroy) {
+                try {
+                    luceneIdx.destroy();
+                }
+                catch (Exception e) {
+                    // Mirrors the quiet-close behavior of the stop path.
+                }
+            }
+            else
+                U.closeQuiet(luceneIdx);
+        }
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -602,6 +602,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
         float[] qryVector,
         int k,
         float threshold,
+        int efSearch,
         String typeName,
         IndexingQueryFilter filter
     ) throws IgniteCheckedException {
@@ -624,7 +625,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
             Throwable failReason = null;
             try {
-                return tbl.luceneIndex().vectorQuery(field.toUpperCase(), qryVector, k, threshold, filter);
+                return tbl.luceneIndex().vectorQuery(field.toUpperCase(), qryVector, k, threshold, efSearch, filter);
             }
             catch (Throwable t) {
                 failReason = t;

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -435,7 +435,7 @@ public class IgniteH2Indexing implements GridQueryIndexing {
             if (expireTime == 0L)
                 expireTime = Long.MAX_VALUE;
 
-            tbl.luceneIndex().store(row.key(), row.value(), row.version(), expireTime);
+            tbl.luceneIndex().store(row.key(), row.value(), row.version(), expireTime, row.link());
         }
     }
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/IgniteH2Indexing.java
@@ -2316,6 +2316,8 @@ public class IgniteH2Indexing implements GridQueryIndexing {
 
         Collection<H2TableDescriptor> descriptors = schemaMgr.tablesForCache(cacheName).stream()
             .filter(descriptor -> nonNull(descriptor.luceneIndex()))
+            // An index that restored itself from its own persistent state opts out of the row scan.
+            .filter(descriptor -> descriptor.luceneIndex().needsRebuild())
             .collect(toList());
 
         if (descriptors.isEmpty())
@@ -3072,6 +3074,27 @@ public class IgniteH2Indexing implements GridQueryIndexing {
         if (!F.isEmpty(queries)) {
             for (Long qryId : queries)
                 runningQryMgr.cancel(qryId);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override public void beforeNodeStop() {
+        // Give text/vector indexes their last chance to write persistent state while
+        // the checkpoint lock is still grantable (the database manager blocks it
+        // later in the stop sequence).
+        for (String cacheName : ctx.cache().cacheNames()) {
+            for (H2TableDescriptor tbl : schemaMgr.tablesForCache(cacheName)) {
+                LuceneIndex luceneIdx = tbl.luceneIndex();
+
+                if (luceneIdx != null) {
+                    try {
+                        luceneIdx.beforeNodeStop();
+                    }
+                    catch (Throwable t) {
+                        U.warn(log, "Failed to flush index state on node stop [table=" + tbl.fullTableName() + ']', t);
+                    }
+                }
+            }
         }
     }
 

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/LuceneIndexRebuildClosure.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/LuceneIndexRebuildClosure.java
@@ -97,6 +97,6 @@ public class LuceneIndexRebuildClosure implements SchemaIndexCacheVisitorClosure
         if (expireTime == 0L)
             expireTime = Long.MAX_VALUE;
 
-        luceneIndex0.store(row.key(), row.value(), row.version(), expireTime);
+        luceneIndex0.store(row.key(), row.value(), row.version(), expireTime, row.link());
     }
 }

--- a/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/SchemaManager.java
+++ b/modules/indexing/src/main/java/org/apache/ignite/internal/processors/query/h2/SchemaManager.java
@@ -373,7 +373,7 @@ public class SchemaManager {
                     U.error(log, "Failed to drop table on cache stop (will ignore): " + tbl.fullTableName(), e);
                 }
 
-                schema.drop(tbl);
+                schema.drop(tbl, destroy);
 
                 rmvTbls.add(tbl);
 

--- a/modules/lucene-8/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridLuceneTextIndex.java
+++ b/modules/lucene-8/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridLuceneTextIndex.java
@@ -147,7 +147,7 @@ public class GridLuceneTextIndex implements LuceneIndex {
     }
 
     /** {@inheritDoc} */
-    @Override public void store(CacheObject k, CacheObject v, GridCacheVersion ver, long expires)
+    @Override public void store(CacheObject k, CacheObject v, GridCacheVersion ver, long expires, long link)
         throws IgniteCheckedException {
         CacheObjectContext coctx = objectContext();
 
@@ -276,7 +276,8 @@ public class GridLuceneTextIndex implements LuceneIndex {
 
     /** {@inheritDoc} */
     @Override public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> vectorQuery(String field,
-        float[] qryVector, int k, float threshold, IndexingQueryFilter filters) throws IgniteCheckedException {
+        float[] qryVector, int k, float threshold, int efSearch, IndexingQueryFilter filters)
+        throws IgniteCheckedException {
         throw new IllegalStateException("To use vector query feature, enable gridgain-vector-query module" +
             " (requires Enterprise or Ultimate Edition)");
     }

--- a/modules/lucene-9/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridLuceneTextIndex.java
+++ b/modules/lucene-9/src/main/java/org/apache/ignite/internal/processors/query/h2/opt/GridLuceneTextIndex.java
@@ -134,7 +134,7 @@ public class GridLuceneTextIndex implements LuceneIndex {
     }
 
     /** {@inheritDoc} */
-    @Override public void store(CacheObject k, CacheObject v, GridCacheVersion ver, long expires)
+    @Override public void store(CacheObject k, CacheObject v, GridCacheVersion ver, long expires, long link)
         throws IgniteCheckedException {
         CacheObjectContext coctx = objectContext();
 
@@ -263,7 +263,8 @@ public class GridLuceneTextIndex implements LuceneIndex {
 
     /** {@inheritDoc} */
     @Override public <K, V> GridCloseableIterator<IgniteBiTuple<K, V>> vectorQuery(String field,
-        float[] qryVector, int k, float threshold, IndexingQueryFilter filters) throws IgniteCheckedException {
+        float[] qryVector, int k, float threshold, int efSearch, IndexingQueryFilter filters)
+        throws IgniteCheckedException {
         throw new IllegalStateException("To use vector query feature, enable gridgain-vector-query module" +
             " (requires Enterprise or Ultimate Edition)");
     }


### PR DESCRIPTION
CE-side changes for the GG8 vector search Phase-3 work (design doc + ADRs live in gridgain-ue under `modules/vector-query/docs/`). Consumed by ggprivate/ggprivate#2224 — matching branch `gg-49160` in both repos is required to build.

### What

- **Index config:** `@QueryVectorField` and `QueryIndex` gain `m` + `efConstruction` (`0` = engine default), threaded through `QueryEntity`/`QueryUtils` into `GridQueryIndexDescriptor` (new default methods; both implementors updated).
- **Query config:** `VectorQuery.setEfSearch()` (`0` = engine default), carried through `GridCacheQueryAdapter` → `GridQueryProcessor.queryVector` → `GridQueryIndexing.queryLocalVector` → widened `LuceneIndex.vectorQuery(..., int efSearch, ...)`.
- **Row link:** `LuceneIndex.store(...)` now carries the data-row link — both call sites (live update in `IgniteH2Indexing`, `LuceneIndexRebuildClosure`) already hold the `CacheDataRow`. This lets the vector index materialize hits by a direct row read instead of duplicating key/value bytes on heap (ADR-0006; ratified storage ask #4).
- `GridLuceneTextIndex` (lucene-8/9) aligned with the widened SPI.

All public-API additions are additive with defaults. The widened `GridCacheQueryAdapter` constructor is updated at all call sites (SPI/TEXT/SET queries pass `efSearch = 0`).

### Verification

core + indexing + lucene-9 compile green (JDK 8 / JDK 21 per module as on CI). On the paired gridgain-ue branch: `GridCacheVectorQuerySelfTest` (15 node-level tests, all similarity functions) and the new `GridJVectorIndexConcurrencyTest` pass against these interfaces.

### Added in the second commit (storage seams for persistent vector indexes)

- \`PageIO.registerExtension(IOVersions)\` — a generic registry consulted by \`getPageIO\` so plugin page types resolve in generic page machinery; the IO classes themselves stay in gridgain-ue (ratified ask #1: registration hook only, no vector types in CE).
- \`LuceneIndex.destroy()\` — cache destroy drops persistent index state (plumbed through \`SchemaManager\`/\`H2Schema\`/\`H2TableDescriptor.onDrop(destroy)\`); node stop keeps it.
- \`LuceneIndex.needsRebuild()\` — an index that restored itself from its own persistent state opts out of the restart row scan (\`rebuildInMemoryIndexes\` filter).
- \`GridQueryIndexing.beforeNodeStop()\` + invocation from \`GridQueryProcessor.onKernalStop(cancel=false)\`: indexes flush persistent state while the checkpoint lock is still grantable — empirically, the cache-close path runs after \`CheckpointTimeoutLock\` blocks and cannot write.